### PR TITLE
fix: workaround missing ov extension failure

### DIFF
--- a/src/physicalai/inference/preprocessors/ov_tokenizer.py
+++ b/src/physicalai/inference/preprocessors/ov_tokenizer.py
@@ -34,6 +34,7 @@ class OVTokenizer(Preprocessor):
         self._artifact = Path(artifact)
         # Note: this import initializes OV tokenizers runtime extension
         import openvino_tokenizers  # noqa: F401, PLC0415
+
         # OV Tokenizers support CPU only:
         # https://github.com/openvinotoolkit/openvino_tokenizers?tab=readme-ov-file#usage
         self._adapter = OpenVINOAdapter(device="CPU")

--- a/src/physicalai/inference/preprocessors/ov_tokenizer.py
+++ b/src/physicalai/inference/preprocessors/ov_tokenizer.py
@@ -33,7 +33,7 @@ class OVTokenizer(Preprocessor):
         super().__init__()
         self._artifact = Path(artifact)
         # Note: this import initializes OV tokenizers runtime extension
-        import openvino_tokenizers  # noqa: F401
+        import openvino_tokenizers  # noqa: F401, PLC0415
         # OV Tokenizers support CPU only:
         # https://github.com/openvinotoolkit/openvino_tokenizers?tab=readme-ov-file#usage
         self._adapter = OpenVINOAdapter(device="CPU")

--- a/src/physicalai/inference/preprocessors/ov_tokenizer.py
+++ b/src/physicalai/inference/preprocessors/ov_tokenizer.py
@@ -9,9 +9,6 @@ from pathlib import Path
 
 import numpy as np
 
-# Note: this import initializes OV tokenizers runtime extension
-import openvino_tokenizers  # noqa: F401
-
 from physicalai.inference.adapters import OpenVINOAdapter
 from physicalai.inference.constants import TASK, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
 from physicalai.inference.preprocessors import Preprocessor
@@ -35,6 +32,8 @@ class OVTokenizer(Preprocessor):
         """
         super().__init__()
         self._artifact = Path(artifact)
+        # Note: this import initializes OV tokenizers runtime extension
+        import openvino_tokenizers  # noqa: F401
         # OV Tokenizers support CPU only:
         # https://github.com/openvinotoolkit/openvino_tokenizers?tab=readme-ov-file#usage
         self._adapter = OpenVINOAdapter(device="CPU")

--- a/src/physicalai/inference/preprocessors/ov_tokenizer.py
+++ b/src/physicalai/inference/preprocessors/ov_tokenizer.py
@@ -9,6 +9,9 @@ from pathlib import Path
 
 import numpy as np
 
+# Note: this import initializes OV tokenizers runtime extension
+import openvino_tokenizers  # noqa: F401
+
 from physicalai.inference.adapters import OpenVINOAdapter
 from physicalai.inference.constants import TASK, TOKENIZED_PROMPT, TOKENIZED_PROMPT_MASK
 from physicalai.inference.preprocessors import Preprocessor


### PR DESCRIPTION
## Summary

- Force import OV tokenizers to avoid missing extension issue in some environments

Example error message:
```bash
  File "/home/user/physicalai/.venv/lib/python3.12/site-packages/openvino/_ov_api.py", line 601, in read_model
    return Model(super().read_model(model, config=config))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Exception from src/inference/src/cpp/core.cpp:85:
Exception from src/core/xml_util/src/xml_deserialize_util.cpp:1323:
Cannot create SpecialTokensSplit layer SpecialTokensSplit_1047993 id:15 from unsupported opset: extension
```
