### PR TITLE
refactor: use dict in action chunk trim transform

### DIFF
--- a/src/physicalai/inference/postprocessors/action_chunk_trimmer.py
+++ b/src/physicalai/inference/postprocessors/action_chunk_trimmer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, override
 
+from physicalai.inference.constants import ACTION
 from physicalai.inference.postprocessors.base import Postprocessor
 
 if TYPE_CHECKING:
@@ -30,7 +31,7 @@ class ActionChunkTrimmer(Postprocessor):
 
     Examples:
         >>> trimmer = ActionChunkTrimmer(n_action_steps=10)
-        >>> trimmer(np.zeros((1, 50, 6))).shape
+        >>> trimmer({"action": np.zeros((1, 50, 6))})["action"].shape
         (1, 10, 6)
     """
 
@@ -43,10 +44,11 @@ class ActionChunkTrimmer(Postprocessor):
         self._n_action_steps = n_action_steps
 
     @override
-    def __call__(self, actions: np.ndarray) -> np.ndarray:
+    def __call__(self, outputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        actions = outputs[ACTION]
         if actions.ndim == _NDIM_WITH_TEMPORAL and actions.shape[1] > self._n_action_steps:
-            actions = actions[:, : self._n_action_steps, :]
-        return actions
+            outputs[ACTION] = actions[:, : self._n_action_steps, :]
+        return outputs
 
     def __repr__(self) -> str:
         """Return string representation."""

--- a/tests/unit/inference/postprocessors/test_action_chunk_trimmer.py
+++ b/tests/unit/inference/postprocessors/test_action_chunk_trimmer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import numpy as np
 
+from physicalai.inference.constants import ACTION
 from physicalai.inference.postprocessors import ActionChunkTrimmer, Postprocessor
 
 
@@ -15,39 +16,43 @@ class TestActionChunkTrimmer:
 
     def test_trims_temporal_axis_when_chunk_is_longer_than_limit(self) -> None:
         trimmer = ActionChunkTrimmer(n_action_steps=4)
-        actions = np.arange(2 * 8 * 3).reshape(2, 8, 3)
+        outputs = {
+            ACTION: np.arange(2 * 8 * 3).reshape(2, 8, 3),
+            "scores": np.array([0.9, 0.8]),
+        }
 
-        result = trimmer(actions)
+        result = trimmer(outputs)
 
-        assert result.shape == (2, 4, 3)
-        np.testing.assert_array_equal(result, actions[:, :4, :])
+        assert result[ACTION].shape == (2, 4, 3)
+        np.testing.assert_array_equal(result[ACTION], outputs[ACTION][:, :4, :])
+        np.testing.assert_array_equal(result["scores"], np.array([0.9, 0.8]))
 
     def test_keeps_temporal_axis_when_chunk_matches_limit(self) -> None:
         trimmer = ActionChunkTrimmer(n_action_steps=8)
-        actions = np.arange(2 * 8 * 3).reshape(2, 8, 3)
+        outputs = {ACTION: np.arange(2 * 8 * 3).reshape(2, 8, 3)}
 
-        result = trimmer(actions)
+        result = trimmer(outputs)
 
-        assert result.shape == (2, 8, 3)
-        np.testing.assert_array_equal(result, actions)
+        assert result[ACTION].shape == (2, 8, 3)
+        np.testing.assert_array_equal(result[ACTION], outputs[ACTION])
 
     def test_keeps_temporal_axis_when_chunk_is_shorter_than_limit(self) -> None:
         trimmer = ActionChunkTrimmer(n_action_steps=10)
-        actions = np.arange(2 * 8 * 3).reshape(2, 8, 3)
+        outputs = {ACTION: np.arange(2 * 8 * 3).reshape(2, 8, 3)}
 
-        result = trimmer(actions)
+        result = trimmer(outputs)
 
-        assert result.shape == (2, 8, 3)
-        np.testing.assert_array_equal(result, actions)
+        assert result[ACTION].shape == (2, 8, 3)
+        np.testing.assert_array_equal(result[ACTION], outputs[ACTION])
 
     def test_non_temporal_array_is_passed_through(self) -> None:
         trimmer = ActionChunkTrimmer(n_action_steps=1)
-        actions = np.arange(2 * 6).reshape(2, 6)
+        outputs = {ACTION: np.arange(2 * 6).reshape(2, 6)}
 
-        result = trimmer(actions)
+        result = trimmer(outputs)
 
-        assert result.shape == (2, 6)
-        np.testing.assert_array_equal(result, actions)
+        assert result[ACTION].shape == (2, 6)
+        np.testing.assert_array_equal(result[ACTION], outputs[ACTION])
 
     def test_repr(self) -> None:
         trimmer = ActionChunkTrimmer(n_action_steps=6)

--- a/tests/unit/robot/test_bimanual_widowxai.py
+++ b/tests/unit/robot/test_bimanual_widowxai.py
@@ -14,6 +14,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+pytest.importorskip("trossen_arm", reason="trossen_arm SDK is not installed")
+
 # ---------------------------------------------------------------------------
 # Mock trossen_arm SDK (same pattern as test_widowxai.py)
 # ---------------------------------------------------------------------------

--- a/tests/unit/robot/test_widowxai.py
+++ b/tests/unit/robot/test_widowxai.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, call, patch
 import numpy as np
 import pytest
 
+pytest.importorskip("trossen_arm", reason="trossen_arm SDK is not installed")
+
 from physicalai.robot.trossen.constants import HOME_POSITION
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- trimmer now operated on dicts, because it's default representation that inference model utilizes
- trossen sdk imports are gently skipped in unit tests

## Why

-

## Validation

- validated with export in PAS training

## Breaking changes

- None

## Related issues

- Closes #
