### PR TITLE
POC: add runtime teleoperation policy

### DIFF
--- a/docs/explanation/runtime.md
+++ b/docs/explanation/runtime.md
@@ -11,13 +11,14 @@ runtime.run(duration_s=60)
 
 ## Responsibilities
 
-| Component        | Owns                                                       | Does not own      |
-| ---------------- | ---------------------------------------------------------- | ----------------- |
-| `InferenceModel` | model load, preprocess, inference, postprocess             | robot loop timing |
-| `Execution`      | where inference runs                                       | robot IO          |
-| `ActionQueue`    | action chunks and buffering                                | model inference   |
-| `PolicyRuntime`  | observe, request inference, send action, callbacks, timing | policy math       |
-| `Robot`          | hardware connection, observations, actions                 | policy inference  |
+| Component            | Owns                                                       | Does not own      |
+| -------------------- | ---------------------------------------------------------- | ----------------- |
+| `InferenceModel`     | model load, preprocess, inference, postprocess             | robot loop timing |
+| `TeleoperatorPolicy` | reading a leader robot and producing action chunks         | follower robot IO |
+| `Execution`          | where policy evaluation runs                               | robot IO          |
+| `ActionQueue`        | action chunks and buffering                                | model inference   |
+| `PolicyRuntime`      | observe, request inference, send action, callbacks, timing | policy math       |
+| `Robot`              | hardware connection, observations, actions                 | policy inference  |
 
 ## Loop
 
@@ -33,6 +34,8 @@ while running:
 ```
 
 The exact observation structure and merging strategy may change as the API stabilizes.
+
+`PolicyRuntime` accepts any policy-like object with `predict_action_chunk()`. A trained `InferenceModel` is one implementation. `TeleoperatorPolicy` is another implementation that reads a leader robot and returns the leader joint positions as a one-step action chunk for the follower.
 
 ## Execution Modes
 

--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -5,6 +5,7 @@ This section contains task-oriented guides for common runtime workflows.
 ## Runtime
 
 - [Run a policy on a robot](runtime/run-policy-on-robot.md)
+- [Teleoperate a robot](runtime/teleoperate-a-robot.md)
 - [Use execution modes](runtime/use-execution-modes.md)
 - [Add runtime callbacks](runtime/add-runtime-callbacks.md)
 

--- a/docs/how-to/runtime/teleoperate-a-robot.md
+++ b/docs/how-to/runtime/teleoperate-a-robot.md
@@ -1,0 +1,116 @@
+# Teleoperate a Robot
+
+Use `TeleoperatorPolicy` when you have a leader robot instead of a trained model. The leader robot is read every control tick and its joint positions are sent as actions to the follower robot through the normal `PolicyRuntime` loop.
+
+## When To Use
+
+Use this workflow for direct leader-follower teleoperation, data collection, hardware bring-up, and debugging robot action conventions before running a learned policy.
+
+Do not use this workflow when the leader and follower have different joint order, different units, or different action semantics unless you add an explicit mapping layer.
+
+## Run The Example
+
+For SO101, pass separate calibration files for the leader and follower arms.
+
+```bash
+uv run --extra observer-rerun --extra robots --extra capture examples/runtime/teleoperation.py \
+  --robot so101 \
+  --leader-port /dev/ttyACM0 \
+  --follower-port /dev/ttyACM1 \
+  --leader-calibration /path/to/leader-calibration.json \
+  --follower-calibration /path/to/follower-calibration.json \
+  --camera overhead:uvc:/dev/video0 \
+  --camera arm:uvc:/dev/video2 \
+  --fps 30 \
+  --rerun spawn \
+  --rerun-image-decimation 15 \
+  --rerun-jpeg-quality 75 \
+  --rerun-image-max-dim 480 \
+  --duration-s 90
+```
+
+For WidowXAI:
+
+```bash
+uv run --extra observer-rerun --extra robots --extra capture examples/runtime/teleoperation.py \
+  --robot widowxai \
+  --leader-ip 192.168.1.2 \
+  --follower-ip 192.168.1.3 \
+  --camera front:uvc:/dev/video0 \
+  --fps 30 \
+  --rerun spawn \
+  --duration-s 90
+```
+
+For bimanual WidowXAI:
+
+```bash
+uv run --extra observer-rerun --extra robots --extra capture examples/runtime/teleoperation.py \
+  --robot bimanual_widowxai \
+  --leader-ip-left 192.168.1.2 \
+  --leader-ip-right 192.168.1.3 \
+  --follower-ip-left 192.168.1.4 \
+  --follower-ip-right 192.168.1.5 \
+  --fps 30 \
+  --duration-s 90
+```
+
+## Python API
+
+```python
+from physicalai.robot import SO101, connect
+from physicalai.runtime import ActionQueue, PolicyRuntime, SyncExecution, TeleoperatorPolicy
+
+leader = SO101(
+    port="/dev/ttyACM0",
+    calibration="/path/to/leader-calibration.json",
+    role="leader",
+)
+follower = SO101(
+    port="/dev/ttyACM1",
+    calibration="/path/to/follower-calibration.json",
+    role="follower",
+)
+
+runtime = PolicyRuntime(
+    robot=follower,
+    model=TeleoperatorPolicy(leader),
+    execution=SyncExecution(fps=30, request_threshold=1.0),
+    action_queue=ActionQueue(),
+    fps=30,
+)
+
+with connect(leader), runtime:
+    runtime.run(duration_s=60)
+```
+
+## How It Works
+
+`PolicyRuntime` accepts a policy-like object with `predict_action_chunk()`. `InferenceModel` satisfies that contract, and so does `TeleoperatorPolicy`.
+
+```text
+PolicyRuntime
+  -> SyncExecution.maybe_request(follower_observation)
+  -> TeleoperatorPolicy.predict_action_chunk(...)
+  -> leader.get_observation().joint_positions[None, :]
+  -> ActionQueue.push_chunk(...)
+  -> follower.send_action(action)
+```
+
+`TeleoperatorPolicy` returns a chunk of size one, so `SyncExecution` should be used. The example uses `request_threshold=1.0` so each consumed action causes the next control tick to read the leader again.
+
+## Safety Checks
+
+Before running teleoperation, verify these conditions:
+
+- Leader and follower are the same robot type.
+- `leader.joint_names` and `follower.joint_names` have the same order.
+- Leader and follower observations/actions use compatible units.
+- The follower workspace is clear and safe.
+- The leader starts from a pose that the follower can safely reach.
+
+## Limitations
+
+`TeleoperatorPolicy` currently mirrors absolute joint positions. It does not do retargeting, scaling, joint remapping, gripper adaptation, velocity control, filtering, or workspace constraints.
+
+For human-in-the-loop policy control, wrap a learned policy and switch between `model_policy.predict_action_chunk()` and `TeleoperatorPolicy.predict_action_chunk()` based on a takeover signal.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ PhysicalAI provides runtime components for working with exported robot policies.
 | Install the package     | [Installation](getting-started/installation.md)         |
 | Run first inference     | [Quickstart](getting-started/quickstart.md)             |
 | Run a policy on a robot | [Run a Policy](getting-started/run-a-policy.md)         |
+| Teleoperate a robot     | [Teleoperate](how-to/runtime/teleoperate-a-robot.md)    |
 | Write runtime YAML      | [Runtime Config](how-to/config/write-runtime-config.md) |
 | Use the runtime CLI     | [CLI Run](how-to/cli/run.md)                            |
 | Understand architecture | [Architecture](explanation/architecture.md)             |

--- a/examples/runtime/teleoperation.py
+++ b/examples/runtime/teleoperation.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Teleoperate a follower robot from a leader robot with runtime callbacks.
+
+Prerequisites::
+
+    uv sync --extra capture --extra robots --extra observer-rerun
+
+Examples:
+
+uv run --extra observer-rerun --extra robots --extra capture examples/runtime/teleoperation.py \
+  --robot so101 \
+  --leader-port /dev/ttyACM0 \
+  --follower-port /dev/ttyACM1 \
+  --leader-calibration /home/mark/.cache/physicalai/robots/leader/calibrations/leader.json \
+  --follower-calibration /home/mark/.cache/physicalai/robots/follower/calibrations/follower.json \
+  --camera overhead:uvc:/dev/video34 \
+  --camera arm:uvc:/dev/video32 \
+  --fps 30 \
+  --rerun spawn \
+  --rerun-image-decimation 15 \
+  --rerun-jpeg-quality 75 \
+  --rerun-image-max-dim 480 \
+  --duration-s 30
+
+uv run --extra observer-rerun --extra robots --extra capture examples/runtime/teleoperation.py \
+  --robot widowxai \
+  --leader-ip 192.168.1.2 \
+  --follower-ip 192.168.1.3 \
+  --camera front:uvc:/dev/video0 \
+  --fps 30 \
+  --rerun spawn \
+  --duration-s 90
+
+uv run --extra observer-rerun --extra robots --extra capture examples/runtime/teleoperation.py \
+  --robot bimanual_widowxai \
+  --leader-ip-left 192.168.1.2 \
+  --leader-ip-right 192.168.1.3 \
+  --follower-ip-left 192.168.1.4 \
+  --follower-ip-right 192.168.1.5 \
+  --fps 30 \
+  --duration-s 90
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+
+from physicalai.capture import select_cameras_interactive
+from physicalai.robot import Robot, connect
+from physicalai.runtime import (
+    ActionQueue,
+    PolicyRuntime,
+    RerunCallback,
+    SyncExecution,
+    TeleoperatorPolicy,
+)
+
+from utils import parse_camera_specs
+
+
+def build_teleop_robots(args: argparse.Namespace) -> tuple[Robot, Robot]:
+    """Construct leader and follower robots from CLI args."""
+    if args.robot == "so101":
+        from physicalai.robot import SO101
+
+        if not args.leader_port:
+            raise SystemExit("error: --leader-port is required for so101")
+        if not args.follower_port:
+            raise SystemExit("error: --follower-port is required for so101")
+        if not args.leader_calibration:
+            raise SystemExit("error: --leader-calibration is required for so101")
+        if not args.follower_calibration:
+            raise SystemExit("error: --follower-calibration is required for so101")
+        leader = SO101(port=args.leader_port, calibration=args.leader_calibration, role="leader")
+        follower = SO101(port=args.follower_port, calibration=args.follower_calibration, role="follower")
+        return leader, follower
+
+    if args.robot == "widowxai":
+        from physicalai.robot import WidowXAI
+
+        if not args.leader_ip:
+            raise SystemExit("error: --leader-ip is required for widowxai")
+        if not args.follower_ip:
+            raise SystemExit("error: --follower-ip is required for widowxai")
+        return WidowXAI(ip=args.leader_ip, role="leader"), WidowXAI(ip=args.follower_ip, role="follower")
+
+    if args.robot == "bimanual_widowxai":
+        from physicalai.robot import BimanualWidowXAI, WidowXAI
+
+        if not args.leader_ip_left or not args.leader_ip_right:
+            raise SystemExit("error: --leader-ip-left and --leader-ip-right are required for bimanual_widowxai")
+        if not args.follower_ip_left or not args.follower_ip_right:
+            raise SystemExit("error: --follower-ip-left and --follower-ip-right are required for bimanual_widowxai")
+        leader = BimanualWidowXAI(
+            WidowXAI(ip=args.leader_ip_left, role="leader"),
+            WidowXAI(ip=args.leader_ip_right, role="leader"),
+        )
+        follower = BimanualWidowXAI(
+            WidowXAI(ip=args.follower_ip_left, role="follower"),
+            WidowXAI(ip=args.follower_ip_right, role="follower"),
+        )
+        return leader, follower
+
+    raise SystemExit(f"error: unknown robot type: {args.robot}")
+
+
+def main() -> None:
+    """Run the teleoperation example."""
+
+    def _handle_sigint(sig: int, frame: object) -> None:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        print("\nInterrupting... press Ctrl+C again to force kill.")
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _handle_sigint)
+
+    parser = argparse.ArgumentParser(
+        description="Teleoperate a follower robot from a leader robot",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    robot_group = parser.add_argument_group("robot")
+    robot_group.add_argument("--robot", required=True, choices=("so101", "widowxai", "bimanual_widowxai"))
+    robot_group.add_argument("--leader-port", help="Leader serial port (so101)")
+    robot_group.add_argument("--follower-port", help="Follower serial port (so101)")
+    robot_group.add_argument("--leader-calibration", help="Leader calibration JSON path (so101)")
+    robot_group.add_argument("--follower-calibration", help="Follower calibration JSON path (so101)")
+    robot_group.add_argument("--leader-ip", help="Leader robot IP (widowxai)")
+    robot_group.add_argument("--follower-ip", help="Follower robot IP (widowxai)")
+    robot_group.add_argument("--leader-ip-left", help="Left leader IP (bimanual_widowxai)")
+    robot_group.add_argument("--leader-ip-right", help="Right leader IP (bimanual_widowxai)")
+    robot_group.add_argument("--follower-ip-left", help="Left follower IP (bimanual_widowxai)")
+    robot_group.add_argument("--follower-ip-right", help="Right follower IP (bimanual_widowxai)")
+
+    cam_group = parser.add_argument_group("cameras")
+    cam_group.add_argument(
+        "--camera", action="append", dest="cameras", metavar="NAME:DRIVER:DEVICE",
+        help="Camera as name:driver:device_id (repeatable). Omit for interactive selection.",
+    )
+    cam_group.add_argument("--cam-width", type=int, default=640, help="Camera width (default: 640)")
+    cam_group.add_argument("--cam-height", type=int, default=480, help="Camera height (default: 480)")
+    cam_group.add_argument("--cam-fps", type=int, default=30, help="Camera FPS (default: 30)")
+
+    rt_group = parser.add_argument_group("runtime")
+    rt_group.add_argument("--fps", type=float, default=30.0, help="Control loop FPS (default: 30)")
+    rt_group.add_argument("--duration-s", type=float, default=60.0, help="Duration in seconds")
+    rt_group.add_argument(
+        "--shared-camera",
+        action="store_true",
+        help="Use shared memory cameras (iceoryx2) — faster but incompatible with debugger",
+    )
+
+    rr_group = parser.add_argument_group("rerun")
+    rr_group.add_argument("--rerun", choices=("off", "spawn", "connect", "save"), default="off")
+    rr_group.add_argument("--rerun-addr", default="127.0.0.1:9876")
+    rr_group.add_argument("--rerun-save-path", default="teleop.rrd")
+    rr_group.add_argument("--rerun-no-images", action="store_true", help="Scalars only")
+    rr_group.add_argument("--rerun-image-decimation", type=int, default=1, help="Only send 1/N frames to Rerun")
+    rr_group.add_argument(
+        "--rerun-jpeg-quality",
+        type=int,
+        default=None,
+        help="JPEG quality for Rerun images (0-100, default: no re-encoding)",
+    )
+    rr_group.add_argument(
+        "--rerun-image-max-dim",
+        type=int,
+        default=None,
+        help="Max width/height for Rerun images (default: no resizing)",
+    )
+
+    args = parser.parse_args()
+
+    leader, follower = build_teleop_robots(args)
+    if args.cameras:
+        cameras = parse_camera_specs(args.cameras, args.cam_width, args.cam_height, args.cam_fps, shared=args.shared_camera)
+    else:
+        cameras = select_cameras_interactive(args.cam_width, args.cam_height, args.cam_fps)
+
+    callbacks: list = []
+    if args.rerun != "off":
+        callbacks.append(
+            RerunCallback(
+                cameras=cameras,
+                image_decimation=args.rerun_image_decimation,
+                log_images=not args.rerun_no_images,
+                image_jpeg_quality=args.rerun_jpeg_quality,
+                image_max_dim=args.rerun_image_max_dim,
+                mode=args.rerun,
+                connect_addr=args.rerun_addr,
+                save_path=args.rerun_save_path if args.rerun == "save" else None,
+            )
+        )
+
+    runtime = PolicyRuntime(
+        robot=follower,
+        model=TeleoperatorPolicy(leader),
+        execution=SyncExecution(fps=int(args.fps), request_threshold=1.0),
+        action_queue=ActionQueue(),
+        cameras=cameras,
+        fps=args.fps,
+        callbacks=callbacks,
+    )
+
+    with connect(leader), runtime:
+        for name, cam in cameras.items():
+            w = getattr(cam, "actual_width", None)
+            h = getattr(cam, "actual_height", None)
+            f = getattr(cam, "actual_fps", None)
+            print(f"  {name}: {w}x{h} @ {f}fps" if w and h else f"  {name}: connected")
+        print(f"Teleoperating {args.robot} at {args.fps} fps for {args.duration_s}s...")
+        stats = runtime.run(duration_s=args.duration_s)
+
+    print(f"\nDone — {stats.steps} steps, {stats.inference_count} leader reads, {stats.total_holds} holds")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Overview: how-to/README.md
       - Runtime:
           - Run a Policy on a Robot: how-to/runtime/run-policy-on-robot.md
+          - Teleoperate a Robot: how-to/runtime/teleoperate-a-robot.md
           - Use Execution Modes: how-to/runtime/use-execution-modes.md
           - Add Runtime Callbacks: how-to/runtime/add-runtime-callbacks.md
       - Inference:

--- a/src/physicalai/runtime/__init__.py
+++ b/src/physicalai/runtime/__init__.py
@@ -6,6 +6,7 @@
 Public API::
 
     from physicalai.runtime import PolicyRuntime, RunStats, RuntimeCallback
+    from physicalai.runtime import RuntimePolicy, TeleoperatorPolicy
     from physicalai.runtime import SyncExecution, AsyncExecution, Execution, WorkerDiedError
     from physicalai.runtime import ActionQueue
     from physicalai.runtime import ChunkSmoother, LerpSmoother, ReplaceSmoother
@@ -27,6 +28,7 @@ from physicalai.runtime.execution import (
     SyncExecution,
     WorkerDiedError,
 )
+from physicalai.runtime.policies import RuntimePolicy, TeleoperatorPolicy
 from physicalai.runtime.runtime import (
     PolicyRuntime,
     RunStats,
@@ -50,7 +52,9 @@ __all__ = [
     "RerunCallback",
     "RunStats",
     "RuntimeCallback",
+    "RuntimePolicy",
     "SyncExecution",
+    "TeleoperatorPolicy",
     "TickEvent",
     "WorkerDiedError",
 ]

--- a/src/physicalai/runtime/execution.py
+++ b/src/physicalai/runtime/execution.py
@@ -14,9 +14,9 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
-    from physicalai.inference.model import InferenceModel
     from physicalai.runtime._action_queue import ActionQueue
     from physicalai.runtime._callback_bus import _CallbackBus
+    from physicalai.runtime.policies import RuntimePolicy
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ class Execution(ABC):
         self._session_id = session_id
 
     @abstractmethod
-    def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
+    def start(self, model: RuntimePolicy, action_queue: ActionQueue) -> None:
         """Bind to model and queue. Called once before the loop."""
         ...
 
@@ -83,7 +83,7 @@ class SyncExecution(Execution):
                 the chunk (discards the stale tail). Set to 0.0 to drain
                 the entire chunk before re-inferring.
         """
-        self._model: InferenceModel | None = None
+        self._model: RuntimePolicy | None = None
         self._queue: ActionQueue | None = None
         self._chunk_size: int = 0
         self._fps = fps
@@ -93,7 +93,7 @@ class SyncExecution(Execution):
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
 
-    def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
+    def start(self, model: RuntimePolicy, action_queue: ActionQueue) -> None:
         """Bind model and queue."""
         self._model = model
         self._queue = action_queue
@@ -178,7 +178,7 @@ class AsyncExecution(Execution):
         self._watchdog_timeout_s = watchdog_timeout_s
         self._max_consecutive_holds = max_consecutive_holds or 3 * fps
 
-        self._model: InferenceModel | None = None
+        self._model: RuntimePolicy | None = None
         self._queue: ActionQueue | None = None
         self._chunk_size: int = 0
         self._threshold_count: int = 0
@@ -196,7 +196,7 @@ class AsyncExecution(Execution):
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
 
-    def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
+    def start(self, model: RuntimePolicy, action_queue: ActionQueue) -> None:
         """Bind model/queue and spawn inference thread."""
         self._model = model
         self._queue = action_queue

--- a/src/physicalai/runtime/policies.py
+++ b/src/physicalai/runtime/policies.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime policy interfaces and implementations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from physicalai.robot.interface import Robot
+
+
+@runtime_checkable
+class RuntimePolicy(Protocol):
+    """Policy-like object that can produce action chunks for ``PolicyRuntime``."""
+
+    def predict_action_chunk(self, observation: dict[str, np.ndarray]) -> np.ndarray:
+        """Return an action chunk with shape ``(chunk_size, action_dim)``."""
+        ...
+
+    def reset(self) -> None:
+        """Reset policy state for a new episode."""
+        ...
+
+
+class TeleoperatorPolicy:
+    """Policy that mirrors a leader robot's joint state as follower actions."""
+
+    def __init__(self, leader_robot: Robot) -> None:
+        """Initialize with the leader robot to read each control tick."""
+        self.leader_robot = leader_robot
+
+    def predict_action_chunk(self, observation: dict[str, np.ndarray]) -> np.ndarray:  # noqa: ARG002
+        """Read the leader and return one action for the follower."""
+        leader_obs = self.leader_robot.get_observation()
+        action = np.asarray(leader_obs.joint_positions, dtype=np.float32)
+        return action[None, :]
+
+    def reset(self) -> None:
+        """No-op; teleoperation has no model state."""

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -25,8 +25,8 @@ if TYPE_CHECKING:
 
     from physicalai.capture.camera import Camera
     from physicalai.capture.frame import Frame
-    from physicalai.inference.model import InferenceModel
     from physicalai.robot.interface import Robot, RobotObservation
+    from physicalai.runtime.policies import RuntimePolicy
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class PolicyRuntime:
     def __init__(  # noqa: D107
         self,
         robot: Robot,
-        model: InferenceModel,
+        model: RuntimePolicy,
         execution: Execution,
         fps: float,
         cameras: Mapping[str, Camera] | None = None,

--- a/tests/unit/runtime/test_policies.py
+++ b/tests/unit/runtime/test_policies.py
@@ -1,0 +1,72 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from physicalai.runtime import ActionQueue, PolicyRuntime, SyncExecution, TeleoperatorPolicy
+
+
+@dataclass
+class FakeRobotObservation:
+    joint_positions: np.ndarray
+    timestamp: float
+    sensor_data: dict[str, np.ndarray] | None = None
+    images: dict | None = None
+
+    @property
+    def state(self) -> np.ndarray:
+        return self.joint_positions
+
+
+def _make_robot(joint_positions: np.ndarray) -> MagicMock:
+    robot = MagicMock()
+    robot.joint_names = [f"joint_{i}" for i in range(joint_positions.shape[0])]
+    robot.get_observation.return_value = FakeRobotObservation(
+        joint_positions=joint_positions,
+        timestamp=time.monotonic(),
+    )
+    return robot
+
+
+def test_teleoperator_policy_returns_leader_state_as_single_action_chunk() -> None:
+    leader_state = np.array([0.1, 0.2, 0.3], dtype=np.float64)
+    leader = _make_robot(leader_state)
+    policy = TeleoperatorPolicy(leader)
+
+    chunk = policy.predict_action_chunk({"state": np.zeros((1, 3), dtype=np.float32)})
+
+    assert chunk.shape == (1, 3)
+    assert chunk.dtype == np.float32
+    np.testing.assert_array_equal(chunk[0], leader_state.astype(np.float32))
+
+
+def test_policy_runtime_can_drive_follower_from_teleoperator_policy() -> None:
+    leader_state = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+    leader = _make_robot(leader_state)
+    follower = _make_robot(np.zeros(3, dtype=np.float32))
+
+    runtime = PolicyRuntime(
+        robot=follower,
+        model=TeleoperatorPolicy(leader),
+        execution=SyncExecution(request_threshold=1.0),
+        action_queue=ActionQueue(),
+        fps=10.0,
+    )
+    runtime._connected = True  # noqa: SLF001
+
+    with patch("physicalai.runtime.runtime.time") as mock_time:
+        mock_time.perf_counter.return_value = 0.0
+        mock_time.sleep = MagicMock()
+        mock_time.time.return_value = 0.0
+        stats = runtime.run(duration_s=0.3)
+
+    assert stats.steps == 3
+    assert follower.send_action.call_count == 3
+    for call in follower.send_action.call_args_list:
+        np.testing.assert_array_equal(call.args[0], leader_state)


### PR DESCRIPTION
TL/DR: implement a model policy whose predicted actions are the observed state from a leader robot.

```
class TeleoperatorPolicy:
    def predict_action_chunk(self, observation: dict[str, np.ndarray]) -> np.ndarray:  # noqa: ARG002
        """Read the leader and return one action for the follower."""
        leader_obs = self.leader_robot.get_observation()
        action = np.asarray(leader_obs.joint_positions, dtype=np.float32)
        return action[None, :]
```