### PR TITLE
fix: temporaly delete benchmark module to avoid conflicts with training lib

### DIFF
--- a/src/physicalai/benchmark/__init__.py
+++ b/src/physicalai/benchmark/__init__.py
@@ -1,4 +1,0 @@
-# Copyright (C) 2026 Intel Corporation
-# SPDX-License-Identifier: Apache-2.0
-
-"""Benchmarking protocols and runners."""


### PR DESCRIPTION
## Summary

- deletes `src/physicalai/benchmark`

## Why

- Empty benchmark folder with init shadows similar module in PAS library, which results in import failures 

## Validation

-

## Breaking changes

- None

## Related issues

- Closes #
