### PR TITLE
fix(capture): add only_usable option 

### DIFF
--- a/src/physicalai/capture/cameras/uvc/_camera.py
+++ b/src/physicalai/capture/cameras/uvc/_camera.py
@@ -144,10 +144,10 @@ class UVCCamera(Camera):
     # ------------------------------------------------------------------
 
     @classmethod
-    def discover(cls) -> list[Any]:  # pragma: no cover - wrapper uses typed DeviceInfo
+    def discover(cls, *, only_usable: bool = True) -> list[Any]:  # pragma: no cover - wrapper uses typed DeviceInfo
         from ._discover import discover_uvc  # noqa: PLC0415
 
-        return discover_uvc()
+        return discover_uvc(only_usable=only_usable)
 
     @classmethod
     def query_formats(cls, device_id: str) -> list[tuple[int, int, int]]:

--- a/src/physicalai/capture/cameras/uvc/_discover.py
+++ b/src/physicalai/capture/cameras/uvc/_discover.py
@@ -25,12 +25,18 @@ if TYPE_CHECKING:
 __all__ = ["discover_uvc"]
 
 
-def discover_uvc() -> list[DeviceInfo]:
+def discover_uvc(*, only_usable: bool = True) -> list[DeviceInfo]:
     """Discover UVC devices for the current platform.
+
+    Args:
+        only_usable: When True (default), only return devices that can
+            actually be opened.  Cameras already in use by another
+            process will not appear in the results.  Set to False to
+            include all detected devices regardless of availability.
 
     Returns:
         List of discovered UVC devices for the current platform.
     """
     # Use omnicamera/pynokhwa's discovery on all platforms.
     # V4L2 offers richer information but does not check camera can be opened.
-    return OmniCamera.discover()
+    return OmniCamera.discover(only_usable=only_usable)

--- a/src/physicalai/capture/cameras/uvc/_omnicamera.py
+++ b/src/physicalai/capture/cameras/uvc/_omnicamera.py
@@ -240,10 +240,10 @@ class OmniCamera(Camera):
         return frame
 
     @classmethod
-    def discover(cls) -> list[DeviceInfo]:
+    def discover(cls, *, only_usable: bool = True) -> list[DeviceInfo]:
         from physicalai.capture.discovery import DeviceInfo  # noqa: PLC0415
 
-        infos = omni_camera.query(only_usable=False)
+        infos = omni_camera.query(only_usable=only_usable)
 
         if sys.platform.startswith("linux"):
             # V4L2 exposes multiple /dev/videoN nodes per physical camera

--- a/src/physicalai/capture/discovery.py
+++ b/src/physicalai/capture/discovery.py
@@ -35,12 +35,20 @@ class DeviceInfo(BaseModel):
     metadata: dict[str, Any] | None = Field(default=None, description="Backend-specific extras.")
 
 
-def discover_all() -> dict[str, list[DeviceInfo]]:
+def discover_all(*, only_usable: bool = True) -> dict[str, list[DeviceInfo]]:
     """Discover available cameras across all supported camera types.
 
     Each camera type is tried independently; failures are silently
     skipped so that a missing SDK does not prevent discovery of other
     camera types.
+
+    Args:
+        only_usable: When True (default), only return devices that can
+            actually be opened.  For UVC cameras, devices already in use
+            by another process will not appear in the results.  Set to
+            False to include all detected devices regardless of
+            availability.  Only applies to backends that support this
+            filter (currently UVC).
 
     Returns:
         Dict mapping camera type name to list of discovered devices.
@@ -52,7 +60,7 @@ def discover_all() -> dict[str, list[DeviceInfo]]:
     with contextlib.suppress(Exception):
         from physicalai.capture.cameras.uvc import discover_uvc  # noqa: PLC0415
 
-        results["uvc"] = discover_uvc()
+        results["uvc"] = discover_uvc(only_usable=only_usable)
 
     with contextlib.suppress(Exception):
         from physicalai.capture.cameras.ip import IPCamera  # noqa: PLC0415


### PR DESCRIPTION
## Summary

`only_usable` option for capture device discovery, i.e. `discover_all(only_usable=True)`

## Why

When a UVC camera is already in use by another process, it silently disappears from discovery results. This option lets users see all detected devices regardless of availability, useful for debugging "missing camera" issues.

## Validation

Tested on CLI

## Breaking changes

- None

## Related issues

- Closes #
