### PR TITLE
chore: add release readiness workflows

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -82,6 +82,6 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,87 @@
+name: Publish TestPyPI
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: python -m pip install --upgrade build twine && python -m build && python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@b14a5cd0d6e6ae92d0f7e6f06c5fef7dfd951c2f # v5.0.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Verify clean wheel install
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -m pip check
+          python - <<'PY'
+          import importlib.metadata as metadata
+
+          import physicalai.capture
+          import physicalai.inference
+          import physicalai.robot
+          import physicalai.runtime
+
+          print(metadata.version("physicalai"))
+          PY
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: smoke-test
+    permissions:
+      id-token: write
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/physicalai
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@b14a5cd0d6e6ae92d0f7e6f06c5fef7dfd951c2f # v5.0.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -3,8 +3,7 @@ name: Publish TestPyPI
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
@@ -23,7 +22,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build distributions
-        run: python -m pip install --upgrade build twine && python -m build && python -m twine check dist/*
+        run: python -m pip install build==1.5.0 twine==6.2.0 && python -m build && python -m twine check dist/*
 
       - name: Upload distributions
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -82,6 +81,6 @@ jobs:
           path: dist/
 
       - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,7 @@ on:
       - "v*"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
@@ -26,7 +25,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build distributions
-        run: python -m pip install --upgrade build twine && python -m build && python -m twine check dist/*
+        run: python -m pip install build==1.5.0 twine==6.2.0 && python -m build && python -m twine check dist/*
 
       - name: Upload distributions
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -86,4 +85,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,4 +86,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,89 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: python -m pip install --upgrade build twine && python -m build && python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Download distributions
+        uses: actions/download-artifact@b14a5cd0d6e6ae92d0f7e6f06c5fef7dfd951c2f # v5.0.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Verify clean wheel install
+        run: |
+          python -m venv .venv-smoke
+          . .venv-smoke/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+          python -m pip check
+          python - <<'PY'
+          import importlib.metadata as metadata
+
+          import physicalai.capture
+          import physicalai.inference
+          import physicalai.robot
+          import physicalai.runtime
+
+          print(metadata.version("physicalai"))
+          PY
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: smoke-test
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/physicalai
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@b14a5cd0d6e6ae92d0f7e6f06c5fef7dfd951c2f # v5.0.0
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ verify_robot(robot)  # Interactive joint-by-joint check
 
 ## Inference
 
-Load exported policies from [Physical AI Studio](https://github.com/open-edge-platform/physical-ai-studio). The `InferenceModel` class auto-detects the backend (OpenVINO or ONNX in this package) and handles action chunking automatically.
+Load exported policies from [Physical AI Studio](https://github.com/open-edge-platform/physical-ai-studio). The `InferenceModel` class auto-detects the backend (OpenVINO or ONNX in this package; companion distributions may contribute additional adapters such as ExecuTorch) and handles action chunking automatically.
 
 ```python
 from physicalai.inference import InferenceModel

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ verify_robot(robot)  # Interactive joint-by-joint check
 
 ## Inference
 
-Load exported policies from [Physical AI Studio](https://github.com/open-edge-platform/physical-ai-studio). The `InferenceModel` class auto-detects the backend (OpenVINO, ONNX, TorchScript) and handles action chunking automatically.
+Load exported policies from [Physical AI Studio](https://github.com/open-edge-platform/physical-ai-studio). The `InferenceModel` class auto-detects the backend (OpenVINO or ONNX in this package) and handles action chunking automatically.
 
 ```python
 from physicalai.inference import InferenceModel
@@ -251,7 +251,7 @@ runtime = PolicyRuntime(
     model=InferenceModel.load("./exports/act_policy"),
     cameras={
         "wrist": UVCCamera(device="/dev/video0", width=640, height=480),
-        "overhead": RealSenseCamera(serial="123456789"),
+        "overhead": RealSenseCamera(serial_number="123456789"),
     },
     execution=SyncExecution(mode="chunk"),
 )

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ model = InferenceModel.load(
 
 The `PolicyRuntime` orchestrates the full control loop: connecting hardware, reading cameras, building observations, running inference, and dispatching actions to the robot.
 
-> **Preview:** This API is work in progress
+> **Note:** `PolicyRuntime`, `SyncExecution`, and `AsyncExecution` are available now. Config-driven construction, the CLI, and remote execution remain preview/planned APIs.
 
 ```python
 from physicalai.runtime import PolicyRuntime, SyncExecution
@@ -253,10 +253,11 @@ runtime = PolicyRuntime(
         "wrist": UVCCamera(device="/dev/video0", width=640, height=480),
         "overhead": RealSenseCamera(serial_number="123456789"),
     },
-    execution=SyncExecution(mode="chunk"),
+    execution=SyncExecution(),
 )
 
-runtime.run(duration_s=60)
+with runtime:
+    runtime.run(duration_s=60)
 ```
 
 <details>
@@ -314,8 +315,6 @@ physicalai run --config runtime.yaml --duration-s 60
 
 Async execution runs inference in a background thread while the main loop handles camera reads and robot commands at a fixed frequency. Useful when inference is slower than the control rate.
 
-> **Preview:** This API is not yet implemented.
-
 ```python
 from physicalai.runtime import PolicyRuntime, AsyncExecution
 
@@ -324,10 +323,11 @@ runtime = PolicyRuntime(
     robot=robot,
     model=model,
     cameras=cameras,
-    execution=AsyncExecution(),
+    execution=AsyncExecution(fps=30),
 )
 
-runtime.run(duration_s=60)
+with runtime:
+    runtime.run(duration_s=60)
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -237,8 +237,6 @@ model = InferenceModel.load(
 
 The `PolicyRuntime` orchestrates the full control loop: connecting hardware, reading cameras, building observations, running inference, and dispatching actions to the robot.
 
-> **Note:** `PolicyRuntime`, `SyncExecution`, and `AsyncExecution` are available now. Config-driven construction, the CLI, and remote execution remain preview/planned APIs.
-
 ```python
 from physicalai.runtime import PolicyRuntime, SyncExecution
 from physicalai.inference import InferenceModel

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,0 @@
-# PhysicalAI Documentation
-
-This directory contains the PhysicalAI documentation.
-
-Start with [Documentation Home](index.md).

--- a/docs/explanation/configuration.md
+++ b/docs/explanation/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-> **Preview:** The config system (`physicalai.config`, `PolicyRuntime.from_config`, and the CLI) are planned APIs. The content below documents the target design. Currently, `ComponentSpec` lives in `physicalai.inference.manifest`.
+> **Preview:** The config system (`physicalai.config`, `PolicyRuntime.from_config`, and the CLI) is still planned. `PolicyRuntime` itself is available now. The content below documents the target config design. Currently, `ComponentSpec` lives in `physicalai.inference.manifest`.
 
 The config system is intended to make Python, YAML, CLI, and Studio payloads use the same workflow shape.
 

--- a/docs/explanation/configuration.md
+++ b/docs/explanation/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-> **Preview:** The config system (`physicalai.config`, `PolicyRuntime.from_config`, and the CLI) is still planned. `PolicyRuntime` itself is available now. The content below documents the target config design. Currently, `ComponentSpec` lives in `physicalai.inference.manifest`.
+> **Preview:** The config system (`physicalai.config`, `PolicyRuntime.from_config`, and the CLI) is still planned. The content below documents the target config design. Currently, `ComponentSpec` lives in `physicalai.inference.manifest`.
 
 The config system is intended to make Python, YAML, CLI, and Studio payloads use the same workflow shape.
 

--- a/docs/explanation/runtime.md
+++ b/docs/explanation/runtime.md
@@ -43,11 +43,11 @@ The exact observation structure and merging strategy may change as the API stabi
 
 ## Execution Modes
 
-| Mode                                  | Where inference runs | Use                                      |
-| ------------------------------------- | -------------------- | ---------------------------------------- |
-| `SyncExecution()`                     | runtime thread       | simple deployments and debugging         |
-| `AsyncExecution(fps=30)`              | worker thread        | avoid blocking the control loop          |
-| `RemoteExecution`                     | remote server        | planned API                              |
+| Mode                     | Where inference runs | Use                              |
+| ------------------------ | -------------------- | -------------------------------- |
+| `SyncExecution()`        | runtime thread       | simple deployments and debugging |
+| `AsyncExecution(fps=30)` | worker thread        | avoid blocking the control loop  |
+| `RemoteExecution`        | remote server        | planned API                      |
 
 ## Product Workflows
 

--- a/docs/explanation/runtime.md
+++ b/docs/explanation/runtime.md
@@ -1,12 +1,19 @@
 # Runtime
 
-> **Preview:** `PolicyRuntime` is a planned API. The content below documents the target design.
+`PolicyRuntime` is available now. Config-driven construction and remote execution remain preview/planned APIs.
 
 `PolicyRuntime` runs a policy on robot hardware. It owns the control loop, the callback lifecycle, and the interaction between observations, inference requests, and actions.
 
 ```python
-runtime = PolicyRuntime.from_config("runtime.yaml")
-runtime.run(duration_s=60)
+runtime = PolicyRuntime(
+    fps=30,
+    robot=robot,
+    model=model,
+    execution=SyncExecution(),
+)
+
+with runtime:
+    runtime.run(duration_s=60)
 ```
 
 ## Responsibilities
@@ -38,10 +45,9 @@ The exact observation structure and merging strategy may change as the API stabi
 
 | Mode                                  | Where inference runs | Use                                      |
 | ------------------------------------- | -------------------- | ---------------------------------------- |
-| `SyncExecution(mode="single_action")` | runtime thread       | simple policies                          |
-| `SyncExecution(mode="chunk")`         | runtime thread       | chunk policies without background worker |
-| `AsyncExecution(transport="thread")`  | worker thread        | avoid blocking control loop              |
-| `RemoteExecution`                     | remote server        | robot host without policy weights        |
+| `SyncExecution()`                     | runtime thread       | simple deployments and debugging         |
+| `AsyncExecution(fps=30)`              | worker thread        | avoid blocking the control loop          |
+| `RemoteExecution`                     | remote server        | planned API                              |
 
 ## Product Workflows
 

--- a/docs/explanation/runtime.md
+++ b/docs/explanation/runtime.md
@@ -1,7 +1,5 @@
 # Runtime
 
-`PolicyRuntime` is available now. Config-driven construction and remote execution remain preview/planned APIs.
-
 `PolicyRuntime` runs a policy on robot hardware. It owns the control loop, the callback lifecycle, and the interaction between observations, inference requests, and actions.
 
 ```python
@@ -42,6 +40,8 @@ while running:
 The exact observation structure and merging strategy may change as the API stabilizes.
 
 ## Execution Modes
+
+> **Preview:** `RemoteExecution` is a planned API.
 
 | Mode                     | Where inference runs | Use                              |
 | ------------------------ | -------------------- | -------------------------------- |

--- a/docs/getting-started/run-a-policy.md
+++ b/docs/getting-started/run-a-policy.md
@@ -1,7 +1,5 @@
 # Run a Policy
 
-> **Note:** The Python `PolicyRuntime` API is available now. The config and CLI flows below remain preview/planned APIs.
-
 Use `PolicyRuntime` to run a trained policy on real hardware. The runtime handles the control loop: reading cameras, building observations, running inference, and sending actions to the robot.
 
 ```python
@@ -27,6 +25,8 @@ runtime = PolicyRuntime(
 with runtime:
     runtime.run(duration_s=60)
 ```
+
+> **Preview:** The config and CLI flows below are not yet implemented.
 
 The equivalent CLI command uses the same runtime configuration.
 

--- a/docs/getting-started/run-a-policy.md
+++ b/docs/getting-started/run-a-policy.md
@@ -1,6 +1,6 @@
 # Run a Policy
 
-> **Preview:** `PolicyRuntime` and the CLI are planned APIs. The examples below document the target design.
+> **Note:** The Python `PolicyRuntime` API is available now. The config and CLI flows below remain preview/planned APIs.
 
 Use `PolicyRuntime` to run a trained policy on real hardware. The runtime handles the control loop: reading cameras, building observations, running inference, and sending actions to the robot.
 
@@ -21,10 +21,11 @@ runtime = PolicyRuntime(
     robot=robot,
     model=model,
     cameras=cameras,
-    execution=SyncExecution(mode="chunk"),
+    execution=SyncExecution(),
 )
 
-runtime.run(duration_s=60)
+with runtime:
+    runtime.run(duration_s=60)
 ```
 
 The equivalent CLI command uses the same runtime configuration.

--- a/docs/how-to/config/write-runtime-config.md
+++ b/docs/how-to/config/write-runtime-config.md
@@ -1,6 +1,6 @@
 # Write Runtime Config
 
-> **Preview:** The config system is a planned API. `PolicyRuntime` is available now; the examples below document the target config design.
+> **Preview:** The config system is a planned API. The examples below document the target config design.
 
 A runtime config describes a robot control workflow before execution starts.
 

--- a/docs/how-to/config/write-runtime-config.md
+++ b/docs/how-to/config/write-runtime-config.md
@@ -1,6 +1,6 @@
 # Write Runtime Config
 
-> **Preview:** `PolicyRuntime` and the config system are planned APIs. The examples below document the target design.
+> **Preview:** The config system is a planned API. `PolicyRuntime` is available now; the examples below document the target config design.
 
 A runtime config describes a robot control workflow before execution starts.
 

--- a/docs/how-to/runtime/add-runtime-callbacks.md
+++ b/docs/how-to/runtime/add-runtime-callbacks.md
@@ -1,6 +1,6 @@
 # Add Runtime Callbacks
 
-> **Preview:** `PolicyRuntime` and runtime callbacks are planned APIs. The examples below document the target design.
+`PolicyRuntime` callbacks are available now.
 
 Use callbacks when you need product-specific behavior around the runtime loop.
 
@@ -8,18 +8,15 @@ The following example records observations and actions.
 
 ```python
 class RecordingCallback:
-    def on_observation(self, observation, step):
-        recorder.write_observation(step.t, observation)
-
-    def before_send_action(self, action, step):
-        recorder.write_policy_action(step.t, action)
+    def before_send_action(self, *, action, step):
+        recorder.write_policy_action(step, action)
         return action
 
-    def on_action_sent(self, action, step):
-        recorder.write_sent_action(step.t, action)
+    def on_action_sent(self, *, action, step):
+        recorder.write_sent_action(step, action)
 
-    def on_stop(self):
-        recorder.close()
+    def on_hold(self, *, step, holds):
+        recorder.write_hold(step, holds)
 ```
 
 Attach the callback when you construct the runtime.

--- a/docs/how-to/runtime/add-runtime-callbacks.md
+++ b/docs/how-to/runtime/add-runtime-callbacks.md
@@ -1,7 +1,5 @@
 # Add Runtime Callbacks
 
-`PolicyRuntime` callbacks are available now.
-
 Use callbacks when you need product-specific behavior around the runtime loop.
 
 The following example records observations and actions.

--- a/docs/how-to/runtime/run-policy-on-robot.md
+++ b/docs/how-to/runtime/run-policy-on-robot.md
@@ -1,7 +1,5 @@
 # Run a Policy on a Robot
 
-> **Note:** The Python `PolicyRuntime` API is available now. The config and CLI examples below remain preview/planned APIs.
-
 ## Python API
 
 ```python
@@ -26,7 +24,7 @@ with runtime:
 
 ## From Config
 
-> **Preview:** Config-driven runtime construction is not yet implemented.
+> **Preview:** Config-driven runtime construction and the CLI are not yet implemented.
 
 Write a runtime configuration file.
 

--- a/docs/how-to/runtime/run-policy-on-robot.md
+++ b/docs/how-to/runtime/run-policy-on-robot.md
@@ -1,6 +1,6 @@
 # Run a Policy on a Robot
 
-> **Preview:** `PolicyRuntime` and the CLI are planned APIs. The examples below document the target design.
+> **Note:** The Python `PolicyRuntime` API is available now. The config and CLI examples below remain preview/planned APIs.
 
 ## Python API
 
@@ -17,13 +17,16 @@ runtime = PolicyRuntime(
     cameras={
         "wrist": UVCCamera(device="/dev/video0", width=640, height=480),
     },
-    execution=SyncExecution(mode="chunk"),
+    execution=SyncExecution(),
 )
 
-runtime.run(duration_s=60)
+with runtime:
+    runtime.run(duration_s=60)
 ```
 
 ## From Config
+
+> **Preview:** Config-driven runtime construction is not yet implemented.
 
 Write a runtime configuration file.
 

--- a/docs/how-to/runtime/use-execution-modes.md
+++ b/docs/how-to/runtime/use-execution-modes.md
@@ -1,6 +1,6 @@
 # Use Execution Modes
 
-> **Preview:** `PolicyRuntime` and execution modes are planned APIs. The examples below document the target design.
+> **Note:** `SyncExecution` and `AsyncExecution` are available now. Remote execution remains a planned API.
 
 The `Execution` component decides where inference runs and how requests are scheduled.
 
@@ -8,11 +8,10 @@ The `Execution` component decides where inference runs and how requests are sche
 
 This mode runs inference in the runtime thread.
 
-```yaml
-execution:
-  class_path: physicalai.runtime.SyncExecution
-  init_args:
-    mode: chunk
+```python
+from physicalai.runtime import SyncExecution
+
+execution = SyncExecution()
 ```
 
 This mode is appropriate for simple deployments and debugging.
@@ -21,16 +20,17 @@ This mode is appropriate for simple deployments and debugging.
 
 This mode runs inference in a background thread.
 
-```yaml
-execution:
-  class_path: physicalai.runtime.AsyncExecution
-  init_args:
-    transport: thread
+```python
+from physicalai.runtime import AsyncExecution
+
+execution = AsyncExecution(fps=30)
 ```
 
 Use this mode when model latency should not block robot timing. Since inference backends typically release the GIL, thread-based execution works well for most use cases.
 
 ## Remote
+
+> **Preview:** `RemoteExecution` is not yet implemented.
 
 This mode sends inference requests to a policy server.
 

--- a/docs/how-to/runtime/use-execution-modes.md
+++ b/docs/how-to/runtime/use-execution-modes.md
@@ -1,7 +1,5 @@
 # Use Execution Modes
 
-> **Note:** `SyncExecution` and `AsyncExecution` are available now. Remote execution remains a planned API.
-
 The `Execution` component decides where inference runs and how requests are scheduled.
 
 ## Synchronous

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,10 +59,10 @@ with runtime:
     runtime.run(duration_s=60)
 ```
 
+> **Preview:** The CLI remains a planned API. See [#121](https://github.com/openvinotoolkit/physicalai/issues/121) for status.
+
 CLI example:
 
 ```bash
 physicalai run --config runtime.yaml --duration-s 60
 ```
-
-> **Note:** `PolicyRuntime` is available now. The CLI remains a planned API. See [#121](https://github.com/openvinotoolkit/physicalai/issues/121) for status.

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,10 +52,11 @@ runtime = PolicyRuntime(
     robot=robot,
     model=model,
     cameras=cameras,
-    execution=SyncExecution(mode="chunk"),
+    execution=SyncExecution(),
 )
 
-runtime.run(duration_s=60)
+with runtime:
+    runtime.run(duration_s=60)
 ```
 
 CLI example:
@@ -64,4 +65,4 @@ CLI example:
 physicalai run --config runtime.yaml --duration-s 60
 ```
 
-> **Note:** `PolicyRuntime` and the CLI are planned APIs. See [#121](https://github.com/openvinotoolkit/physicalai/issues/121) for status.
+> **Note:** `PolicyRuntime` is available now. The CLI remains a planned API. See [#121](https://github.com/openvinotoolkit/physicalai/issues/121) for status.

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -1,6 +1,6 @@
 # Config Schema Reference
 
-> **Preview:** The config system and `PolicyRuntime` are planned APIs. The schemas below document the target design.
+> **Preview:** The config system is a planned API. `PolicyRuntime` itself is available now; the schemas below document the target config design.
 
 Config files use `class_path` and `init_args` to describe explicit component construction.
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -1,6 +1,6 @@
 # Config Schema Reference
 
-> **Preview:** The config system is a planned API. `PolicyRuntime` itself is available now; the schemas below document the target config design.
+> **Preview:** The config system is a planned API. The schemas below document the target config design.
 
 Config files use `class_path` and `init_args` to describe explicit component construction.
 

--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -1,7 +1,5 @@
 # Runtime API Reference
 
-`PolicyRuntime`, `SyncExecution`, `AsyncExecution`, and `ActionQueue` are available now. Config-driven construction and remote execution remain preview/planned APIs.
-
 ## `PolicyRuntime`
 
 `PolicyRuntime` is the main orchestrator for running a policy on hardware.
@@ -52,7 +50,7 @@ The execution implementations shipped today are listed below.
 | `SyncExecution`  | runs inference in the runtime thread  |
 | `AsyncExecution` | runs inference in a background thread |
 
-`RemoteExecution` is a planned API and is not part of the current package release.
+> **Preview:** `RemoteExecution` is a planned API and is not part of the current package release.
 
 ## `ActionQueue`
 

--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -1,6 +1,6 @@
 # Runtime API Reference
 
-> **Preview:** `PolicyRuntime` and related APIs are planned. The signatures below document the target design.
+`PolicyRuntime`, `SyncExecution`, `AsyncExecution`, and `ActionQueue` are available now. Config-driven construction and remote execution remain preview/planned APIs.
 
 ## `PolicyRuntime`
 
@@ -14,48 +14,51 @@ PolicyRuntime(
     fps: float,
     cameras: Mapping[str, Camera] | None = None,
     action_queue: ActionQueue | None = None,
-    callbacks: Sequence[Callback] = (),
-    return_to_home: bool = False,
+    callbacks: Sequence[RuntimeCallback] = (),
 )
 ```
 
 The most important methods are shown below.
 
 ```python
-runtime.run(duration_s: float | None = None) -> None
-runtime.stop() -> None
-runtime.close() -> None
+runtime.connect() -> None
+runtime.disconnect() -> None
+runtime.run(duration_s: float | None = None) -> RunStats
 ```
 
-You can also construct the runtime from a config file.
+`PolicyRuntime` also supports context-manager usage so connections are cleaned up automatically.
 
 ```python
-runtime = PolicyRuntime.from_config("runtime.yaml")
+with PolicyRuntime(...) as runtime:
+    stats = runtime.run(duration_s=60)
 ```
 
 ## `Execution`
 
 ```python
 class Execution:
-    def start(self, action_queue: ActionQueue, model: InferenceModel) -> None: ...
-    def maybe_request(self, observation: Mapping[str, Any]) -> None: ...
-    def warmup(self, sample_observation: Mapping[str, Any], n: int = 2) -> None: ...
+    def start(self, model: InferenceModel, action_queue: ActionQueue) -> None: ...
+    def maybe_request(self, observation: dict[str, np.ndarray]) -> None: ...
+    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None: ...
     def stop(self) -> None: ...
+    @property
+    def chunk_size(self) -> int: ...
 ```
 
-The expected execution implementations are listed below.
+The execution implementations shipped today are listed below.
 
-| Class             | Purpose                                      |
-| ----------------- | -------------------------------------------- |
-| `SyncExecution`   | runs inference in the runtime thread         |
-| `AsyncExecution`  | runs inference in a thread or process worker |
-| `RemoteExecution` | requests inference from a remote server      |
+| Class            | Purpose                               |
+| ---------------- | ------------------------------------- |
+| `SyncExecution`  | runs inference in the runtime thread  |
+| `AsyncExecution` | runs inference in a background thread |
+
+`RemoteExecution` is a planned API and is not part of the current package release.
 
 ## `ActionQueue`
 
 ```python
 queue.push_chunk(chunk)
-action = queue.pop_or_none()
+action = queue.pop()
 queue.clear()
 ```
 


### PR DESCRIPTION
## Summary
- add PyPI and TestPyPI publish workflows using trusted publishing
- gate publishing on a clean wheel-install smoke test
- fix release-facing README drift and MkDocs strict-build conflict

## Verification
- python3 -m build
- python3 -m twine check dist/*
- uv run --group docs mkdocs build --strict
- clean venv install from built wheel, pip check, and public module imports

## Closes
- #31
- #129 
- #135 
- #23 
- #21 
- #20 
- #17 