### PR TITLE
chore: bump version to 0.2.0.dev0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/physicalai.png" alt="Physical AI" width="100%">
+  <img src="https://raw.githubusercontent.com/openvinotoolkit/physicalai/main/docs/assets/physicalai.png" alt="Physical AI" width="100%">
 </p>
 
 <div align="center">
@@ -28,7 +28,7 @@ Physical AI Runtime provides the deployment-side components for running trained 
 ---
 
 <p align="center">
-  <img src="docs/assets/inference_rerun.gif" alt="Inference demo" width="100%">
+  <img src="https://raw.githubusercontent.com/openvinotoolkit/physicalai/main/docs/assets/inference_rerun.gif" alt="Inference demo" width="100%">
 </p>
 
 ## Installation
@@ -385,14 +385,14 @@ runtime.run(duration_s=60)
 
 ---
 
-> **Full walkthrough:** See [`examples/tutorials/collect_train_deploy.ipynb`](./examples/tutorials/collect_train_deploy.ipynb) for a complete collect → train → deploy guide.
+> **Full walkthrough:** See [`examples/tutorials/collect_train_deploy.ipynb`](https://github.com/openvinotoolkit/physicalai/blob/main/examples/tutorials/collect_train_deploy.ipynb) for a complete collect -> train -> deploy guide.
 
 ---
 
 ## Documentation
 
-[Home](./docs/index.md) • [Getting Started](./docs/getting-started/) • [How-To Guides](./docs/how-to/) • [Concepts](./docs/explanation/) • [API Reference](./docs/reference/)
+[Home](https://github.com/openvinotoolkit/physicalai/tree/main/docs) • [Getting Started](https://github.com/openvinotoolkit/physicalai/tree/main/docs/getting-started) • [How-To Guides](https://github.com/openvinotoolkit/physicalai/tree/main/docs/how-to) • [Concepts](https://github.com/openvinotoolkit/physicalai/tree/main/docs/explanation) • [API Reference](https://github.com/openvinotoolkit/physicalai/tree/main/docs/reference)
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/openvinotoolkit/physicalai/blob/main/CONTRIBUTING.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "physicalai"
-version = "0.1.0"
+version = "0.2.0.dev0"
 requires-python = ">=3.12, <3.15"
 description = "Lightweight runtime for physical AI inference"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,10 @@ docs = ["mkdocs>=1.6", "mkdocs-material>=9.6"]
 allow-direct-references = true
 
 [project.urls]
-Homepage = "https://github.com/openvinotoolkit/physical-ai"
-Documentation = "https://github.com/openvinotoolkit/physical-ai"
-Repository = "https://github.com/openvinotoolkit/physical-ai"
-Issues = "https://github.com/openvinotoolkit/physical-ai/issues"
+Homepage = "https://github.com/openvinotoolkit/physicalai"
+Documentation = "https://github.com/openvinotoolkit/physicalai/tree/main/docs"
+Repository = "https://github.com/openvinotoolkit/physicalai"
+Issues = "https://github.com/openvinotoolkit/physicalai/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/physicalai"]

--- a/uv.lock
+++ b/uv.lock
@@ -1451,7 +1451,7 @@ wheels = [
 
 [[package]]
 name = "physicalai"
-version = "0.1.0"
+version = "0.2.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonargparse", extra = ["shtab", "signatures"] },


### PR DESCRIPTION
## Summary
- bump the package version on  to the next development version

## Why
- makes it clear  is ahead of the published release
- avoids accidentally rebuilding  from ongoing development on 
- prepares the next development cycle using a PEP 440 development version
