### PR TITLE
feat: add a universal resize preprocessing node

### DIFF
--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -102,6 +102,7 @@ component_registry.register("single_pass", "physicalai.inference.runners.SingleP
 
 # Preprocessors
 component_registry.register("normalize", "physicalai.inference.preprocessors.StatsNormalizer")
+component_registry.register("resize", "physicalai.inference.preprocessors.ResizePreprocessor")
 component_registry.register("smolvla_resize", "physicalai.inference.preprocessors.ResizeSmolVLA")
 component_registry.register("new_line", "physicalai.inference.preprocessors.NewLinePreprocessor")
 component_registry.register("hf_tokenizer", "physicalai.inference.preprocessors.HFTokenizer")

--- a/src/physicalai/inference/preprocessors/__init__.py
+++ b/src/physicalai/inference/preprocessors/__init__.py
@@ -13,7 +13,7 @@ from physicalai.inference.preprocessors.lambda_processor import LambdaPreprocess
 from physicalai.inference.preprocessors.new_line import NewLinePreprocessor
 from physicalai.inference.preprocessors.ov_tokenizer import OVTokenizer
 from physicalai.inference.preprocessors.pi05 import Pi05Preprocessor
-from physicalai.inference.preprocessors.resize import ResizePreprocessor
+from physicalai.inference.preprocessors.resize import ResizeMode, ResizePreprocessor
 from physicalai.inference.preprocessors.smolvla import ResizeSmolVLA
 from physicalai.inference.preprocessors.stats_normalizer import StatsNormalizer
 
@@ -24,6 +24,7 @@ __all__ = [
     "OVTokenizer",
     "Pi05Preprocessor",
     "Preprocessor",
+    "ResizeMode",
     "ResizePreprocessor",
     "ResizeSmolVLA",
     "StatsNormalizer",

--- a/src/physicalai/inference/preprocessors/__init__.py
+++ b/src/physicalai/inference/preprocessors/__init__.py
@@ -13,6 +13,7 @@ from physicalai.inference.preprocessors.lambda_processor import LambdaPreprocess
 from physicalai.inference.preprocessors.new_line import NewLinePreprocessor
 from physicalai.inference.preprocessors.ov_tokenizer import OVTokenizer
 from physicalai.inference.preprocessors.pi05 import Pi05Preprocessor
+from physicalai.inference.preprocessors.resize import ResizePreprocessor
 from physicalai.inference.preprocessors.smolvla import ResizeSmolVLA
 from physicalai.inference.preprocessors.stats_normalizer import StatsNormalizer
 
@@ -23,6 +24,7 @@ __all__ = [
     "OVTokenizer",
     "Pi05Preprocessor",
     "Preprocessor",
+    "ResizePreprocessor",
     "ResizeSmolVLA",
     "StatsNormalizer",
 ]

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -101,8 +101,8 @@ class ResizePreprocessor(Preprocessor):
 
         if self._keep_aspect_ratio:
             ratio = max(cur_width / target_width, cur_height / target_height)
-            resized_height = min(int(cur_height / ratio), target_height)
-            resized_width = min(int(cur_width / ratio), target_width)
+            resized_height = max(1, min(int(cur_height / ratio), target_height))
+            resized_width = max(1, min(int(cur_width / ratio), target_width))
         else:
             resized_height = target_height
             resized_width = target_width
@@ -119,6 +119,9 @@ class ResizePreprocessor(Preprocessor):
         pad_bottom = pad_height - pad_top
         pad_left = pad_width // 2
         pad_right = pad_width - pad_left
+
+        if pad_height == 0 and pad_width == 0:
+            return img
 
         return np.pad(
             img,

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
+
 import cv2
 import numpy as np
 
@@ -13,29 +15,36 @@ from physicalai.inference.constants import IMAGES
 from .base import Preprocessor
 
 
+class ResizeMode(StrEnum):
+    """Resize strategy for :class:`ResizePreprocessor`."""
+
+    STRETCH = "stretch"
+    LETTERBOX = "letterbox"
+
+
 class ResizePreprocessor(Preprocessor):
     """Resize observation images to a target resolution.
 
     Args:
         image_resolution: Target (height, width) for images.
-        padding: Whether to pad images to reach the target resolution.
-        keep_aspect_ratio: Whether to preserve the aspect ratio when resizing.
+        mode: Resize strategy.
+            - ``stretch`` distorts to exact target size without padding.
+            - ``letterbox`` preserves aspect ratio and pads to exact target.
+        pad_value: Fill value used for letterbox padding.
     """
 
     def __init__(
         self,
         image_resolution: tuple[int, int],
         *,
-        padding: bool = True,
-        keep_aspect_ratio: bool = True,
+        mode: ResizeMode | str = ResizeMode.LETTERBOX,
         pad_value: int = 0,
     ) -> None:
         """Initialize the resize preprocessor."""
         super().__init__()
         self._image_resolution = image_resolution
-        self._padding = padding
+        self._mode = ResizeMode(mode)
         self._pad_value = pad_value
-        self._keep_aspect_ratio = keep_aspect_ratio
 
     def __call__(
         self,
@@ -73,13 +82,11 @@ class ResizePreprocessor(Preprocessor):
     def _resize_with_ar_pad(self, img: np.ndarray) -> np.ndarray:  # noqa: PLR0914
         """Resize an image array to the target resolution.
 
-        Behavior depends on the preprocessor configuration:
+                Behavior depends on the configured ``mode``:
 
-        - ``keep_aspect_ratio``: scale so the image fits within the target while
-          preserving proportions. When disabled, the image is stretched to the
-          exact target size.
-        - ``padding``: zero-pad symmetrically so the output exactly matches the
-          target resolution. When disabled, the output keeps the resized size.
+                - ``stretch``: image is resized directly to the target dimensions.
+                - ``letterbox``: image is scaled to fit while preserving aspect ratio,
+                    then padded symmetrically to exactly match the target dimensions.
 
         Args:
             img: Input image array with shape ``(batch, channels, height, width)``.
@@ -99,18 +106,18 @@ class ResizePreprocessor(Preprocessor):
         target_height, target_width = self._image_resolution
         cur_height, cur_width = img.shape[2:]
 
-        if self._keep_aspect_ratio:
+        if self._mode == ResizeMode.LETTERBOX:
             ratio = max(cur_width / target_width, cur_height / target_height)
             resized_height = max(1, min(int(cur_height / ratio), target_height))
             resized_width = max(1, min(int(cur_width / ratio), target_width))
-        else:
+        else:  # ResizeMode.STRETCH
             resized_height = target_height
             resized_width = target_width
 
         if (resized_height, resized_width) != (cur_height, cur_width):
             img = self._resize_bchw(img, resized_width, resized_height)
 
-        if not self._padding:
+        if self._mode == ResizeMode.STRETCH:
             return img
 
         pad_height = target_height - resized_height

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preprocessor that resizes images to a target resolution."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .base import Preprocessor
+
+
+class ResizePreprocessor(Preprocessor):
+    """Resize observation images to a target resolution.
+
+    Args:
+        image_resolution: Target (height, width) for images.
+        padding: Whether to pad images to reach the target resolution.
+        keep_aspect_ratio: Whether to preserve the aspect ratio when resizing.
+    """
+
+    def __init__(
+        self,
+        image_resolution: tuple[int, int],
+        padding: bool,
+        keep_aspect_ratio: bool,
+    ) -> None:
+        """Initialize the resize preprocessor."""
+        super().__init__()
+        self._image_resolution = image_resolution
+        self._padding = padding
+        self._keep_aspect_ratio = keep_aspect_ratio
+
+    def __call__(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Resize observation images to the target resolution."""
+        raise NotImplementedError

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -28,11 +28,13 @@ class ResizePreprocessor(Preprocessor):
         *,
         padding: bool = True,
         keep_aspect_ratio: bool = True,
+        pad_value: int = 0,
     ) -> None:
         """Initialize the resize preprocessor."""
         super().__init__()
         self._image_resolution = image_resolution
         self._padding = padding
+        self._pad_value = pad_value
         self._keep_aspect_ratio = keep_aspect_ratio
 
     def __call__(
@@ -121,6 +123,7 @@ class ResizePreprocessor(Preprocessor):
         return np.pad(
             img,
             ((0, 0), (0, 0), (pad_top, pad_bottom), (pad_left, pad_right)),
+            constant_values=self._pad_value,
         )
 
     @staticmethod

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -5,7 +5,10 @@
 
 from __future__ import annotations
 
+import cv2
 import numpy as np
+
+from physicalai.inference.constants import IMAGES
 
 from .base import Preprocessor
 
@@ -22,8 +25,9 @@ class ResizePreprocessor(Preprocessor):
     def __init__(
         self,
         image_resolution: tuple[int, int],
-        padding: bool,
-        keep_aspect_ratio: bool,
+        *,
+        padding: bool = True,
+        keep_aspect_ratio: bool = True,
     ) -> None:
         """Initialize the resize preprocessor."""
         super().__init__()
@@ -31,6 +35,112 @@ class ResizePreprocessor(Preprocessor):
         self._padding = padding
         self._keep_aspect_ratio = keep_aspect_ratio
 
-    def __call__(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
-        """Resize observation images to the target resolution."""
-        raise NotImplementedError
+    def __call__(
+        self,
+        inputs: dict[str, np.ndarray | dict[str, np.ndarray]],
+    ) -> dict[str, np.ndarray | dict[str, np.ndarray]]:
+        """Resize observation images to the target resolution.
+
+        Images may be provided as a single array under the ``images`` key, a
+        nested ``{camera: array}`` dict under ``images``, or flat ``images.*``
+        keys. ``is_pad`` keys are left untouched.
+
+        Args:
+            inputs: Observation dict. Image arrays are expected to have shape
+                ``(batch, channels, height, width)``.
+
+        Returns:
+            A new dict with the image arrays resized.
+        """
+        outputs: dict[str, np.ndarray | dict[str, np.ndarray]] = dict(inputs)
+        images_value = outputs.get(IMAGES)
+
+        if isinstance(images_value, dict):
+            outputs[IMAGES] = {key: self._resize_with_ar_pad(value) for key, value in images_value.items()}
+        elif isinstance(images_value, np.ndarray):
+            outputs[IMAGES] = self._resize_with_ar_pad(images_value)
+        else:
+            image_keys = [key for key in outputs if key.startswith(IMAGES) and "is_pad" not in key]
+            for key in image_keys:
+                value = outputs[key]
+                if isinstance(value, np.ndarray):
+                    outputs[key] = self._resize_with_ar_pad(value)
+
+        return outputs
+
+    def _resize_with_ar_pad(self, img: np.ndarray) -> np.ndarray:  # noqa: PLR0914
+        """Resize an image array to the target resolution.
+
+        Behavior depends on the preprocessor configuration:
+
+        - ``keep_aspect_ratio``: scale so the image fits within the target while
+          preserving proportions. When disabled, the image is stretched to the
+          exact target size.
+        - ``padding``: zero-pad symmetrically so the output exactly matches the
+          target resolution. When disabled, the output keeps the resized size.
+
+        Args:
+            img: Input image array with shape ``(batch, channels, height, width)``.
+
+        Returns:
+            Resized image array.
+
+        Raises:
+            ValueError: If the input array does not have 4 dimensions
+                (batch, channels, height, width).
+        """
+        img_dim = 4
+        if img.ndim != img_dim:
+            msg = f"(b,c,h,w) expected, but {img.shape}"
+            raise ValueError(msg)
+
+        target_height, target_width = self._image_resolution
+        cur_height, cur_width = img.shape[2:]
+
+        if self._keep_aspect_ratio:
+            ratio = max(cur_width / target_width, cur_height / target_height)
+            resized_height = min(int(cur_height / ratio), target_height)
+            resized_width = min(int(cur_width / ratio), target_width)
+        else:
+            resized_height = target_height
+            resized_width = target_width
+
+        if (resized_height, resized_width) != (cur_height, cur_width):
+            img = self._resize_bchw(img, resized_width, resized_height)
+
+        if not self._padding:
+            return img
+
+        pad_height = target_height - resized_height
+        pad_width = target_width - resized_width
+        pad_top = pad_height // 2
+        pad_bottom = pad_height - pad_top
+        pad_left = pad_width // 2
+        pad_right = pad_width - pad_left
+
+        return np.pad(
+            img,
+            ((0, 0), (0, 0), (pad_top, pad_bottom), (pad_left, pad_right)),
+        )
+
+    @staticmethod
+    def _resize_bchw(img: np.ndarray, width: int, height: int) -> np.ndarray:
+        """Bilinear resize of a ``(batch, channels, height, width)`` array.
+
+        Args:
+            img: Input array in channels-first layout.
+            width: Target width.
+            height: Target height.
+
+        Returns:
+            Resized array in channels-first layout.
+        """
+        img_hwc = np.transpose(img, (0, 2, 3, 1))  # (B, H, W, C)
+        resized = []
+        for i in range(img_hwc.shape[0]):
+            out = cv2.resize(img_hwc[i], (width, height), interpolation=cv2.INTER_LINEAR)
+            if out.ndim == 2:  # noqa: PLR2004
+                out = out[:, :, np.newaxis]
+            resized.append(out)
+        stacked = np.stack(resized, axis=0)  # (B, H, W, C)
+        return np.transpose(stacked, (0, 3, 1, 2))  # (B, C, H, W)

--- a/tests/unit/inference/preprocessors/test_resize.py
+++ b/tests/unit/inference/preprocessors/test_resize.py
@@ -53,6 +53,15 @@ class TestResizePreprocessor:
         # Aspect ratio preserved (32:16 -> 64:32), no padding applied.
         assert result[IMAGES].shape == (1, 3, 64, 32)
 
+    def test_keep_aspect_ratio_clamps_to_minimum_size_one(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(512, 512), padding=False, keep_aspect_ratio=True)
+        img = np.random.rand(1, 3, 1, 640).astype(np.float32)
+
+        result = prep({IMAGES: img})
+
+        # 1x640 downscaled to 512-wide would produce height=0 without clamping.
+        assert result[IMAGES].shape == (1, 3, 1, 512)
+
     def test_nested_image_dict(self) -> None:
         prep = ResizePreprocessor(image_resolution=(64, 64), keep_aspect_ratio=False)
         images = {"cam0": np.random.rand(1, 3, 32, 32).astype(np.float32)}

--- a/tests/unit/inference/preprocessors/test_resize.py
+++ b/tests/unit/inference/preprocessors/test_resize.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from physicalai.inference.constants import IMAGES
-from physicalai.inference.preprocessors import Preprocessor, ResizePreprocessor
+from physicalai.inference.preprocessors import Preprocessor, ResizeMode, ResizePreprocessor
 
 
 class TestResizePreprocessor:
@@ -16,13 +16,13 @@ class TestResizePreprocessor:
         assert isinstance(prep, Preprocessor)
 
     def test_stretch_no_aspect_no_padding(self) -> None:
-        prep = ResizePreprocessor(image_resolution=(64, 64), padding=False, keep_aspect_ratio=False)
+        prep = ResizePreprocessor(image_resolution=(64, 64), mode=ResizeMode.STRETCH)
         img = np.random.rand(1, 3, 32, 16).astype(np.float32)
         result = prep({IMAGES: img})
         assert result[IMAGES].shape == (1, 3, 64, 64)
 
-    def test_keep_aspect_ratio_with_padding(self) -> None:
-        prep = ResizePreprocessor(image_resolution=(64, 64), padding=True, keep_aspect_ratio=True)
+    def test_letterbox_preserves_aspect_ratio_with_padding(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), mode=ResizeMode.LETTERBOX)
         img = np.random.rand(1, 3, 32, 16).astype(np.float32)
         result = prep({IMAGES: img})
         # Padded back to the exact target resolution.
@@ -31,8 +31,7 @@ class TestResizePreprocessor:
     def test_padding_uses_configured_pad_value(self) -> None:
         prep = ResizePreprocessor(
             image_resolution=(64, 64),
-            padding=True,
-            keep_aspect_ratio=True,
+            mode=ResizeMode.LETTERBOX,
             pad_value=7,
         )
         img = np.ones((1, 1, 32, 16), dtype=np.float32)
@@ -46,30 +45,33 @@ class TestResizePreprocessor:
         assert np.all(out[:, :, :, 48:] == 7)
         assert np.allclose(out[:, :, :, 16:48], 1.0)
 
-    def test_keep_aspect_ratio_without_padding(self) -> None:
-        prep = ResizePreprocessor(image_resolution=(64, 64), padding=False, keep_aspect_ratio=True)
-        img = np.random.rand(1, 3, 32, 16).astype(np.float32)
+    def test_letterbox_skips_padding_when_aspect_already_matches(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), mode=ResizeMode.LETTERBOX)
+        img = np.random.rand(1, 3, 32, 32).astype(np.float32)
         result = prep({IMAGES: img})
-        # Aspect ratio preserved (32:16 -> 64:32), no padding applied.
-        assert result[IMAGES].shape == (1, 3, 64, 32)
+        assert result[IMAGES].shape == (1, 3, 64, 64)
 
-    def test_keep_aspect_ratio_clamps_to_minimum_size_one(self) -> None:
-        prep = ResizePreprocessor(image_resolution=(512, 512), padding=False, keep_aspect_ratio=True)
-        img = np.random.rand(1, 3, 1, 640).astype(np.float32)
+    def test_letterbox_clamps_to_minimum_size_one(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(512, 512), mode=ResizeMode.LETTERBOX, pad_value=7)
+        img = np.ones((1, 1, 1, 640), dtype=np.float32)
 
         result = prep({IMAGES: img})
+        out = result[IMAGES]
 
         # 1x640 downscaled to 512-wide would produce height=0 without clamping.
-        assert result[IMAGES].shape == (1, 3, 1, 512)
+        assert out.shape == (1, 1, 512, 512)
+        assert np.all(out[:, :, :255, :] == 7)
+        assert np.allclose(out[:, :, 255:256, :], 1.0)
+        assert np.all(out[:, :, 256:, :] == 7)
 
     def test_nested_image_dict(self) -> None:
-        prep = ResizePreprocessor(image_resolution=(64, 64), keep_aspect_ratio=False)
+        prep = ResizePreprocessor(image_resolution=(64, 64), mode=ResizeMode.STRETCH)
         images = {"cam0": np.random.rand(1, 3, 32, 32).astype(np.float32)}
         result = prep({IMAGES: images})
         assert result[IMAGES]["cam0"].shape == (1, 3, 64, 64)
 
     def test_flat_image_keys(self) -> None:
-        prep = ResizePreprocessor(image_resolution=(64, 64), keep_aspect_ratio=False)
+        prep = ResizePreprocessor(image_resolution=(64, 64), mode=ResizeMode.STRETCH)
         inputs = {
             "images.cam0": np.random.rand(1, 3, 32, 32).astype(np.float32),
             "images.cam0.is_pad": np.zeros((1,), dtype=bool),

--- a/tests/unit/inference/preprocessors/test_resize.py
+++ b/tests/unit/inference/preprocessors/test_resize.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from physicalai.inference.constants import IMAGES
+from physicalai.inference.preprocessors import Preprocessor, ResizePreprocessor
+
+
+class TestResizePreprocessor:
+    def test_is_preprocessor(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64))
+        assert isinstance(prep, Preprocessor)
+
+    def test_stretch_no_aspect_no_padding(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), padding=False, keep_aspect_ratio=False)
+        img = np.random.rand(1, 3, 32, 16).astype(np.float32)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].shape == (1, 3, 64, 64)
+
+    def test_keep_aspect_ratio_with_padding(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), padding=True, keep_aspect_ratio=True)
+        img = np.random.rand(1, 3, 32, 16).astype(np.float32)
+        result = prep({IMAGES: img})
+        # Padded back to the exact target resolution.
+        assert result[IMAGES].shape == (1, 3, 64, 64)
+
+    def test_keep_aspect_ratio_without_padding(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), padding=False, keep_aspect_ratio=True)
+        img = np.random.rand(1, 3, 32, 16).astype(np.float32)
+        result = prep({IMAGES: img})
+        # Aspect ratio preserved (32:16 -> 64:32), no padding applied.
+        assert result[IMAGES].shape == (1, 3, 64, 32)
+
+    def test_nested_image_dict(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), keep_aspect_ratio=False)
+        images = {"cam0": np.random.rand(1, 3, 32, 32).astype(np.float32)}
+        result = prep({IMAGES: images})
+        assert result[IMAGES]["cam0"].shape == (1, 3, 64, 64)
+
+    def test_flat_image_keys(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), keep_aspect_ratio=False)
+        inputs = {
+            "images.cam0": np.random.rand(1, 3, 32, 32).astype(np.float32),
+            "images.cam0.is_pad": np.zeros((1,), dtype=bool),
+        }
+        result = prep(inputs)
+        assert result["images.cam0"].shape == (1, 3, 64, 64)
+        # is_pad keys are left untouched.
+        assert result["images.cam0.is_pad"].shape == (1,)
+
+    def test_invalid_ndim_raises(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64))
+        img = np.random.rand(3, 32, 32).astype(np.float32)
+        with pytest.raises(ValueError, match="expected"):
+            prep({IMAGES: img})

--- a/tests/unit/inference/preprocessors/test_resize.py
+++ b/tests/unit/inference/preprocessors/test_resize.py
@@ -28,6 +28,24 @@ class TestResizePreprocessor:
         # Padded back to the exact target resolution.
         assert result[IMAGES].shape == (1, 3, 64, 64)
 
+    def test_padding_uses_configured_pad_value(self) -> None:
+        prep = ResizePreprocessor(
+            image_resolution=(64, 64),
+            padding=True,
+            keep_aspect_ratio=True,
+            pad_value=7,
+        )
+        img = np.ones((1, 1, 32, 16), dtype=np.float32)
+
+        result = prep({IMAGES: img})
+        out = result[IMAGES]
+
+        assert out.shape == (1, 1, 64, 64)
+        # 32x16 scales to 64x32, so left and right pads are 16 pixels each.
+        assert np.all(out[:, :, :, :16] == 7)
+        assert np.all(out[:, :, :, 48:] == 7)
+        assert np.allclose(out[:, :, :, 16:48], 1.0)
+
     def test_keep_aspect_ratio_without_padding(self) -> None:
         prep = ResizePreprocessor(image_resolution=(64, 64), padding=False, keep_aspect_ratio=True)
         img = np.random.rand(1, 3, 32, 16).astype(np.float32)


### PR DESCRIPTION
## Summary

- resize node supports two extra parameters: padding and keep aspect ratio
- can be used for instance for ACT 

## Why

- flexible parametrized preprocessing node allows more flexibility for enabling new policies without modifying inference

## Validation

- Check against the original ACT torch resize implementation

## Breaking changes

- None
