### PR TITLE
feat: add from_config() and usage example

### DIFF
--- a/examples/runtime/run_from_config.py
+++ b/examples/runtime/run_from_config.py
@@ -4,17 +4,18 @@
 
 """Load a PolicyRuntime from a YAML config and run it.
 
-Equivalent to ``physicalai run --config <path>`` but from a Python script,
-useful for notebooks, debugging, and apps that want to drive the runtime
-programmatically while still using the CLI's config schema.
+Showcases :meth:`PolicyRuntime.from_config` — loads the same ``runtime:``
+schema as ``physicalai run --config``, but the caller owns ``duration_s``
+(passed directly to :meth:`PolicyRuntime.run`). Any ``run:`` block in the
+YAML is parsed and ignored by ``from_config``.
 
 Examples:
 
-    # Run for the duration specified inside the YAML (or indefinitely if absent)
-    python examples/runtime/run_from_config.py examples/runtime/rtc_runtime.yaml
+    # Run for the default 60s
+    python examples/runtime/run_from_config.py examples/runtime/runtime.yaml
 
-    # Override duration from the command line
-    python examples/runtime/run_from_config.py examples/runtime/rtc_runtime.yaml --duration-s 30
+    # Override duration
+    python examples/runtime/run_from_config.py examples/runtime/runtime.yaml --duration-s 30
 """
 
 from __future__ import annotations
@@ -25,6 +26,8 @@ import sys
 from pathlib import Path
 
 from physicalai.runtime import PolicyRuntime
+
+_DEFAULT_DURATION_S = 60.0
 
 
 def main() -> int:
@@ -43,8 +46,8 @@ def main() -> int:
     parser.add_argument(
         "--duration-s",
         type=float,
-        default=None,
-        help="Run duration in seconds. Defaults to running indefinitely.",
+        default=_DEFAULT_DURATION_S,
+        help=f"Run duration in seconds (default: {_DEFAULT_DURATION_S:g}).",
     )
     args = parser.parse_args()
 
@@ -52,9 +55,7 @@ def main() -> int:
         print(f"Config not found: {args.config}", file=sys.stderr)
         return 2
 
-    print(f"Loading runtime from {args.config}...")
     runtime = PolicyRuntime.from_config(args.config)
-    print("Runtime loaded.")
 
     with runtime:
         print(f"Running (duration_s={args.duration_s})")

--- a/examples/runtime/run_from_config.py
+++ b/examples/runtime/run_from_config.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load a PolicyRuntime from a YAML config and run it.
+
+Equivalent to ``physicalai run --config <path>`` but from a Python script,
+useful for notebooks, debugging, and apps that want to drive the runtime
+programmatically while still using the CLI's config schema.
+
+Examples:
+
+    # Run for the duration specified inside the YAML (or indefinitely if absent)
+    python examples/runtime/run_from_config.py examples/runtime/rtc_runtime.yaml
+
+    # Override duration from the command line
+    python examples/runtime/run_from_config.py examples/runtime/rtc_runtime.yaml --duration-s 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+from pathlib import Path
+
+from physicalai.runtime import PolicyRuntime
+
+
+def main() -> int:
+    def _handle_sigint(sig: int, frame: object) -> None:  # noqa: ARG001
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        print("\nInterrupting... press Ctrl+C again to force kill.")
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, _handle_sigint)
+
+    parser = argparse.ArgumentParser(
+        description="Load a PolicyRuntime from a YAML config and run it.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config", type=Path, help="Path to runtime YAML config.")
+    parser.add_argument(
+        "--duration-s",
+        type=float,
+        default=None,
+        help="Run duration in seconds. Defaults to running indefinitely.",
+    )
+    args = parser.parse_args()
+
+    if not args.config.is_file():
+        print(f"Config not found: {args.config}", file=sys.stderr)
+        return 2
+
+    print(f"Loading runtime from {args.config}...")
+    runtime = PolicyRuntime.from_config(args.config)
+    print("Runtime loaded.")
+
+    with runtime:
+        print(f"Running (duration_s={args.duration_s})")
+        stats = runtime.run(duration_s=args.duration_s)
+
+    print(
+        f"\nDone — {stats.steps} steps, {stats.inference_count} inferences, "
+        f"{stats.total_holds} holds, {stats.transient_errors} transient errors",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/runtime/runtime.yaml
+++ b/examples/runtime/runtime.yaml
@@ -1,0 +1,100 @@
+# PhysicalAI runtime — minimal sample config
+#
+# Edit every CHANGE_ME field for your hardware, then run:
+#   python examples/runtime/run_from_config.py examples/runtime/runtime.yaml
+#
+# This sample uses SyncExecution (inference blocks the control loop). It is the
+# simplest mode and a good first check that your model + robot + camera work
+# together. For lower-jitter runs, switch ``execution`` to:
+#
+#   execution:
+#     class_path: physicalai.runtime.AsyncExecution    # background-thread inference
+#     init_args:
+#       request_threshold: 0.5
+#
+# or, for an RTC-exported model:
+#
+#   execution:
+#     class_path: physicalai.runtime.RTCExecution
+#     init_args:
+#       fps: 30.0
+#   action_queue:
+#     class_path: physicalai.runtime.RTCActionQueue
+
+runtime:
+  robot:
+    class_path: physicalai.robot.SO101
+    init_args:
+      port: /dev/ttyACM0 # CHANGE_ME: your robot's serial port
+      calibration: ./robot_calibration.json # CHANGE_ME: path to calibration JSON
+
+  model:
+    class_path: physicalai.inference.InferenceModel
+    init_args:
+      export_dir: ./exports/my_policy # CHANGE_ME: path to exported OpenVINO model
+      device: GPU # GPU | CPU | NPU
+
+  execution:
+    class_path: physicalai.runtime.SyncExecution
+
+  cameras:
+    overhead: # scene/workspace view
+      class_path: physicalai.capture.SharedCamera
+      init_args:
+        camera_type: uvc
+        camera_kwargs:
+          device: /dev/video0 # CHANGE_ME: use /dev/v4l/by-id/... for stable identity
+          width: 640
+          height: 480
+          fps: 30
+    gripper: # wrist-mounted view (rename to ``arm`` if the model expects that key)
+      class_path: physicalai.capture.SharedCamera
+      init_args:
+        camera_type: uvc
+        camera_kwargs:
+          device: /dev/video2 # CHANGE_ME
+          width: 640
+          height: 480
+          fps: 30
+
+  fps: 30.0
+  task: "pick up the red cube" # CHANGE_ME: task string the model was trained with
+
+  callbacks:
+    # Live visualization in Rerun. ``mode: spawn`` launches a viewer window.
+    # For a remote/long-running viewer, swap to:
+    #   mode: connect
+    #   connect_addr: "127.0.0.1:9876"
+    # and start ``rerun`` separately.
+    #
+    # Cameras are declared again here so the callback can subscribe to the
+    # same shared-memory streams as the runtime. SharedCamera matches
+    # publishers by ``camera_type`` + ``camera_kwargs``, so keep these blocks
+    # in sync with the runtime ``cameras:`` section above.
+    - class_path: physicalai.runtime.RerunCallback
+      init_args:
+        cameras:
+          overhead:
+            class_path: physicalai.capture.SharedCamera
+            init_args:
+              camera_type: uvc
+              camera_kwargs:
+                device: /dev/video0 # CHANGE_ME: same as overhead camera above
+                width: 640
+                height: 480
+                fps: 30
+          gripper:
+            class_path: physicalai.capture.SharedCamera
+            init_args:
+              camera_type: uvc
+              camera_kwargs:
+                device: /dev/video2 # CHANGE_ME: same as gripper camera above
+                width: 640
+                height: 480
+                fps: 30
+        mode: spawn
+        log_images: true
+        image_decimation: 1 # log every Nth frame; raise to reduce viewer load
+
+run:
+  duration_s: 60.0

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -22,6 +22,7 @@ from physicalai.runtime.smoothers import LerpSmoother
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+    from pathlib import Path
 
     from physicalai.capture.camera import Camera
     from physicalai.capture.frame import Frame
@@ -275,6 +276,37 @@ class PolicyRuntime:
 
     def __exit__(self, *exc_info: object) -> None:  # noqa: D105
         self.disconnect()
+
+    @classmethod
+    def from_config(cls, config: str | Path) -> Self:
+        """Build a :class:`PolicyRuntime` from a YAML/JSON config file.
+
+        Uses the same schema as ``physicalai run --config``. The optional
+        top-level ``run:`` block is parsed but ignored — pass ``duration_s``
+        to :meth:`run` directly.
+
+        Args:
+            config: Path to a YAML or JSON config file.
+
+        Returns:
+            Instantiated runtime, not yet connected. Call ``connect()`` or
+            use as a context manager before invoking ``run()``.
+
+        Example::
+
+            with PolicyRuntime.from_config("rtc_runtime.yaml") as runtime:
+                runtime.run(duration_s=60)
+        """
+        from jsonargparse import ActionConfigFile, ArgumentParser  # noqa: PLC0415
+
+        parser = ArgumentParser()
+        parser.add_argument("--config", action=ActionConfigFile)
+        parser.add_class_arguments(cls, "runtime")
+        # Accept (and ignore) the CLI's ``run:`` block so configs round-trip
+        # between ``physicalai run --config`` and ``from_config``.
+        parser.add_method_arguments(cls, "run", "run")
+        ns = parser.parse_args(["--config", str(config)])
+        return parser.instantiate(ns).runtime
 
     def run(self, *, duration_s: float | None = None) -> RunStats:  # noqa: PLR0915
         """Run the control loop.

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -295,3 +296,114 @@ class TestRunStats:
         assert stats.total_pops == 8
         assert stats.total_holds == 2
         assert stats.inference_count == 3
+
+
+class _ConfigFakeRobot:
+    """Minimal Robot-protocol stub usable as a YAML ``class_path`` target."""
+
+    def __init__(self, port: str = "/dev/null") -> None:
+        self.port = port
+
+    @property
+    def joint_names(self) -> list[str]:
+        return ["j0", "j1"]
+
+    def connect(self) -> None: ...
+    def disconnect(self) -> None: ...
+    def is_connected(self) -> bool:
+        return True
+
+    def get_observation(self) -> FakeRobotObservation:
+        return FakeRobotObservation(
+            joint_positions=np.zeros(2, dtype=np.float32),
+            timestamp=time.monotonic(),
+            sensor_data=None,
+            images=None,
+        )
+
+    def send_action(self, action: np.ndarray, *, goal_time: float = 0.1) -> None: ...
+
+
+_FAKE_ROBOT_PATH = f"{__name__}._ConfigFakeRobot"
+_SYNC_EXECUTION_PATH = "physicalai.runtime.execution.SyncExecution"
+_MODEL_PATH = "physicalai.inference.model.InferenceModel"
+
+
+def _minimal_yaml(*, fps: float = 30.0, include_run_block: bool = False) -> str:
+    body = (
+        "runtime:\n"
+        f"  fps: {fps}\n"
+        "  robot:\n"
+        f"    class_path: {_FAKE_ROBOT_PATH}\n"
+        "    init_args:\n"
+        "      port: /dev/null\n"
+        "  model:\n"
+        f"    class_path: {_MODEL_PATH}\n"
+        "    init_args:\n"
+        "      export_dir: /tmp/fake\n"
+        "  execution:\n"
+        f"    class_path: {_SYNC_EXECUTION_PATH}\n"
+    )
+    if include_run_block:
+        body += "run:\n  duration_s: 5\n"
+    return body
+
+
+class TestFromConfig:
+    """``PolicyRuntime.from_config`` — YAML/JSON loader symmetric to the CLI."""
+
+    def test_loads_minimal_yaml(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text(_minimal_yaml())
+
+        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
+            runtime = PolicyRuntime.from_config(cfg_path)
+
+        assert isinstance(runtime, PolicyRuntime)
+        assert runtime._fps == 30.0  # noqa: SLF001
+        assert isinstance(runtime.robot, _ConfigFakeRobot)
+        assert runtime.robot.port == "/dev/null"
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text(_minimal_yaml(fps=15.0))
+
+        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
+            runtime = PolicyRuntime.from_config(str(cfg_path))
+
+        assert runtime._fps == 15.0  # noqa: SLF001
+
+    def test_ignores_run_block(self, tmp_path: Path) -> None:
+        """The CLI's ``run:`` block parses but is dropped — caller passes duration to run()."""
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text(_minimal_yaml(include_run_block=True))
+
+        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
+            runtime = PolicyRuntime.from_config(cfg_path)
+
+        assert isinstance(runtime, PolicyRuntime)
+        # Runtime carries no record of run.duration_s; only its constructor args.
+        assert not hasattr(runtime, "duration_s")
+
+    def test_missing_required_field_raises(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "runtime.yaml"
+        # No model block — schema must reject.
+        cfg_path.write_text(
+            "runtime:\n"
+            "  fps: 30\n"
+            "  robot:\n"
+            f"    class_path: {_FAKE_ROBOT_PATH}\n"
+            "  execution:\n"
+            f"    class_path: {_SYNC_EXECUTION_PATH}\n",
+        )
+        with pytest.raises(SystemExit):
+            PolicyRuntime.from_config(cfg_path)
+
+    def test_returns_disconnected_runtime(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text(_minimal_yaml())
+
+        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
+            runtime = PolicyRuntime.from_config(cfg_path)
+
+        assert runtime._connected is False  # noqa: SLF001

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -18,6 +18,8 @@ import pytest
 from physicalai.runtime._action_queue import ChunkedActionQueue as ActionQueue, ChunkedActionQueue
 from physicalai.runtime.execution import SyncExecution, WorkerDiedError
 from physicalai.runtime.runtime import PolicyRuntime, RunStats
+from physicalai.robot.interface import RobotObservation
+from physicalai.inference.model import InferenceModel
 
 from physicalai.capture import Frame
 
@@ -313,7 +315,7 @@ class _ConfigFakeRobot:
     def is_connected(self) -> bool:
         return True
 
-    def get_observation(self) -> FakeRobotObservation:
+    def get_observation(self) -> RobotObservation:
         return FakeRobotObservation(
             joint_positions=np.zeros(2, dtype=np.float32),
             timestamp=time.monotonic(),
@@ -324,9 +326,16 @@ class _ConfigFakeRobot:
     def send_action(self, action: np.ndarray, *, goal_time: float = 0.1) -> None: ...
 
 
+class _ConfigFakeModel(InferenceModel):
+    """Minimal InferenceModel subclass that skips export-dir filesystem access."""
+
+    def __init__(self, export_dir: str = "/tmp/fake") -> None:  # noqa: S108
+        self.export_dir = export_dir  # type: ignore[assignment]
+
+
 _FAKE_ROBOT_PATH = f"{__name__}._ConfigFakeRobot"
 _SYNC_EXECUTION_PATH = "physicalai.runtime.execution.SyncExecution"
-_MODEL_PATH = "physicalai.inference.model.InferenceModel"
+_MODEL_PATH = f"{__name__}._ConfigFakeModel"
 
 
 def _minimal_yaml(*, fps: float = 30.0, include_run_block: bool = False) -> str:
@@ -356,8 +365,7 @@ class TestFromConfig:
         cfg_path = tmp_path / "runtime.yaml"
         cfg_path.write_text(_minimal_yaml())
 
-        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
-            runtime = PolicyRuntime.from_config(cfg_path)
+        runtime = PolicyRuntime.from_config(cfg_path)
 
         assert isinstance(runtime, PolicyRuntime)
         assert runtime._fps == 30.0  # noqa: SLF001
@@ -368,8 +376,7 @@ class TestFromConfig:
         cfg_path = tmp_path / "runtime.yaml"
         cfg_path.write_text(_minimal_yaml(fps=15.0))
 
-        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
-            runtime = PolicyRuntime.from_config(str(cfg_path))
+        runtime = PolicyRuntime.from_config(str(cfg_path))
 
         assert runtime._fps == 15.0  # noqa: SLF001
 
@@ -378,8 +385,7 @@ class TestFromConfig:
         cfg_path = tmp_path / "runtime.yaml"
         cfg_path.write_text(_minimal_yaml(include_run_block=True))
 
-        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
-            runtime = PolicyRuntime.from_config(cfg_path)
+        runtime = PolicyRuntime.from_config(cfg_path)
 
         assert isinstance(runtime, PolicyRuntime)
         # Runtime carries no record of run.duration_s; only its constructor args.
@@ -403,7 +409,6 @@ class TestFromConfig:
         cfg_path = tmp_path / "runtime.yaml"
         cfg_path.write_text(_minimal_yaml())
 
-        with patch("physicalai.inference.model.InferenceModel.__init__", return_value=None):
-            runtime = PolicyRuntime.from_config(cfg_path)
+        runtime = PolicyRuntime.from_config(cfg_path)
 
         assert runtime._connected is False  # noqa: SLF001


### PR DESCRIPTION
## Summary

- Add `PolicyRuntime.from_config(path)` classmethod. Loads YAML/JSON via same `jsonargparse` schema as `physicalai run --config`
- Add `examples/runtime/run_from_config.py` that loads a config yaml
- Add `examples/runtime/runtime.yaml` shippable sample: SO-101, two cameras and `SyncExecution`

Physical AI Studio can export the runtime config via `jsonargparse`:
```python
from jsonargparse import ArgumentParser
from physicalai.runtime import PolicyRuntime

parser = ArgumentParser()
parser.add_class_arguments(PolicyRuntime, "runtime")
parser.add_method_arguments(PolicyRuntime, "run", "run")

ns = parser.parse_object({
    "runtime": {
        "fps": 30.0,
        "robot": {"class_path": "...", "init_args": {...}},
        "model": {"class_path": "physicalai.inference.model.InferenceModel",
                  "init_args": {"export_dir": str(export_dir)}},
        "execution": {"class_path": "physicalai.runtime.execution.SyncExecution"},
        "cameras": {...},
    },
    "run": {"duration_s": None},
})
cfg_path.write_text(parser.dump(ns))
```


## Why

- Apps embedding the runtime reimplement the CLI parser to load configs. `from_config` removes that duplication and keeps CLI + programmatic paths on one schema.

## Validation

- Ran `run_from_config.py sync_runtime.yaml` against local SO-101 + 3 cameras + OpenVINO export. Connects, ticks at FPS, Rerun logs frames + scalars.

## Breaking changes

- None. Additive; CLI and existing constructor unchanged.

## Related issues

- Closes #