### PR TITLE
feat(runtime): implement Real-Time Chunking (RTC) execution strategy

### DIFF
--- a/examples/runtime/async_inference.py
+++ b/examples/runtime/async_inference.py
@@ -30,8 +30,8 @@ from physicalai.capture.transport import SharedCamera
 from physicalai.inference import InferenceModel
 from physicalai.robot import SO101
 from physicalai.runtime import (
-    ActionQueue,
     AsyncExecution,
+    ChunkedActionQueue,
     LerpSmoother,
     PolicyRuntime,
 )
@@ -73,7 +73,7 @@ def main():
         robot=robot,
         model=model,
         execution=AsyncExecution(threshold=0.3, fps=int(args.fps)),
-        action_queue=ActionQueue(smoother=LerpSmoother(duration_frames=5)),
+        action_queue=ChunkedActionQueue(smoother=LerpSmoother(duration_frames=5)),
         cameras=cameras,
         fps=args.fps,
     )

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -50,7 +50,7 @@ def main() -> None:
     parser.add_argument("--width", type=int, default=640)
     parser.add_argument("--height", type=int, default=480)
     parser.add_argument("--fps", type=float, default=30.0)
-    parser.add_argument("--duration-s", type=float, default=60.0)
+    parser.add_argument("--duration-s", type=float, default=None, help="Run duration in seconds (default: run indefinitely)")
     # RTC parameters
     parser.add_argument("--chunk-size", type=int, default=50)
     parser.add_argument("--execution-horizon", type=int, default=10)
@@ -147,6 +147,17 @@ def main() -> None:
             f"p95={latency_tracker.percentile_s(95):.3f}s"
         )
     finally:
+        print("\nRobot is holding position (torque ON).")
+        try:
+            resp = input("Disable torque? The arm will drop under gravity. [y/N]: ").strip().lower()
+            if resp == "y":
+                robot.set_torque(enabled=False)
+                robot.torque_on_disconnect = False
+                print("Torque disabled — arm is free.")
+            else:
+                print("Torque remains enabled — arm holds position.")
+        except (KeyboardInterrupt, EOFError):
+            print("\nTorque remains enabled.")
         runtime.disconnect()
         print("Disconnected")
 

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -30,6 +30,7 @@ from physicalai.inference import InferenceModel
 from physicalai.inference.callbacks import RTCLatencyTracker
 from physicalai.robot import SO101
 from physicalai.runtime import (
+    LowPassFilterCallback,
     PolicyRuntime,
     RTCActionQueue,
     RTCExecution,
@@ -55,6 +56,7 @@ def main() -> None:
     parser.add_argument("--max-action-dim", type=int, default=32)
     parser.add_argument("--max-guidance-weight", type=float, default=10.0)
     parser.add_argument("--queue-threshold", type=int, default=30)
+    parser.add_argument("--low-pass-alpha", type=float, default=None, help="Alpha parameter for stateful LowPassFilterCallback. E.g. 0.5. Defaults to None (disabled).")
     args = parser.parse_args()
 
     # --- Latency tracker callback (lives on the model) ---
@@ -96,6 +98,11 @@ def main() -> None:
     }
 
     # --- PolicyRuntime ---
+    callbacks = []
+    if args.low_pass_alpha is not None:
+        print(f"Applying LowPassFilterCallback with alpha={args.low_pass_alpha}")
+        callbacks.append(LowPassFilterCallback(alpha=args.low_pass_alpha))
+
     runtime = PolicyRuntime(
         robot=robot,
         model=model,
@@ -103,6 +110,7 @@ def main() -> None:
         action_queue=rtc_queue,
         cameras=cameras,
         fps=args.fps,
+        callbacks=callbacks,
     )
 
     try:

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -36,7 +36,6 @@ from physicalai.runtime import (
 )
 from physicalai.inference.component_factory import instantiate_component, resolve_artifact
 from physicalai.inference.manifest import Manifest
-import openvino_tokenizers  # noqa: F401 — registers OV tokenizer ops
 
 
 def main() -> None:

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -34,8 +34,6 @@ from physicalai.runtime import (
     RTCActionQueue,
     RTCExecution,
 )
-from physicalai.inference.component_factory import instantiate_component, resolve_artifact
-from physicalai.inference.manifest import Manifest
 import openvino_tokenizers  # noqa: F401 — registers OV tokenizer ops
 
 
@@ -62,37 +60,26 @@ def main() -> None:
     # --- Latency tracker callback (lives on the model) ---
     latency_tracker = RTCLatencyTracker(window_size=100)
 
-    # --- Load model WITHOUT postprocessors (RTCExecution owns denorm) ---
+    # --- Load model ---
+    # RTCExecution automatically discovers parameters and takes ownership of
+    # postprocessors from the loaded model instance.
     model = InferenceModel.load(
         args.model,
         device=args.device,
-        postprocessors=[],  # skip manifest denorm — execution handles it
         callbacks=[latency_tracker],
     )
-
-    # --- Load denormalization postprocessors from manifest ---
-    # RTCExecution applies these in its background thread to produce
-    # the processed (denormalized) track for the robot.
-
-    manifest = Manifest.load(f"{args.model}/manifest.json")
-    rtc_postprocessors: list = [
-        instantiate_component(resolve_artifact(spec, args.model))
-        for spec in manifest.model.postprocessors
-    ]
 
     # --- RTC queue (shared between execution and runtime) ---
     rtc_queue = RTCActionQueue()
 
     # --- RTC execution strategy ---
+    # Automatically derives chunk_size, max_action_dim, postprocessors and
+    # a dynamic queue_threshold.
     execution = RTCExecution(
-        chunk_size=args.chunk_size,
         execution_horizon=args.execution_horizon,
         fps=args.fps,
-        max_action_dim=args.max_action_dim,
         max_guidance_weight=args.max_guidance_weight,
-        queue_threshold=args.queue_threshold,
         latency_tracker=latency_tracker,
-        postprocessors=rtc_postprocessors,
     )
 
     # --- Hardware ---

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -75,7 +75,7 @@ def main() -> None:
     # the processed (denormalized) track for the robot.
 
     manifest = Manifest.load(f"{args.model}/manifest.json")
-    rtc_postprocessors = [
+    rtc_postprocessors: list = [
         instantiate_component(resolve_artifact(spec, args.model))
         for spec in manifest.model.postprocessors
     ]

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-Time Chunking (RTC) inference with PolicyRuntime.
+
+Demonstrates how to run a Pi0.5 model with RTC denoising baked into
+the graph. The model produces 50-action chunks; the RTCExecution
+strategy handles async inference, dual-track queue management, and
+latency-aware delay compensation.
+
+Usage:
+    python examples/runtime/rtc_inference.py \
+      --model ./exports/pi05_rtc_openvino \
+      --device GPU.0 \
+      --port /dev/ttyACM0 \
+      --calibration /path/to/calibration.json \
+      --overhead-camera /dev/v4l/by-id/usb-... \
+      --arm-camera 353322271391 \
+      --fps 30 \
+      --duration-s 60
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from physicalai.capture.transport import SharedCamera
+from physicalai.inference import InferenceModel
+from physicalai.inference.callbacks import RTCLatencyTracker
+from physicalai.robot import SO101
+from physicalai.runtime import (
+    PolicyRuntime,
+    RTCActionQueue,
+    RTCExecution,
+)
+from physicalai.inference.component_factory import instantiate_component, resolve_artifact
+from physicalai.inference.manifest import Manifest
+import openvino_tokenizers  # noqa: F401 — registers OV tokenizer ops
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Pi0.5 RTC policy with PolicyRuntime")
+    parser.add_argument("--model", required=True, help="Exported RTC model directory")
+    parser.add_argument("--device", default="GPU.0", help="OpenVINO device")
+    parser.add_argument("--port", default="/dev/ttyACM0", help="Robot serial port")
+    parser.add_argument("--calibration", required=True, help="Robot calibration file")
+    parser.add_argument("--overhead-camera", required=True, help="Overhead camera device path (e.g. /dev/v4l/by-id/usb-...)")
+    parser.add_argument("--arm-camera", required=True, help="Arm camera device path (e.g. /dev/v4l/by-id/usb-...)")
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--fps", type=float, default=30.0)
+    parser.add_argument("--duration-s", type=float, default=60.0)
+    # RTC parameters
+    parser.add_argument("--chunk-size", type=int, default=50)
+    parser.add_argument("--execution-horizon", type=int, default=10)
+    parser.add_argument("--max-action-dim", type=int, default=32)
+    parser.add_argument("--max-guidance-weight", type=float, default=10.0)
+    parser.add_argument("--queue-threshold", type=int, default=30)
+    args = parser.parse_args()
+
+    # --- Latency tracker callback (lives on the model) ---
+    latency_tracker = RTCLatencyTracker(window_size=100)
+
+    # --- Load model WITHOUT postprocessors (RTCExecution owns denorm) ---
+    model = InferenceModel.load(
+        args.model,
+        device=args.device,
+        postprocessors=[],  # skip manifest denorm — execution handles it
+        callbacks=[latency_tracker],
+    )
+
+    # --- Load denormalization postprocessors from manifest ---
+    # RTCExecution applies these in its background thread to produce
+    # the processed (denormalized) track for the robot.
+
+    manifest = Manifest.load(f"{args.model}/manifest.json")
+    rtc_postprocessors = [
+        instantiate_component(resolve_artifact(spec, args.model))
+        for spec in manifest.model.postprocessors
+    ]
+
+    # --- RTC queue (shared between execution and runtime) ---
+    rtc_queue = RTCActionQueue()
+
+    # --- RTC execution strategy ---
+    execution = RTCExecution(
+        chunk_size=args.chunk_size,
+        execution_horizon=args.execution_horizon,
+        fps=args.fps,
+        max_action_dim=args.max_action_dim,
+        max_guidance_weight=args.max_guidance_weight,
+        queue_threshold=args.queue_threshold,
+        latency_tracker=latency_tracker,
+        postprocessors=rtc_postprocessors,
+    )
+
+    # --- Hardware ---
+    robot = SO101(port=args.port, calibration=args.calibration, role="follower")
+    cameras = {
+        "overhead": SharedCamera(
+            "uvc", device=args.overhead_camera,
+            width=args.width, height=args.height, fps=int(args.fps),
+        ),
+        "arm": SharedCamera(
+            "uvc", device=args.arm_camera,
+            width=args.width, height=args.height, fps=int(args.fps),
+        ),
+    }
+
+    # --- PolicyRuntime ---
+    runtime = PolicyRuntime(
+        robot=robot,
+        model=model,
+        execution=execution,
+        action_queue=rtc_queue,
+        cameras=cameras,
+        fps=args.fps,
+    )
+
+    try:
+        runtime.connect()
+    except Exception as e:
+        print(f"Failed to connect: {e}")
+        from physicalai.capture import discover_all
+        print("Available cameras:")
+        for driver, devices in discover_all().items():
+            for dev in devices:
+                print(f"  Driver: {driver}, Device: {dev.device_id}, Info: {dev.name}")
+        return
+
+    for name, cam in cameras.items():
+        print(f"Camera '{name}': {cam.actual_width}x{cam.actual_height} @ {cam.actual_fps}fps")
+
+    print(
+        f"Starting RTC runtime — chunk={args.chunk_size}, "
+        f"horizon={args.execution_horizon}, fps={args.fps}"
+    )
+    try:
+        stats = runtime.run(duration_s=args.duration_s)
+        print(
+            f"\nDone — {stats.steps} steps, {stats.inference_count} inferences, "
+            f"{stats.total_holds} holds"
+        )
+        print(
+            f"Latency — max={latency_tracker.max_latency_s:.3f}s, "
+            f"p95={latency_tracker.percentile_s(95):.3f}s"
+        )
+    finally:
+        runtime.disconnect()
+        print("Disconnected")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/physicalai/capture/transport/_shared_camera.py
+++ b/src/physicalai/capture/transport/_shared_camera.py
@@ -270,6 +270,7 @@ class SharedCamera(Camera):
             if sample is None:
                 break
             newest_sample = sample
+            sample = None
 
         if newest_sample is not None:
             header, frame = self._decode_sample(newest_sample)
@@ -297,6 +298,7 @@ class SharedCamera(Camera):
             if sample is None:
                 break
             newest_sample = sample
+            sample = None
 
         if newest_sample is not None:
             header, frame = self._decode_sample(newest_sample)

--- a/src/physicalai/capture/transport/_shared_camera.py
+++ b/src/physicalai/capture/transport/_shared_camera.py
@@ -270,6 +270,9 @@ class SharedCamera(Camera):
             if sample is None:
                 break
             newest_sample = sample
+            # Explicitly clear 'sample' to release reference. Otherwise, Python keeps
+            # it alive during the next receive() call, triggering iceoryx2 subscriber warnings/errors,
+            # especially when run in an IDE where debuggers hold onto local frames.
             sample = None
 
         if newest_sample is not None:
@@ -277,6 +280,8 @@ class SharedCamera(Camera):
             self._last_header = header
             self._latest = frame
             self._check_config_match(header)
+            # Explicitly clear 'newest_sample' to release the iceoryx2 sample borrow under IDE/debugger.
+            newest_sample = None
 
         if self._latest is None:
             msg = "no frame available"
@@ -298,6 +303,9 @@ class SharedCamera(Camera):
             if sample is None:
                 break
             newest_sample = sample
+            # Explicitly clear 'sample' to release reference. Otherwise, Python keeps
+            # it alive during the next receive() call, triggering iceoryx2 subscriber warnings/errors,
+            # especially when run in an IDE where debuggers hold onto local frames.
             sample = None
 
         if newest_sample is not None:
@@ -305,6 +313,8 @@ class SharedCamera(Camera):
             self._last_header = header
             self._latest = frame
             self._check_config_match(header)
+            # Explicitly clear 'newest_sample' to release the iceoryx2 sample borrow under IDE/debugger.
+            newest_sample = None
 
         if self._latest is None:
             msg = "no frame available"

--- a/src/physicalai/inference/callbacks/__init__.py
+++ b/src/physicalai/inference/callbacks/__init__.py
@@ -10,10 +10,12 @@ without modifying model or runner code.
 
 from physicalai.inference.callbacks.base import Callback
 from physicalai.inference.callbacks.latency import LatencyMonitor
+from physicalai.inference.callbacks.rtc_latency import RTCLatencyTracker
 from physicalai.inference.callbacks.throughput import ThroughputMonitor
 
 __all__ = [
     "Callback",
     "LatencyMonitor",
+    "RTCLatencyTracker",
     "ThroughputMonitor",
 ]

--- a/src/physicalai/inference/callbacks/rtc_latency.py
+++ b/src/physicalai/inference/callbacks/rtc_latency.py
@@ -37,7 +37,7 @@ class RTCLatencyTracker(Callback):
         >>> delay = tracker.compute_delay(fps=30, chunk_size=50, execution_horizon=10)
     """
 
-    def __init__(self, window_size: int = 100) -> None:
+    def __init__(self, window_size: int = 100) -> None:  # noqa: D107
         self._window: deque[float] = deque(maxlen=window_size)
         self._start_time: float = 0.0
 
@@ -97,7 +97,7 @@ class RTCLatencyTracker(Callback):
         """
         if self.max_latency_s <= 0:
             return 0
-        return int(math.ceil(self.max_latency_s * fps))
+        return math.ceil(self.max_latency_s * fps)
 
     @override
     def __repr__(self) -> str:

--- a/src/physicalai/inference/callbacks/rtc_latency.py
+++ b/src/physicalai/inference/callbacks/rtc_latency.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Latency tracker callback for RTC inference delay estimation.
+
+Measures wall-clock inference latency over a sliding window and
+exposes the worst-case value for computing ``inference_delay``.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from collections import deque
+from typing import Any, override
+
+import numpy as np
+
+from physicalai.inference.callbacks.base import Callback
+
+
+class RTCLatencyTracker(Callback):
+    """Track inference latency for RTC delay computation.
+
+    Measures the duration of each ``model(inputs)`` call via
+    ``on_predict_start`` / ``on_predict_end`` hooks. Exposes
+    ``max_latency_s`` and ``compute_delay(fps)`` for the
+    ``RTCExecution`` to read.
+
+    Args:
+        window_size: Number of recent measurements to retain.
+
+    Examples:
+        >>> tracker = RTCLatencyTracker()
+        >>> model = InferenceModel.load("./exports/pi05_rtc", callbacks=[tracker])
+        >>> # After some predictions:
+        >>> delay = tracker.compute_delay(fps=30, chunk_size=50, execution_horizon=10)
+    """
+
+    def __init__(self, window_size: int = 100) -> None:
+        self._window: deque[float] = deque(maxlen=window_size)
+        self._start_time: float = 0.0
+
+    @override
+    def on_predict_start(self, inputs: dict[str, Any]) -> None:
+        """Record prediction start time."""
+        self._start_time = time.perf_counter()
+
+    @override
+    def on_predict_end(self, outputs: dict[str, Any]) -> None:
+        """Record prediction duration."""
+        elapsed = time.perf_counter() - self._start_time
+        self._window.append(elapsed)
+
+    @override
+    def on_reset(self) -> None:
+        """Clear recorded latencies."""
+        self._window.clear()
+        self._start_time = 0.0
+
+    @property
+    def max_latency_s(self) -> float:
+        """Worst-case latency in seconds over the sliding window.
+
+        Returns 0.0 if no measurements recorded yet.
+        """
+        return max(self._window) if self._window else 0.0
+
+    @property
+    def latest_latency_s(self) -> float:
+        """Most recent inference latency in seconds."""
+        return self._window[-1] if self._window else 0.0
+
+    def percentile_s(self, q: float) -> float:
+        """Compute a percentile of recorded latencies.
+
+        Args:
+            q: Percentile in [0, 100].
+
+        Returns:
+            The q-th percentile in seconds, or 0.0 if empty.
+        """
+        if not self._window:
+            return 0.0
+        return float(np.percentile(np.array(self._window), q))
+
+    def compute_delay(self, fps: float) -> int:
+        """Compute integer delay for the RTC model input.
+
+        ``delay = ceil(max_latency * fps)``
+
+        Args:
+            fps: Robot control frequency in Hz.
+
+        Returns:
+            Integer delay (number of action steps consumed during inference).
+        """
+        if self.max_latency_s <= 0:
+            return 0
+        return int(math.ceil(self.max_latency_s * fps))
+
+    @override
+    def __repr__(self) -> str:
+        """Return string representation."""
+        return (
+            f"RTCLatencyTracker("
+            f"max={self.max_latency_s:.3f}s, "
+            f"latest={self.latest_latency_s:.3f}s, "
+            f"samples={len(self._window)})"
+        )

--- a/src/physicalai/runtime/__init__.py
+++ b/src/physicalai/runtime/__init__.py
@@ -22,6 +22,7 @@ from physicalai.runtime.execution import (
 from physicalai.runtime.rtc_execution import RTCExecution
 from physicalai.runtime.runtime import (
     ActionQueue,
+    LowPassFilterCallback,
     PolicyRuntime,
     RunStats,
     RuntimeCallback,
@@ -35,6 +36,7 @@ __all__ = [
     "ChunkedActionQueue",
     "Execution",
     "LerpSmoother",
+    "LowPassFilterCallback",
     "PolicyRuntime",
     "RTCActionQueue",
     "RTCExecution",

--- a/src/physicalai/runtime/__init__.py
+++ b/src/physicalai/runtime/__init__.py
@@ -12,12 +12,14 @@ Public API::
 """
 
 from physicalai.runtime._action_queue import ActionQueue  # noqa: PLC2701
+from physicalai.runtime._rtc_action_queue import RTCActionQueue  # noqa: PLC2701
 from physicalai.runtime.execution import (
     AsyncExecution,
     Execution,
     SyncExecution,
     WorkerDiedError,
 )
+from physicalai.runtime.rtc_execution import RTCExecution
 from physicalai.runtime.runtime import (
     PolicyRuntime,
     RunStats,
@@ -32,6 +34,8 @@ __all__ = [
     "Execution",
     "LerpSmoother",
     "PolicyRuntime",
+    "RTCActionQueue",
+    "RTCExecution",
     "ReplaceSmoother",
     "RunStats",
     "RuntimeCallback",

--- a/src/physicalai/runtime/__init__.py
+++ b/src/physicalai/runtime/__init__.py
@@ -7,11 +7,11 @@ Public API::
 
     from physicalai.runtime import PolicyRuntime, RunStats, RuntimeCallback
     from physicalai.runtime import SyncExecution, AsyncExecution, Execution, WorkerDiedError
-    from physicalai.runtime import ActionQueue
+    from physicalai.runtime import ActionQueue, ChunkedActionQueue
     from physicalai.runtime import ChunkSmoother, LerpSmoother, ReplaceSmoother
 """
 
-from physicalai.runtime._action_queue import ActionQueue  # noqa: PLC2701
+from physicalai.runtime._action_queue import ChunkedActionQueue  # noqa: PLC2701
 from physicalai.runtime._rtc_action_queue import RTCActionQueue  # noqa: PLC2701
 from physicalai.runtime.execution import (
     AsyncExecution,
@@ -21,6 +21,7 @@ from physicalai.runtime.execution import (
 )
 from physicalai.runtime.rtc_execution import RTCExecution
 from physicalai.runtime.runtime import (
+    ActionQueue,
     PolicyRuntime,
     RunStats,
     RuntimeCallback,
@@ -31,6 +32,7 @@ __all__ = [
     "ActionQueue",
     "AsyncExecution",
     "ChunkSmoother",
+    "ChunkedActionQueue",
     "Execution",
     "LerpSmoother",
     "PolicyRuntime",

--- a/src/physicalai/runtime/_action_queue.py
+++ b/src/physicalai/runtime/_action_queue.py
@@ -11,7 +11,7 @@ import numpy as np
 from physicalai.runtime.smoothers import ChunkSmoother, ReplaceSmoother
 
 
-class ActionQueue:
+class ChunkedActionQueue:
     """Thread-safe action queue with chunk smoothing."""
 
     def __init__(self, smoother: ChunkSmoother | None = None) -> None:

--- a/src/physicalai/runtime/_rtc_action_queue.py
+++ b/src/physicalai/runtime/_rtc_action_queue.py
@@ -1,0 +1,156 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dual-track action queue for Real-Time Chunking (RTC).
+
+Stores both raw (normalized) actions for ``prev_chunk_left_over``
+feedback and postprocessed (denormalized) actions for robot execution.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class RTCActionQueue:
+    """Thread-safe dual-track action queue for RTC inference.
+
+    Maintains two parallel tracks:
+    - **raw**: normalized model output, used as ``prev_chunk_left_over``
+      for the next inference call.
+    - **processed**: denormalized actions sent to the robot.
+
+    A cursor tracks consumption. ``pop()`` returns one processed action.
+    ``get_left_over()`` returns the unconsumed raw tail.
+    ``merge()`` replaces both tracks, trimming stale prefix.
+
+    All public methods are thread-safe.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._raw: np.ndarray | None = None
+        self._processed: np.ndarray | None = None
+        self._cursor: int = 0
+        self._total_pops: int = 0
+        self._total_holds: int = 0
+        self._consecutive_holds: int = 0
+
+    @property
+    def total_pops(self) -> int:
+        """Total number of actions popped."""
+        return self._total_pops
+
+    @property
+    def total_holds(self) -> int:
+        """Total number of hold events (pop on empty queue)."""
+        return self._total_holds
+
+    @property
+    def consecutive_holds(self) -> int:
+        """Number of consecutive holds (resets on successful pop)."""
+        return self._consecutive_holds
+
+    @property
+    def remaining(self) -> int:
+        """Number of unconsumed actions in the queue."""
+        with self._lock:
+            if self._processed is None:
+                return 0
+            return max(0, len(self._processed) - self._cursor)
+
+    def get_action_index(self) -> int:
+        """Current consumption cursor (snapshot for delay cross-check)."""
+        with self._lock:
+            return self._cursor
+
+    def pop(self) -> np.ndarray | None:
+        """Pop one processed (denormalized) action.
+
+        Returns:
+            Action array of shape ``(action_dim,)``, or ``None`` if empty.
+        """
+        with self._lock:
+            if self._processed is None or self._cursor >= len(self._processed):
+                self._consecutive_holds += 1
+                self._total_holds += 1
+                return None
+            action = self._processed[self._cursor].copy()
+            self._cursor += 1
+            self._consecutive_holds = 0
+            self._total_pops += 1
+            return action
+
+    def get_left_over(self) -> np.ndarray | None:
+        """Return unconsumed raw (normalized) actions.
+
+        Called from the RTC background thread to build
+        ``prev_chunk_left_over`` for the next inference call.
+
+        Returns:
+            Array of shape ``(remaining, action_dim)`` or ``None``.
+        """
+        with self._lock:
+            if self._raw is None or self._cursor >= len(self._raw):
+                return None
+            return self._raw[self._cursor:].copy()
+
+    def merge(
+        self,
+        raw: np.ndarray,
+        processed: np.ndarray,
+        real_delay: int,
+        action_index_before_inference: int | None = None,
+    ) -> None:
+        """Replace queue contents, trimming the first ``real_delay`` actions.
+
+        Args:
+            raw: Raw model output, shape ``(chunk_size, action_dim)``.
+            processed: Postprocessed actions, shape ``(chunk_size, robot_dof)``.
+            real_delay: Number of leading actions to discard (already
+                consumed during inference latency).
+            action_index_before_inference: Cursor snapshot taken before
+                inference started. Used to compute additional actions
+                consumed while inference was running.
+        """
+        with self._lock:
+            # Validate: warn if actual consumed differs from real_delay
+            if action_index_before_inference is not None:
+                indexes_diff = max(0, self._cursor - action_index_before_inference)
+                if indexes_diff != real_delay:
+                    logger.warning(
+                        "Indexes diff != real delay: indexes_diff=%d, real_delay=%d",
+                        indexes_diff, real_delay,
+                    )
+
+            # Trim stale prefix (actions consumed during inference latency)
+            trim = max(0, min(real_delay, len(raw), len(processed)))
+
+            self._raw = raw[trim:]
+            self._processed = processed[trim:]
+            self._cursor = 0
+
+            logger.debug(
+                "RTCActionQueue.merge: trim=%d, remaining=%d",
+                trim, len(self._processed),
+            )
+
+    def below_threshold(self, threshold: int) -> bool:
+        """Check if remaining actions are below threshold."""
+        with self._lock:
+            if self._processed is None:
+                return True
+            return (len(self._processed) - self._cursor) < threshold
+
+    def clear(self) -> None:
+        """Clear all state."""
+        with self._lock:
+            self._raw = None
+            self._processed = None
+            self._cursor = 0
+            self._consecutive_holds = 0

--- a/src/physicalai/runtime/_rtc_action_queue.py
+++ b/src/physicalai/runtime/_rtc_action_queue.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import TYPE_CHECKING
 
-import numpy as np
+if TYPE_CHECKING:
+    import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +67,11 @@ class RTCActionQueue:
             return max(0, len(self._processed) - self._cursor)
 
     def get_action_index(self) -> int:
-        """Current consumption cursor (snapshot for delay cross-check)."""
+        """Current consumption cursor (snapshot for delay cross-check).
+
+        Returns:
+            The current cursor position.
+        """
         with self._lock:
             return self._cursor
 
@@ -98,7 +104,7 @@ class RTCActionQueue:
         with self._lock:
             if self._raw is None or self._cursor >= len(self._raw):
                 return None
-            return self._raw[self._cursor:].copy()
+            return self._raw[self._cursor :].copy()
 
     def merge(
         self,
@@ -125,7 +131,8 @@ class RTCActionQueue:
                 if indexes_diff != real_delay:
                     logger.warning(
                         "Indexes diff != real delay: indexes_diff=%d, real_delay=%d",
-                        indexes_diff, real_delay,
+                        indexes_diff,
+                        real_delay,
                     )
 
             # Trim stale prefix (actions consumed during inference latency)
@@ -137,11 +144,16 @@ class RTCActionQueue:
 
             logger.debug(
                 "RTCActionQueue.merge: trim=%d, remaining=%d",
-                trim, len(self._processed),
+                trim,
+                len(self._processed),
             )
 
     def below_threshold(self, threshold: int) -> bool:
-        """Check if remaining actions are below threshold."""
+        """Check if remaining actions are below threshold.
+
+        Returns:
+            True if remaining actions are fewer than threshold.
+        """
         with self._lock:
             if self._processed is None:
                 return True

--- a/src/physicalai/runtime/_rtc_action_queue.py
+++ b/src/physicalai/runtime/_rtc_action_queue.py
@@ -104,32 +104,31 @@ class RTCActionQueue:
         self,
         raw: np.ndarray,
         processed: np.ndarray,
-        real_delay: int,
         action_index_before_inference: int | None = None,
     ) -> None:
-        """Replace queue contents, trimming the first ``real_delay`` actions.
+        """Replace queue contents, trimming actions consumed during inference.
+
+        Trim is derived from actual cursor movement (actions the robot
+        consumed from the previous chunk while inference was running).
+        For the first chunk, cursor hasn't moved so trim=0 and the
+        full chunk is kept.
 
         Args:
             raw: Raw model output, shape ``(chunk_size, action_dim)``.
             processed: Postprocessed actions, shape ``(chunk_size, robot_dof)``.
-            real_delay: Number of leading actions to discard (already
-                consumed during inference latency).
             action_index_before_inference: Cursor snapshot taken before
-                inference started. Used to compute additional actions
-                consumed while inference was running.
+                inference started. Used to compute how many actions were
+                consumed during inference.
         """
         with self._lock:
-            # Validate: warn if actual consumed differs from real_delay
+            # Trim = actual actions consumed during inference
             if action_index_before_inference is not None:
-                indexes_diff = max(0, self._cursor - action_index_before_inference)
-                if indexes_diff != real_delay:
-                    logger.warning(
-                        "Indexes diff != real delay: indexes_diff=%d, real_delay=%d",
-                        indexes_diff, real_delay,
-                    )
+                trim = max(0, self._cursor - action_index_before_inference)
+            else:
+                trim = 0
 
-            # Trim stale prefix (actions consumed during inference latency)
-            trim = max(0, min(real_delay, len(raw), len(processed)))
+            # Clamp to array length
+            trim = min(trim, len(raw), len(processed))
 
             self._raw = raw[trim:]
             self._processed = processed[trim:]

--- a/src/physicalai/runtime/execution.py
+++ b/src/physicalai/runtime/execution.py
@@ -15,7 +15,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from physicalai.inference.model import InferenceModel
-    from physicalai.runtime._action_queue import ChunkedActionQueue as ActionQueue
+    from physicalai.runtime.runtime import ActionQueue
 
 logger = logging.getLogger(__name__)
 

--- a/src/physicalai/runtime/execution.py
+++ b/src/physicalai/runtime/execution.py
@@ -9,12 +9,13 @@ import logging
 import threading
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
 if TYPE_CHECKING:
     from physicalai.inference.model import InferenceModel
+    from physicalai.runtime._action_queue import ChunkedActionQueue
     from physicalai.runtime.runtime import ActionQueue
 
 logger = logging.getLogger(__name__)
@@ -61,13 +62,13 @@ class SyncExecution(Execution):
 
     def __init__(self) -> None:  # noqa: D107
         self._model: InferenceModel | None = None
-        self._queue: ActionQueue | None = None
+        self._queue: ChunkedActionQueue | None = None
         self._chunk_size: int = 0
 
     def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
         """Bind model and queue."""
         self._model = model
-        self._queue = action_queue
+        self._queue = cast("ChunkedActionQueue", action_queue)
 
     def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
         """Run one inference, seed queue, discover chunk_size.
@@ -118,7 +119,7 @@ class AsyncExecution(Execution):
         self._max_consecutive_holds = max_consecutive_holds or 3 * fps
 
         self._model: InferenceModel | None = None
-        self._queue: ActionQueue | None = None
+        self._queue: ChunkedActionQueue | None = None
         self._chunk_size: int = 0
         self._threshold_count: int = 0
 
@@ -135,7 +136,7 @@ class AsyncExecution(Execution):
     def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
         """Bind model/queue and spawn inference thread."""
         self._model = model
-        self._queue = action_queue
+        self._queue = cast("ChunkedActionQueue", action_queue)
         self._thread = threading.Thread(target=self._run, name="InferenceThread", daemon=True)
         self._thread.start()
 

--- a/src/physicalai/runtime/execution.py
+++ b/src/physicalai/runtime/execution.py
@@ -15,7 +15,7 @@ import numpy as np
 
 if TYPE_CHECKING:
     from physicalai.inference.model import InferenceModel
-    from physicalai.runtime._action_queue import ActionQueue
+    from physicalai.runtime._action_queue import ChunkedActionQueue as ActionQueue
 
 logger = logging.getLogger(__name__)
 

--- a/src/physicalai/runtime/rtc_execution.py
+++ b/src/physicalai/runtime/rtc_execution.py
@@ -155,10 +155,10 @@ class RTCExecution(Execution):
             rtc_config = model.manifest.model_extra.get("rtc", {}) if hasattr(model, "manifest") else {}
             if isinstance(rtc_config, dict) and "chunk_size" in rtc_config:
                 self._chunk_size = int(rtc_config["chunk_size"])
-            elif hasattr(model, "chunk_size"):
+            elif model.chunk_size > 1:
                 self._chunk_size = model.chunk_size
             else:
-                self._chunk_size = 50
+                self._chunk_size = 50  # fallback default to Pi05 chunk size
 
         # 2. Infer max_action_dim
         if self._max_action_dim_param is not None:

--- a/src/physicalai/runtime/rtc_execution.py
+++ b/src/physicalai/runtime/rtc_execution.py
@@ -60,6 +60,9 @@ class RTCExecution(Execution):
         queue_threshold: Re-infer when queue drops below this level.
         latency_tracker: Callback that measures inference latency.
             If None, delay defaults to 0.
+        warmup_inferences: Number of initial inferences treated as warmup.
+            The latency tracker is reset after these to discard
+            compilation/kernel-build overhead (e.g. OpenVINO first-run).
         postprocessors: Denormalization pipeline applied to raw actions.
             These run in the background thread to produce the processed
             track stored in the queue.
@@ -74,6 +77,7 @@ class RTCExecution(Execution):
         max_guidance_weight: float = 10.0,
         queue_threshold: int | None = None,
         latency_tracker: RTCLatencyTracker | None = None,
+        warmup_inferences: int = 2,
         postprocessors: list[Postprocessor] | None = None,
     ) -> None:
         self._chunk_size = chunk_size
@@ -83,6 +87,7 @@ class RTCExecution(Execution):
         self._max_guidance_weight = max_guidance_weight
         self._queue_threshold = queue_threshold if queue_threshold is not None else execution_horizon * 3
         self._latency_tracker = latency_tracker
+        self._warmup_inferences = max(1, warmup_inferences)
         self._postprocessors: list[Postprocessor] = postprocessors or []
 
         self._rtc_queue: RTCActionQueue | None = None
@@ -154,7 +159,7 @@ class RTCExecution(Execution):
             self._obs_slot = deepcopy(sample_observation)
 
         # Wait for the first chunk with a generous timeout
-        if not self._first_chunk_ready.wait(timeout=30.0):
+        if not self._first_chunk_ready.wait(timeout=120.0):
             if self._death_cause is not None:
                 msg = f"RTC thread died during warmup: {self._death_cause}"
                 raise WorkerDiedError(msg) from self._death_cause
@@ -239,6 +244,15 @@ class RTCExecution(Execution):
 
             self._inference_count += 1
 
+            # Reset latency tracker after warmup inferences to discard
+            # compilation overhead (e.g. OpenVINO first-run latency).
+            if self._inference_count <= self._warmup_inferences and self._latency_tracker is not None:
+                self._latency_tracker.on_reset()
+                logger.info(
+                    "Warmup inference %d/%d complete (%.2fs) — latency tracker reset",
+                    self._inference_count, self._warmup_inferences, elapsed,
+                )
+
             # Extract raw actions: (1, chunk_size, action_dim) → (chunk_size, action_dim)
             raw_actions = outputs["action"]
             if raw_actions.ndim == 3:  # noqa: PLR2004
@@ -247,21 +261,20 @@ class RTCExecution(Execution):
             # Postprocess (denormalize) for robot
             processed_actions = self._postprocess(raw_actions)
 
-            # Compute real delay from actual elapsed time
-            real_delay = int(math.ceil(elapsed * self._fps))
-
-            # Merge into dual-track queue (queue clamps trim internally)
+            # Merge into dual-track queue — trim is based on actual
+            # actions consumed (cursor movement) during inference, NOT
+            # wall-clock time.  For the first chunk nothing was consumed
+            # so trim=0 and the full chunk is kept.
             self._rtc_queue.merge(
-                raw_actions, 
-                processed_actions, 
-                real_delay,
+                raw_actions,
+                processed_actions,
                 action_index_before_inference=action_index_before,
             )
             self._first_chunk_ready.set()
 
             logger.debug(
-                "RTC chunk: latency=%.3fs delay=%d remaining=%d",
-                elapsed, real_delay, self._rtc_queue.remaining,
+                "RTC chunk: latency=%.3fs remaining=%d",
+                elapsed, self._rtc_queue.remaining,
             )
 
     def _inject_rtc_inputs(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:

--- a/src/physicalai/runtime/rtc_execution.py
+++ b/src/physicalai/runtime/rtc_execution.py
@@ -50,12 +50,20 @@ class RTCExecution(Execution):
     - ``execution_horizon``: number of fresh actions per chunk
 
     Args:
-        chunk_size: Number of actions per model output chunk.
-        execution_horizon: Fresh actions to execute per chunk.
+        chunk_size: Number of actions per model output chunk. If None, is
+            automatically inferred from the model's manifest or model metadata.
+        execution_horizon: Fresh actions to execute per chunk (range: typically
+            5 to 15, default 10). Low values speed up response but consume more
+            CPU, high values tolerate higher latency spikes.
         fps: Robot control frequency in Hz.
         max_action_dim: Model's internal action dimension (for noise/padding).
-        max_guidance_weight: Classifier-free guidance weight.
-        queue_threshold: Re-infer when queue drops below this level.
+            If None, is automatically inferred from the model's manifest or
+            defaulted to 32.
+        max_guidance_weight: Classifier-free guidance scale weight (range:
+            typically 1.0 to 15.0, default 10.0) injected into diffusion models.
+        queue_threshold: Re-infer when queue drops below this level. If None,
+            is dynamically computed as ``execution_horizon + latency_delay_actions``
+            derived from worst-case inference latency and robot control rate (fps).
         latency_tracker: Callback that measures inference latency.
             If None, delay defaults to 0.
         warmup_inferences: Number of initial inferences treated as warmup.
@@ -63,33 +71,38 @@ class RTCExecution(Execution):
             compilation/kernel-build overhead (e.g. OpenVINO first-run).
         postprocessors: Denormalization pipeline applied to raw actions.
             These run in the background thread to produce the processed
-            track stored in the queue.
+            track stored in the queue. If None, is automatically populated from
+            the model's postprocessors.
     """
 
     def __init__(  # noqa: D107
         self,
-        chunk_size: int = 50,
+        chunk_size: int | None = None,
         execution_horizon: int = 10,
         fps: float = 30.0,
-        max_action_dim: int = 32,
+        max_action_dim: int | None = None,
         max_guidance_weight: float = 10.0,
         queue_threshold: int | None = None,
         latency_tracker: RTCLatencyTracker | None = None,
         warmup_inferences: int = 2,
         postprocessors: list[Postprocessor] | None = None,
     ) -> None:
-        self._chunk_size = chunk_size
+        self._chunk_size_param = chunk_size
         self._execution_horizon = execution_horizon
         self._fps = fps
-        self._max_action_dim = max_action_dim
+        self._max_action_dim_param = max_action_dim
         self._max_guidance_weight = max_guidance_weight
-        self._queue_threshold = queue_threshold if queue_threshold is not None else execution_horizon * 3
+        self._queue_threshold_param = queue_threshold
         self._latency_tracker = latency_tracker
         self._warmup_inferences = max(1, warmup_inferences)
         self._postprocessors: list[Postprocessor] = postprocessors or []
 
         self._rtc_queue: RTCActionQueue | None = None
         self._model: InferenceModel | None = None
+
+        # Discovered/inferred state
+        self._chunk_size: int = 50
+        self._max_action_dim: int = 32
         self._chunk_size_discovered: int = 0
 
         # Thread state
@@ -107,6 +120,20 @@ class RTCExecution(Execution):
         return self._chunk_size_discovered or self._chunk_size
 
     @property
+    def queue_threshold(self) -> int:
+        """Threshold below which a new chunk inference is requested.
+
+        If not explicitly passed during initialization, is dynamically computed
+        as ``execution_horizon + latency_delay_actions``, where
+        ``latency_delay_actions`` is derived from the measured worst-case
+        inference latency and robot control rate of the loop.
+        """
+        if self._queue_threshold_param is not None:
+            return self._queue_threshold_param
+        delay = self._latency_tracker.compute_delay(self._fps) if self._latency_tracker is not None else 0
+        return self._execution_horizon + delay
+
+    @property
     def inference_count(self) -> int:
         """Number of completed inference calls."""
         return self._inference_count
@@ -121,6 +148,41 @@ class RTCExecution(Execution):
         self._model = model
         self._rtc_queue = action_queue
 
+        # 1. Infer chunk_size
+        if self._chunk_size_param is not None:
+            self._chunk_size = self._chunk_size_param
+        else:
+            rtc_config = model.manifest.model_extra.get("rtc", {}) if hasattr(model, "manifest") else {}
+            if isinstance(rtc_config, dict) and "chunk_size" in rtc_config:
+                self._chunk_size = int(rtc_config["chunk_size"])
+            elif hasattr(model, "chunk_size"):
+                self._chunk_size = model.chunk_size
+            else:
+                self._chunk_size = 50
+
+        # 2. Infer max_action_dim
+        if self._max_action_dim_param is not None:
+            self._max_action_dim = self._max_action_dim_param
+        else:
+            rtc_config = model.manifest.model_extra.get("rtc", {}) if hasattr(model, "manifest") else {}
+            if isinstance(rtc_config, dict) and "max_action_dim" in rtc_config:
+                self._max_action_dim = int(rtc_config["max_action_dim"])
+            elif (
+                hasattr(model, "manifest")
+                and model.manifest.hardware.robots
+                and model.manifest.hardware.robots[0].action is not None
+                and model.manifest.hardware.robots[0].action.shape
+            ):
+                self._max_action_dim = model.manifest.hardware.robots[0].action.shape[-1]
+            else:
+                self._max_action_dim = 32
+
+        # 3. Automatically discover postprocessors from model if empty/not provided
+        if not self._postprocessors and hasattr(model, "postprocessors") and model.postprocessors:
+            logger.info("Moving postprocessors from InferenceModel to RTCExecution for async background execution")
+            self._postprocessors = model.postprocessors
+            model.postprocessors = []  # Clear from model so they aren't run twice
+
         self._stop_event.clear()
         self._first_chunk_ready.clear()
         self._thread = threading.Thread(
@@ -134,7 +196,7 @@ class RTCExecution(Execution):
             self._fps,
             self._chunk_size,
             self._execution_horizon,
-            self._queue_threshold,
+            self.queue_threshold,
         )
 
     def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
@@ -199,7 +261,7 @@ class RTCExecution(Execution):
 
         while not self._stop_event.is_set():
             # Only re-infer when queue is running low
-            if not self._rtc_queue.below_threshold(self._queue_threshold):
+            if not self._rtc_queue.below_threshold(self.queue_threshold):
                 time.sleep(_IDLE_SLEEP_S)
                 continue
 

--- a/src/physicalai/runtime/rtc_execution.py
+++ b/src/physicalai/runtime/rtc_execution.py
@@ -1,0 +1,323 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Real-Time Chunking (RTC) execution strategy.
+
+Runs inference in a background daemon thread, injecting RTC-specific
+inputs (noise, prev_chunk_left_over, inference_delay, etc.) and
+managing a dual-track action queue for continuous robot control.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import threading
+import time
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from physicalai.runtime._rtc_action_queue import RTCActionQueue
+from physicalai.runtime.execution import Execution, WorkerDiedError
+
+if TYPE_CHECKING:
+    from physicalai.inference.callbacks.rtc_latency import RTCLatencyTracker
+    from physicalai.inference.model import InferenceModel
+    from physicalai.inference.postprocessors.base import Postprocessor
+    from physicalai.runtime._action_queue import ActionQueue
+
+logger = logging.getLogger(__name__)
+
+_NOT_STARTED = "start() must be called before this method"
+_IDLE_SLEEP_S: float = 0.005
+_ERROR_RETRY_DELAY_S: float = 0.5
+_MAX_CONSECUTIVE_ERRORS: int = 10
+_JOIN_TIMEOUT_S: float = 5.0
+
+
+class RTCExecution(Execution):
+    """Async RTC execution strategy with background inference thread.
+
+    The background thread continuously predicts action chunks and
+    merges them into an :class:`RTCActionQueue`. The main thread pops
+    one action per tick — never blocking on inference.
+
+    RTC-specific inputs injected before each inference call:
+    - ``noise``: random noise for denoising (shape: 1×chunk×action_dim)
+    - ``prev_chunk_left_over``: unconsumed tail (shape: 1×chunk×action_dim)
+    - ``inference_delay``: integer derived from measured latency
+    - ``max_guidance_weight``: classifier-free guidance weight
+    - ``execution_horizon``: number of fresh actions per chunk
+
+    Args:
+        chunk_size: Number of actions per model output chunk.
+        execution_horizon: Fresh actions to execute per chunk.
+        fps: Robot control frequency in Hz.
+        max_action_dim: Model's internal action dimension (for noise/padding).
+        max_guidance_weight: Classifier-free guidance weight.
+        queue_threshold: Re-infer when queue drops below this level.
+        latency_tracker: Callback that measures inference latency.
+            If None, delay defaults to 0.
+        postprocessors: Denormalization pipeline applied to raw actions.
+            These run in the background thread to produce the processed
+            track stored in the queue.
+    """
+
+    def __init__(
+        self,
+        chunk_size: int = 50,
+        execution_horizon: int = 10,
+        fps: float = 30.0,
+        max_action_dim: int = 32,
+        max_guidance_weight: float = 10.0,
+        queue_threshold: int | None = None,
+        latency_tracker: RTCLatencyTracker | None = None,
+        postprocessors: list[Postprocessor] | None = None,
+    ) -> None:
+        self._chunk_size = chunk_size
+        self._execution_horizon = execution_horizon
+        self._fps = fps
+        self._max_action_dim = max_action_dim
+        self._max_guidance_weight = max_guidance_weight
+        self._queue_threshold = queue_threshold if queue_threshold is not None else execution_horizon * 3
+        self._latency_tracker = latency_tracker
+        self._postprocessors: list[Postprocessor] = postprocessors or []
+
+        self._rtc_queue: RTCActionQueue | None = None
+        self._model: InferenceModel | None = None
+        self._chunk_size_discovered: int = 0
+
+        # Thread state
+        self._obs_lock = threading.Lock()
+        self._obs_slot: dict[str, np.ndarray] | None = None
+        self._stop_event = threading.Event()
+        self._first_chunk_ready = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._death_cause: BaseException | None = None
+        self._inference_count: int = 0
+
+    @property
+    def chunk_size(self) -> int:
+        """Discovered chunk size (from warmup or config)."""
+        return self._chunk_size_discovered or self._chunk_size
+
+    @property
+    def inference_count(self) -> int:
+        """Number of completed inference calls."""
+        return self._inference_count
+
+    def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
+        """Bind model and queue, spawn background thread.
+
+        The ``action_queue`` parameter is accepted for interface
+        compatibility but ignored — RTCExecution uses its own
+        :class:`RTCActionQueue` (passed via constructor or created
+        internally). The ``PolicyRuntime`` should be given the same
+        ``RTCActionQueue`` instance.
+        """
+        self._model = model
+        # Accept RTCActionQueue from PolicyRuntime
+        if isinstance(action_queue, RTCActionQueue):
+            self._rtc_queue = action_queue
+        elif self._rtc_queue is None:
+            self._rtc_queue = RTCActionQueue()
+
+        self._stop_event.clear()
+        self._first_chunk_ready.clear()
+        self._thread = threading.Thread(
+            target=self._rtc_loop,
+            name="rtc-inference",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "RTCExecution started (fps=%.1f, chunk=%d, horizon=%d, threshold=%d)",
+            self._fps, self._chunk_size, self._execution_horizon, self._queue_threshold,
+        )
+
+    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
+        """Run one inference to seed the queue and discover chunk size.
+
+        Blocks until the first chunk is produced by the background
+        thread (or timeout).
+
+        Raises:
+            RuntimeError: If start() not called or thread dies during warmup.
+        """
+        if self._model is None or self._rtc_queue is None:
+            raise RuntimeError(_NOT_STARTED)
+
+        # Publish the sample observation for the background thread
+        with self._obs_lock:
+            self._obs_slot = deepcopy(sample_observation)
+
+        # Wait for the first chunk with a generous timeout
+        if not self._first_chunk_ready.wait(timeout=30.0):
+            if self._death_cause is not None:
+                msg = f"RTC thread died during warmup: {self._death_cause}"
+                raise WorkerDiedError(msg) from self._death_cause
+            msg = "RTCExecution warmup timed out waiting for first chunk"
+            raise RuntimeError(msg)
+
+        self._chunk_size_discovered = self._chunk_size
+        logger.info("RTCExecution warmup complete — chunk_size=%d", self._chunk_size_discovered)
+
+    def maybe_request(self, observation: dict[str, np.ndarray]) -> None:
+        """Publish latest observation for the background thread.
+
+        The background thread decides when to re-infer based on
+        queue threshold. This just updates the observation slot.
+
+        Raises:
+            WorkerDiedError: If the inference thread has died.
+        """
+        if self._thread is not None and not self._thread.is_alive() and self._death_cause is not None:
+            msg = f"RTC inference thread died: {self._death_cause}"
+            raise WorkerDiedError(msg) from self._death_cause
+
+        with self._obs_lock:
+            self._obs_slot = {
+                k: v.copy() if isinstance(v, np.ndarray) else v
+                for k, v in observation.items()
+            }
+
+    def stop(self) -> None:
+        """Signal shutdown and join the background thread."""
+        if self._thread is not None:
+            self._stop_event.set()
+            self._thread.join(timeout=_JOIN_TIMEOUT_S)
+            if self._thread.is_alive():
+                logger.warning("RTC thread did not join within %.1fs", _JOIN_TIMEOUT_S)
+            self._thread = None
+            logger.info("RTCExecution stopped (%d inferences)", self._inference_count)
+
+    def _rtc_loop(self) -> None:
+        """Background loop: infer chunks and merge into queue."""
+        assert self._model is not None  # noqa: S101
+        assert self._rtc_queue is not None  # noqa: S101
+        consecutive_errors = 0
+
+        while not self._stop_event.is_set():
+            # Only re-infer when queue is running low
+            if not self._rtc_queue.below_threshold(self._queue_threshold):
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+
+            # Snapshot observation
+            with self._obs_lock:
+                if self._obs_slot is None:
+                    time.sleep(_IDLE_SLEEP_S)
+                    continue
+                inputs = deepcopy(self._obs_slot)
+
+            # Build RTC-specific inputs
+            inputs = self._inject_rtc_inputs(inputs)
+
+            # Snapshot cursor before inference
+            action_index_before = self._rtc_queue.get_action_index()
+
+            # Run inference (callbacks fire inside model.__call__)
+            try:
+                t0 = time.perf_counter()
+                outputs = self._model(inputs)
+                elapsed = time.perf_counter() - t0
+                consecutive_errors = 0
+            except Exception:
+                consecutive_errors += 1
+                logger.exception(
+                    "RTC inference error (%d/%d)",
+                    consecutive_errors, _MAX_CONSECUTIVE_ERRORS,
+                )
+                if consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
+                    self._death_cause = RuntimeError("Too many consecutive RTC errors")
+                    logger.error("RTC thread shutting down after %d consecutive errors", consecutive_errors)
+                    return
+                time.sleep(_ERROR_RETRY_DELAY_S)
+                continue
+
+            self._inference_count += 1
+
+            # Extract raw actions: (1, chunk_size, action_dim) → (chunk_size, action_dim)
+            raw_actions = outputs["action"]
+            if raw_actions.ndim == 3:  # noqa: PLR2004
+                raw_actions = raw_actions[0]
+
+            # Postprocess (denormalize) for robot
+            processed_actions = self._postprocess(raw_actions)
+
+            # Compute real delay from actual elapsed time
+            real_delay = int(math.ceil(elapsed * self._fps))
+
+            # Merge into dual-track queue (queue clamps trim internally)
+            self._rtc_queue.merge(
+                raw_actions, 
+                processed_actions, 
+                real_delay,
+                action_index_before_inference=action_index_before,
+            )
+            self._first_chunk_ready.set()
+
+            logger.debug(
+                "RTC chunk: latency=%.3fs delay=%d remaining=%d",
+                elapsed, real_delay, self._rtc_queue.remaining,
+            )
+
+    def _inject_rtc_inputs(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Add RTC-specific model inputs."""
+        assert self._rtc_queue is not None  # noqa: S101
+
+        # prev_chunk_left_over from queue
+        prev_chunk = self._rtc_queue.get_left_over()
+        if prev_chunk is None:
+            prev_chunk_padded = np.zeros(
+                (1, self._chunk_size, self._max_action_dim),
+                dtype=np.float32,
+            )
+        else:
+            remaining = prev_chunk.shape[0]
+            out_dim = prev_chunk.shape[-1]
+
+            # Pad action dim to model's max_action_dim if needed
+            if out_dim < self._max_action_dim:
+                prev_chunk = np.pad(
+                    prev_chunk,
+                    ((0, 0), (0, self._max_action_dim - out_dim)),
+                )
+
+            # Reshape to (1, remaining, max_action_dim) and pad time to chunk_size
+            prev_chunk_padded = prev_chunk.reshape(1, remaining, self._max_action_dim)
+            pad_len = self._chunk_size - remaining
+            if pad_len > 0:
+                prev_chunk_padded = np.pad(prev_chunk_padded, ((0, 0), (0, pad_len), (0, 0)))
+
+        # Compute delay from latency tracker
+        if self._latency_tracker is not None:
+            delay = self._latency_tracker.compute_delay(self._fps)
+        else:
+            delay = 0
+
+        inputs["prev_chunk_left_over"] = prev_chunk_padded
+        inputs["inference_delay"] = np.int64(delay)
+        inputs["max_guidance_weight"] = np.float32(self._max_guidance_weight)
+        inputs["execution_horizon"] = np.int64(self._execution_horizon)
+
+        return inputs
+
+    def _postprocess(self, actions: np.ndarray) -> np.ndarray:
+        """Apply postprocessors (denormalization) to raw actions.
+
+        Args:
+            actions: Shape ``(chunk_size, action_dim)``.
+
+        Returns:
+            Postprocessed actions, same shape.
+        """
+        if not self._postprocessors:
+            return actions.copy()
+
+        outputs: dict[str, Any] = {"action": actions}
+        for pp in self._postprocessors:
+            outputs = pp(outputs)
+        return outputs["action"]

--- a/src/physicalai/runtime/rtc_execution.py
+++ b/src/physicalai/runtime/rtc_execution.py
@@ -351,6 +351,9 @@ class RTCExecution(Execution):
                 (1, self._chunk_size, self._max_action_dim),
                 dtype=np.float32,
             )
+            # Suppress correction on the first step since there's no real previous trajectory
+            max_guidance_weight = 0.0
+            execution_horizon = 0
         else:
             remaining = prev_chunk.shape[0]
             out_dim = prev_chunk.shape[-1]
@@ -368,13 +371,16 @@ class RTCExecution(Execution):
             if pad_len > 0:
                 prev_chunk_padded = np.pad(prev_chunk_padded, ((0, 0), (0, pad_len), (0, 0)))
 
+            max_guidance_weight = self._max_guidance_weight
+            execution_horizon = self._execution_horizon
+
         # Compute delay from latency tracker
         delay = self._latency_tracker.compute_delay(self._fps) if self._latency_tracker is not None else 0
 
         inputs["prev_chunk_left_over"] = prev_chunk_padded
         inputs["inference_delay"] = np.int64(delay)
-        inputs["max_guidance_weight"] = np.float32(self._max_guidance_weight)
-        inputs["execution_horizon"] = np.int64(self._execution_horizon)
+        inputs["max_guidance_weight"] = np.float32(max_guidance_weight)
+        inputs["execution_horizon"] = np.int64(execution_horizon)
 
         return inputs
 

--- a/src/physicalai/runtime/rtc_execution.py
+++ b/src/physicalai/runtime/rtc_execution.py
@@ -19,14 +19,13 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from physicalai.runtime._rtc_action_queue import RTCActionQueue
 from physicalai.runtime.execution import Execution, WorkerDiedError
 
 if TYPE_CHECKING:
     from physicalai.inference.callbacks.rtc_latency import RTCLatencyTracker
     from physicalai.inference.model import InferenceModel
     from physicalai.inference.postprocessors.base import Postprocessor
-    from physicalai.runtime._action_queue import ActionQueue
+    from physicalai.runtime._rtc_action_queue import RTCActionQueue
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +44,8 @@ class RTCExecution(Execution):
     one action per tick — never blocking on inference.
 
     RTC-specific inputs injected before each inference call:
-    - ``noise``: random noise for denoising (shape: 1×chunk×action_dim)
-    - ``prev_chunk_left_over``: unconsumed tail (shape: 1×chunk×action_dim)
+    - ``noise``: random noise for denoising (shape: 1 x chunk x action_dim)
+    - ``prev_chunk_left_over``: unconsumed tail (shape: 1 x chunk x action_dim)
     - ``inference_delay``: integer derived from measured latency
     - ``max_guidance_weight``: classifier-free guidance weight
     - ``execution_horizon``: number of fresh actions per chunk
@@ -65,7 +64,7 @@ class RTCExecution(Execution):
             track stored in the queue.
     """
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         chunk_size: int = 50,
         execution_horizon: int = 10,
@@ -108,21 +107,15 @@ class RTCExecution(Execution):
         """Number of completed inference calls."""
         return self._inference_count
 
-    def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
+    def start(self, model: InferenceModel, action_queue: RTCActionQueue) -> None:  # type: ignore[override]
         """Bind model and queue, spawn background thread.
 
-        The ``action_queue`` parameter is accepted for interface
-        compatibility but ignored — RTCExecution uses its own
-        :class:`RTCActionQueue` (passed via constructor or created
-        internally). The ``PolicyRuntime`` should be given the same
-        ``RTCActionQueue`` instance.
+        Args:
+            model: The inference model.
+            action_queue: The RTC dual-track action queue.
         """
         self._model = model
-        # Accept RTCActionQueue from PolicyRuntime
-        if isinstance(action_queue, RTCActionQueue):
-            self._rtc_queue = action_queue
-        elif self._rtc_queue is None:
-            self._rtc_queue = RTCActionQueue()
+        self._rtc_queue = action_queue
 
         self._stop_event.clear()
         self._first_chunk_ready.clear()
@@ -134,7 +127,10 @@ class RTCExecution(Execution):
         self._thread.start()
         logger.info(
             "RTCExecution started (fps=%.1f, chunk=%d, horizon=%d, threshold=%d)",
-            self._fps, self._chunk_size, self._execution_horizon, self._queue_threshold,
+            self._fps,
+            self._chunk_size,
+            self._execution_horizon,
+            self._queue_threshold,
         )
 
     def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
@@ -145,6 +141,7 @@ class RTCExecution(Execution):
 
         Raises:
             RuntimeError: If start() not called or thread dies during warmup.
+            WorkerDiedError: If the RTC thread dies during warmup.
         """
         if self._model is None or self._rtc_queue is None:
             raise RuntimeError(_NOT_STARTED)
@@ -178,10 +175,7 @@ class RTCExecution(Execution):
             raise WorkerDiedError(msg) from self._death_cause
 
         with self._obs_lock:
-            self._obs_slot = {
-                k: v.copy() if isinstance(v, np.ndarray) else v
-                for k, v in observation.items()
-            }
+            self._obs_slot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
 
     def stop(self) -> None:
         """Signal shutdown and join the background thread."""
@@ -228,11 +222,12 @@ class RTCExecution(Execution):
                 consecutive_errors += 1
                 logger.exception(
                     "RTC inference error (%d/%d)",
-                    consecutive_errors, _MAX_CONSECUTIVE_ERRORS,
+                    consecutive_errors,
+                    _MAX_CONSECUTIVE_ERRORS,
                 )
                 if consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
                     self._death_cause = RuntimeError("Too many consecutive RTC errors")
-                    logger.error("RTC thread shutting down after %d consecutive errors", consecutive_errors)
+                    logger.exception("RTC thread shutting down after %d consecutive errors", consecutive_errors)
                     return
                 time.sleep(_ERROR_RETRY_DELAY_S)
                 continue
@@ -248,12 +243,12 @@ class RTCExecution(Execution):
             processed_actions = self._postprocess(raw_actions)
 
             # Compute real delay from actual elapsed time
-            real_delay = int(math.ceil(elapsed * self._fps))
+            real_delay = math.ceil(elapsed * self._fps)
 
             # Merge into dual-track queue (queue clamps trim internally)
             self._rtc_queue.merge(
-                raw_actions, 
-                processed_actions, 
+                raw_actions,
+                processed_actions,
                 real_delay,
                 action_index_before_inference=action_index_before,
             )
@@ -261,11 +256,17 @@ class RTCExecution(Execution):
 
             logger.debug(
                 "RTC chunk: latency=%.3fs delay=%d remaining=%d",
-                elapsed, real_delay, self._rtc_queue.remaining,
+                elapsed,
+                real_delay,
+                self._rtc_queue.remaining,
             )
 
     def _inject_rtc_inputs(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
-        """Add RTC-specific model inputs."""
+        """Add RTC-specific model inputs.
+
+        Returns:
+            Updated inputs dict with RTC keys added.
+        """
         assert self._rtc_queue is not None  # noqa: S101
 
         # prev_chunk_left_over from queue
@@ -293,10 +294,7 @@ class RTCExecution(Execution):
                 prev_chunk_padded = np.pad(prev_chunk_padded, ((0, 0), (0, pad_len), (0, 0)))
 
         # Compute delay from latency tracker
-        if self._latency_tracker is not None:
-            delay = self._latency_tracker.compute_delay(self._fps)
-        else:
-            delay = 0
+        delay = self._latency_tracker.compute_delay(self._fps) if self._latency_tracker is not None else 0
 
         inputs["prev_chunk_left_over"] = prev_chunk_padded
         inputs["inference_delay"] = np.int64(delay)

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING, Any, Protocol, Self
 import numpy as np
 
 from physicalai.runtime._action_queue import ActionQueue  # noqa: PLC2701
-from physicalai.runtime._rtc_action_queue import RTCActionQueue  # noqa: PLC2701
 from physicalai.runtime.execution import Execution, WorkerDiedError
 from physicalai.runtime.smoothers import LerpSmoother
 
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
     from physicalai.capture.camera import Camera
     from physicalai.inference.model import InferenceModel
     from physicalai.robot.interface import Robot
+    from physicalai.runtime._rtc_action_queue import RTCActionQueue
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +166,7 @@ class PolicyRuntime:
         if not self._connected:
             msg = "PolicyRuntime.run() called before connect(). Use 'with runtime:' or call runtime.connect() first."
             raise RuntimeError(msg)
-        self._execution.start(self._model, self._action_queue)
+        self._execution.start(self._model, self._action_queue)  # type: ignore[arg-type]
         sample_obs = self._build_model_input()
         self._execution.warmup(sample_obs)
 

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -60,6 +60,10 @@ class ActionQueue(Protocol):
         """Total number of actions popped."""
         ...
 
+    def push_chunk(self, chunk: np.ndarray, offset: int = 0) -> None:
+        """Push a chunk of actions into the queue."""
+        ...
+
     def below_threshold(self, threshold: int) -> bool:
         """Check if remaining actions are below threshold."""
         ...
@@ -126,7 +130,9 @@ class PolicyRuntime:
         self._execution = execution
         self._fps = fps
         self._cameras: Mapping[str, Camera] = cameras or {}
-        self._action_queue = action_queue or ChunkedActionQueue(smoother=LerpSmoother(duration_frames=_DEFAULT_LERP_FRAMES))
+        self._action_queue = action_queue or ChunkedActionQueue(
+            smoother=LerpSmoother(duration_frames=_DEFAULT_LERP_FRAMES)
+        )
         self._callbacks = list(callbacks)
         self._goal_time = (1.0 / fps) * 3
         self._connected = False

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Protocol, Self
 import numpy as np
 
 from physicalai.runtime._action_queue import ActionQueue  # noqa: PLC2701
+from physicalai.runtime._rtc_action_queue import RTCActionQueue  # noqa: PLC2701
 from physicalai.runtime.execution import Execution, WorkerDiedError
 from physicalai.runtime.smoothers import LerpSmoother
 
@@ -74,7 +75,7 @@ class PolicyRuntime:
         execution: Execution,
         fps: float,
         cameras: Mapping[str, Camera] | None = None,
-        action_queue: ActionQueue | None = None,
+        action_queue: ActionQueue | RTCActionQueue | None = None,
         callbacks: Sequence[RuntimeCallback] = (),
     ) -> None:
         if fps <= 0:

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -85,6 +85,52 @@ class RuntimeCallback(Protocol):
         ...
 
 
+class LowPassFilterCallback:
+    """Stateful low-pass filter (Exponential Moving Average) callback for smooth actions.
+
+    Filters outgoing multidimensional joint positions/actions using a simple
+    discrete one-pole IIR filter (exponential moving average):
+        y_t = alpha * x_t + (1 - alpha) * y_{t-1}
+
+    Args:
+        alpha: Smoothing factor in range (0, 1]. A lower value introduces
+            more smoothing (heavy low-pass filter), whereas 1.0 is a no-op.
+    """
+
+    def __init__(self, alpha: float = 0.5) -> None:  # noqa: D107
+        if not (0.0 < alpha <= 1.0):
+            msg = f"alpha must be in (0, 1], got {alpha}"
+            raise ValueError(msg)
+        self.alpha = alpha
+        self._last_action: np.ndarray | None = None
+
+    def before_send_action(self, *, action: np.ndarray, step: int) -> np.ndarray:  # noqa: ARG002
+        """Filter target action vector using previous action state.
+
+        Args:
+            action: The target raw/unfiltered joint configuration.
+            step: The iteration step index in the control loop.
+
+        Returns:
+            The smoothed/filtered action target configuration.
+        """
+        if self._last_action is None or self._last_action.shape != action.shape:
+            # First tick or shape mismatch: initialize filter state to current action
+            self._last_action = action.copy()
+            return action
+
+        # Apply low-pass recursive formula
+        filtered_action = self.alpha * action + (1.0 - self.alpha) * self._last_action
+        self._last_action = filtered_action.copy()
+        return filtered_action
+
+    def on_action_sent(self, *, action: np.ndarray, step: int) -> None:
+        """No-op."""
+
+    def on_hold(self, *, step: int, holds: int) -> None:
+        """No-op."""
+
+
 @dataclass(frozen=True)
 class RunStats:
     """Statistics from a PolicyRuntime.run() session."""

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -60,10 +60,6 @@ class ActionQueue(Protocol):
         """Total number of actions popped."""
         ...
 
-    def push_chunk(self, chunk: np.ndarray, offset: int = 0) -> None:
-        """Push a chunk of actions into the queue."""
-        ...
-
     def below_threshold(self, threshold: int) -> bool:
         """Check if remaining actions are below threshold."""
         ...

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
 
 import numpy as np
 
-from physicalai.runtime._action_queue import ActionQueue  # noqa: PLC2701
+from physicalai.runtime._action_queue import ChunkedActionQueue  # noqa: PLC2701
 from physicalai.runtime.execution import Execution, WorkerDiedError
 from physicalai.runtime.smoothers import LerpSmoother
 
@@ -22,11 +22,51 @@ if TYPE_CHECKING:
     from physicalai.capture.camera import Camera
     from physicalai.inference.model import InferenceModel
     from physicalai.robot.interface import Robot
-    from physicalai.runtime._rtc_action_queue import RTCActionQueue
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_LERP_FRAMES = 5
+
+
+@runtime_checkable
+class ActionQueue(Protocol):
+    """Protocol for a thread-safe action queue."""
+
+    def pop(self) -> np.ndarray | None:
+        """Pop the next action.
+
+        Returns:
+            Single action vector, or None if empty.
+        """
+        ...
+
+    @property
+    def remaining(self) -> int:
+        """Number of unconsumed actions in the queue."""
+        ...
+
+    @property
+    def consecutive_holds(self) -> int:
+        """Number of consecutive holds (resets on successful pop)."""
+        ...
+
+    @property
+    def total_holds(self) -> int:
+        """Total number of hold events (pop on empty queue)."""
+        ...
+
+    @property
+    def total_pops(self) -> int:
+        """Total number of actions popped."""
+        ...
+
+    def below_threshold(self, threshold: int) -> bool:
+        """Check if remaining actions are below threshold."""
+        ...
+
+    def clear(self) -> None:
+        """Clear all state from the queue."""
+        ...
 
 
 class RuntimeCallback(Protocol):
@@ -75,7 +115,7 @@ class PolicyRuntime:
         execution: Execution,
         fps: float,
         cameras: Mapping[str, Camera] | None = None,
-        action_queue: ActionQueue | RTCActionQueue | None = None,
+        action_queue: ActionQueue | None = None,
         callbacks: Sequence[RuntimeCallback] = (),
     ) -> None:
         if fps <= 0:
@@ -86,7 +126,7 @@ class PolicyRuntime:
         self._execution = execution
         self._fps = fps
         self._cameras: Mapping[str, Camera] = cameras or {}
-        self._action_queue = action_queue or ActionQueue(smoother=LerpSmoother(duration_frames=_DEFAULT_LERP_FRAMES))
+        self._action_queue = action_queue or ChunkedActionQueue(smoother=LerpSmoother(duration_frames=_DEFAULT_LERP_FRAMES))
         self._callbacks = list(callbacks)
         self._goal_time = (1.0 / fps) * 3
         self._connected = False

--- a/tests/unit/runtime/test_action_queue.py
+++ b/tests/unit/runtime/test_action_queue.py
@@ -4,13 +4,13 @@ import threading
 
 import numpy as np
 
-from physicalai.runtime._action_queue import ActionQueue
+from physicalai.runtime._action_queue import ChunkedActionQueue
 from physicalai.runtime.smoothers import LerpSmoother, ReplaceSmoother
 
 
-class TestActionQueue:
+class TestChunkedActionQueue:
     def test_push_pop_roundtrip(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         chunk = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         queue.push_chunk(chunk)
 
@@ -20,11 +20,11 @@ class TestActionQueue:
             np.testing.assert_array_equal(action, chunk[i])
 
     def test_pop_empty_returns_none(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         assert queue.pop() is None
 
     def test_consecutive_holds_increment_and_reset(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         queue.pop()
         queue.pop()
         assert queue.consecutive_holds == 2
@@ -34,7 +34,7 @@ class TestActionQueue:
         assert queue.consecutive_holds == 0
 
     def test_total_counters(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         queue.pop()
         queue.pop()
         queue.push_chunk(np.array([[1.0], [2.0], [3.0]], dtype=np.float32))
@@ -47,7 +47,7 @@ class TestActionQueue:
         assert queue.total_pops == 3
 
     def test_remaining_property(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         assert queue.remaining == 0
 
         queue.push_chunk(np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32))
@@ -57,7 +57,7 @@ class TestActionQueue:
         assert queue.remaining == 1
 
     def test_below_threshold(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         assert queue.below_threshold(1) is True
 
         queue.push_chunk(np.array([[1.0], [2.0], [3.0]], dtype=np.float32))
@@ -66,7 +66,7 @@ class TestActionQueue:
         assert queue.below_threshold(2) is False
 
     def test_clear(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         queue.push_chunk(np.array([[1.0], [2.0]], dtype=np.float32))
         queue.pop()
         queue.pop()
@@ -82,7 +82,7 @@ class TestActionQueue:
         assert queue.total_pops == 2
 
     def test_push_with_offset(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         chunk = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=np.float32)
         queue.push_chunk(chunk, offset=2)
 
@@ -92,11 +92,11 @@ class TestActionQueue:
         np.testing.assert_array_equal(action, [5.0, 6.0])
 
     def test_default_smoother_is_replace(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         assert isinstance(queue._smoother, ReplaceSmoother)
 
     def test_smoother_integration_lerp(self) -> None:
-        queue = ActionQueue(smoother=LerpSmoother(duration_frames=5))
+        queue = ChunkedActionQueue(smoother=LerpSmoother(duration_frames=5))
         first = np.array([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]], dtype=np.float32)
         queue.push_chunk(first)
 
@@ -111,7 +111,7 @@ class TestActionQueue:
         assert not np.array_equal(first_action, second[0]), "LerpSmoother should blend, not replace"
 
     def test_smoother_integration_replace(self) -> None:
-        queue = ActionQueue(smoother=ReplaceSmoother())
+        queue = ChunkedActionQueue(smoother=ReplaceSmoother())
         first = np.array([[1.0], [2.0], [3.0]], dtype=np.float32)
         queue.push_chunk(first)
 
@@ -124,9 +124,9 @@ class TestActionQueue:
         np.testing.assert_array_equal(action, [10.0])
 
 
-class TestActionQueueThreadSafety:
+class TestChunkedActionQueueThreadSafety:
     def test_concurrent_push_pop(self) -> None:
-        queue = ActionQueue()
+        queue = ChunkedActionQueue()
         errors: list[Exception] = []
         action_dim = 4
         n_pushes = 100

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from physicalai.runtime._action_queue import ActionQueue
+from physicalai.runtime._action_queue import ChunkedActionQueue as ActionQueue
 from physicalai.runtime.execution import AsyncExecution, SyncExecution, WorkerDiedError
 
 

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -250,6 +250,33 @@ class TestRuntimeCallback:
         assert callback.on_hold.call_count >= 1
 
 
+class TestLowPassFilterCallback:
+    def test_low_pass_filtering_values(self) -> None:
+        from physicalai.runtime.runtime import LowPassFilterCallback
+
+        cb = LowPassFilterCallback(alpha=0.6)
+
+        # First step: initialize
+        act1 = np.array([1.0, 2.0], dtype=np.float32)
+        res1 = cb.before_send_action(action=act1, step=0)
+        assert np.allclose(res1, act1)
+
+        # Second step: verify formula y_t = alpha * x_t + (1 - alpha) * y_t-1
+        # y_1 = 0.6 * [3.0, 4.0] + 0.4 * [1.0, 2.0] = [1.8 + 0.4, 2.4 + 0.8] = [2.2, 3.2]
+        act2 = np.array([3.0, 4.0], dtype=np.float32)
+        res2 = cb.before_send_action(action=act2, step=1)
+        assert np.allclose(res2, np.array([2.2, 3.2], dtype=np.float32))
+
+    def test_low_pass_invalid_alpha(self) -> None:
+        from physicalai.runtime.runtime import LowPassFilterCallback
+
+        with pytest.raises(ValueError, match="alpha"):
+            LowPassFilterCallback(alpha=0.0)
+
+        with pytest.raises(ValueError, match="alpha"):
+            LowPassFilterCallback(alpha=1.1)
+
+
 class TestRunStats:
     def test_fields_populated(self) -> None:
         stats = RunStats(steps=10, total_pops=8, total_holds=2, inference_count=3)

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from physicalai.runtime._action_queue import ActionQueue
+from physicalai.runtime._action_queue import ChunkedActionQueue as ActionQueue
 from physicalai.runtime.execution import SyncExecution, WorkerDiedError
 from physicalai.runtime.runtime import PolicyRuntime, RunStats
 


### PR DESCRIPTION
## Summary

- Implement Real-Time Chunking (RTC) execution strategy for continuous, non-blocking robot control with async background inference.

## Why

- Standard synchronous inference blocks the control loop, causing jitter at high FPS. RTC decouples inference from action dispatch by running predictions in a daemon thread and serving actions from a dual-track queue — enabling smooth 30 Hz+ robot control even when individual inferences take hundreds of milliseconds.

## Validation

- Manual testing with Pi0.5 RTC model on SO-101 robot at 30 FPS
- Warmup inference correctly resets the latency tracker to discard OpenVINO first-run compilation overhead
- Thread safety verified via `threading.Lock` on all shared state (observation slot, action queue)
- Error recovery: background thread tolerates up to 10 consecutive inference failures before halting

## Breaking changes

- None

## Related issues

- None


### Changes Made

| File | Description |
|------|-------------|
| rtc_execution.py | New `RTCExecution` class — background daemon thread continuously predicts action chunks, injects RTC inputs (noise, `prev_chunk_left_over`, `inference_delay`, `max_guidance_weight`, `execution_horizon`), and merges results into the dual-track queue |
| _rtc_action_queue.py | New `RTCActionQueue` — thread-safe dual-track queue storing both raw (for feedback) and postprocessed (for robot) actions, with cursor-based consumption and latency-aware trim on merge |
| rtc_latency.py | New `RTCLatencyTracker` callback — sliding-window latency measurement with `compute_delay(fps)` for the RTC model's `inference_delay` input |
| __init__.py | Export `RTCExecution` and `RTCActionQueue` |
| __init__.py | Export `RTCLatencyTracker` |
| runtime.py | Accept `RTCActionQueue` in `PolicyRuntime` type signature |
| _shared_camera.py | Minor fix: explicitly set `sample = None` after failed reads |
| rtc_inference.py | End-to-end example demonstrating RTC inference with Pi0.5 on SO-101 |

### Architecture

```mermaid
graph LR
    A[Main Thread - 30Hz tick] -->|publish obs| B[Observation Slot]
    B -->|read obs| C[RTC Daemon Thread]
    C -->|model inference| D[InferenceModel]
    D -->|raw actions| C
    C -->|merge| E[RTCActionQueue]
    A -->|pop 1 action| E
    E -->|action| F[Robot]
    C -->|latency| G[RTCLatencyTracker]
    G -->|compute_delay| C
```