### PR TITLE
fix: missing mean iteration time in the perf benchmark

### DIFF
--- a/docs/explanation/inference.md
+++ b/docs/explanation/inference.md
@@ -76,4 +76,4 @@ warmup_iters  -> measured loop -> metrics
 When no `inputs` iterable is provided, the benchmark generates random inputs according to `model.input_features` specifications,
 so it can run without a recorded dataset. Pass a custom iterable to benchmark against real observations.
 
-The reported metrics (`num_iters`, `min_iter_time`, `max_iter_time`, `median_iter_time`, `std_iter_time`, `avg_warmup_iter_time`) are per-iteration seconds and reflect the full preprocess → runner → postprocess pipeline.
+The reported metrics (`num_iters`, `min_iter_time`, `max_iter_time`, `mean_iter_time`, `median_iter_time`, `std_iter_time`, `avg_warmup_iter_time`) are per-iteration seconds and reflect the full preprocess → runner → postprocess pipeline.

--- a/docs/reference/benchmark-api.md
+++ b/docs/reference/benchmark-api.md
@@ -29,5 +29,6 @@ Runs `warmup_iters` warmup iterations followed by the measured loop and returns 
 | `num_iters`            | Number of measured iterations.                 |
 | `min_iter_time`        | Fastest measured iteration.                    |
 | `max_iter_time`        | Slowest measured iteration.                    |
+| `mean_iter_time`       | Mean measured iteration.                       |
 | `median_iter_time`     | Median measured iteration.                     |
 | `std_iter_time`        | Population standard deviation (0.0 if n == 1). |

--- a/src/physicalai/benchmark/performance/inference_benchmark.py
+++ b/src/physicalai/benchmark/performance/inference_benchmark.py
@@ -6,7 +6,7 @@
 import time
 from collections.abc import Iterable
 from itertools import islice
-from statistics import median, pstdev
+from statistics import mean, median, pstdev
 
 import numpy as np
 
@@ -74,6 +74,8 @@ class InferenceLatencyBenchmark:
             - ``num_iters``: Number of measured iterations executed.
             - ``min_iter_time`` / ``max_iter_time``: Extremes of measured
               per-iteration times.
+            - ``mean_iter_time``: Arithmetic mean of measured per-iteration
+              times.
             - ``median_iter_time``: Median per-iteration time.
             - ``std_iter_time``: Population standard deviation of measured
               per-iteration times (``0.0`` when only a single iteration ran).
@@ -129,6 +131,7 @@ class InferenceLatencyBenchmark:
         results["num_iters"] = len(iter_times)
         results["min_iter_time"] = min(iter_times)
         results["max_iter_time"] = max(iter_times)
+        results["mean_iter_time"] = mean(iter_times)
         results["median_iter_time"] = median(iter_times)
         results["std_iter_time"] = pstdev(iter_times) if len(iter_times) > 1 else 0.0
 

--- a/tests/unit/benchmark/performance/test_inference_benchmark.py
+++ b/tests/unit/benchmark/performance/test_inference_benchmark.py
@@ -78,6 +78,7 @@ class TestInferenceLatencyBenchmark:
             "avg_warmup_iter_time",
             "min_iter_time",
             "max_iter_time",
+            "mean_iter_time",
             "median_iter_time",
             "std_iter_time",
         ):


### PR DESCRIPTION
## Summary

- Add mean iteration time measured after warmup

## Why

- Mean is more common than median
