### PR TITLE
fix: align input type / layouts support across resize preprocessing nodes

### DIFF
--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -120,7 +120,7 @@ class ResizePreprocessor(Preprocessor):
             msg = f"Unsupported image dtype: {img.dtype}"
             raise ValueError(msg)
 
-        channels_last = img.shape[-1] == 3  # noqa: PLR2004
+        channels_last = img.shape[-1] == 3 and img.shape[1] != 3  # noqa: PLR2004
         if channels_last:
             img = np.transpose(img, (0, 3, 1, 2))  # (B, H, W, C) -> (B, C, H, W)
 

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -58,8 +58,8 @@ class ResizePreprocessor(Preprocessor):
 
         Image arrays may be in channels-first ``(batch, channels, height,
         width)`` or channels-last ``(batch, height, width, channels)`` layout,
-        with ``uint8`` or floating-point values. The output is always in
-        channels-first layout and preserves the input dtype.
+        with ``uint8`` (normalized to ``float32`` in [0, 1]) or floating-point
+        values. The output is always in channels-first layout and ``float32``.
 
         Args:
             inputs: Observation dict.

--- a/src/physicalai/inference/preprocessors/resize.py
+++ b/src/physicalai/inference/preprocessors/resize.py
@@ -56,9 +56,13 @@ class ResizePreprocessor(Preprocessor):
         nested ``{camera: array}`` dict under ``images``, or flat ``images.*``
         keys. ``is_pad`` keys are left untouched.
 
+        Image arrays may be in channels-first ``(batch, channels, height,
+        width)`` or channels-last ``(batch, height, width, channels)`` layout,
+        with ``uint8`` or floating-point values. The output is always in
+        channels-first layout and preserves the input dtype.
+
         Args:
-            inputs: Observation dict. Image arrays are expected to have shape
-                ``(batch, channels, height, width)``.
+            inputs: Observation dict.
 
         Returns:
             A new dict with the image arrays resized.
@@ -88,20 +92,37 @@ class ResizePreprocessor(Preprocessor):
                 - ``letterbox``: image is scaled to fit while preserving aspect ratio,
                     then padded symmetrically to exactly match the target dimensions.
 
+        Accepts channels-first ``(B,C,H,W)`` or
+        channels-last ``(B,H,W,C)`` arrays with ``uint8``
+        or floating-point values. The output is always in channels-first layout
+        and ``fp32``.
+
         Args:
-            img: Input image array with shape ``(batch, channels, height, width)``.
+            img: Input image array in channels-first or channels-last layout.
 
         Returns:
-            Resized image array.
+            Resized image array in channels-first layout.
 
         Raises:
-            ValueError: If the input array does not have 4 dimensions
-                (batch, channels, height, width).
+            ValueError: If the input array does not have 4 dimensions, or if it
+                has an unsupported dtype (not ``uint8`` or floating point).
         """
         img_dim = 4
         if img.ndim != img_dim:
-            msg = f"(b,c,h,w) expected, but {img.shape}"
+            msg = f"(B,C,H,W) expected, but {img.shape}"
             raise ValueError(msg)
+
+        if img.dtype == np.uint8:
+            img = img.astype(np.float32) / 255.0
+        elif np.issubdtype(img.dtype, np.floating):
+            img = img.astype(np.float32)
+        else:
+            msg = f"Unsupported image dtype: {img.dtype}"
+            raise ValueError(msg)
+
+        channels_last = img.shape[-1] == 3  # noqa: PLR2004
+        if channels_last:
+            img = np.transpose(img, (0, 3, 1, 2))  # (B, H, W, C) -> (B, C, H, W)
 
         target_height, target_width = self._image_resolution
         cur_height, cur_width = img.shape[2:]
@@ -117,24 +138,21 @@ class ResizePreprocessor(Preprocessor):
         if (resized_height, resized_width) != (cur_height, cur_width):
             img = self._resize_bchw(img, resized_width, resized_height)
 
-        if self._mode == ResizeMode.STRETCH:
-            return img
+        if self._mode == ResizeMode.LETTERBOX:
+            pad_height = target_height - resized_height
+            pad_width = target_width - resized_width
+            if pad_height > 0 or pad_width > 0:
+                pad_top = pad_height // 2
+                pad_bottom = pad_height - pad_top
+                pad_left = pad_width // 2
+                pad_right = pad_width - pad_left
+                img = np.pad(
+                    img,
+                    ((0, 0), (0, 0), (pad_top, pad_bottom), (pad_left, pad_right)),
+                    constant_values=self._pad_value,
+                )
 
-        pad_height = target_height - resized_height
-        pad_width = target_width - resized_width
-        pad_top = pad_height // 2
-        pad_bottom = pad_height - pad_top
-        pad_left = pad_width // 2
-        pad_right = pad_width - pad_left
-
-        if pad_height == 0 and pad_width == 0:
-            return img
-
-        return np.pad(
-            img,
-            ((0, 0), (0, 0), (pad_top, pad_bottom), (pad_left, pad_right)),
-            constant_values=self._pad_value,
-        )
+        return img
 
     @staticmethod
     def _resize_bchw(img: np.ndarray, width: int, height: int) -> np.ndarray:

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -79,7 +79,7 @@ class ResizeSmolVLA(Preprocessor):
                 msg = f"Unsupported image dtype: {img.dtype}"
                 raise ValueError(msg)
 
-            if img_fp32.ndim == 4 and img_fp32.shape[-1] == 3:  # noqa: PLR2004
+            if img_fp32.ndim == 4 and img_fp32.shape[-1] == 3 and img_fp32.shape[1] != 3:  # noqa: PLR2004
                 img_fp32 = np.transpose(img_fp32, (0, 3, 1, 2))  # (B, H, W, C) to (B, C, H, W)
 
             resized_img = self._resize_with_pad(img_fp32, *self.image_resolution, pad_value=0)

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -51,6 +51,9 @@ class ResizeSmolVLA(Preprocessor):
                         with pixel values normalized to [-1, 1].
             - IMAGE_MASKS: Boolean masks of shape (batch_size, height, width) indicating
                              valid image regions (all ones for padded images).
+
+        Raises:
+            ValueError: If input images have unsupported data types.
         """
         inputs = dict(inputs)
 
@@ -66,7 +69,18 @@ class ResizeSmolVLA(Preprocessor):
         resized_images = []
 
         for img in images:
-            resized_img = self._resize_with_pad(img, *self.image_resolution, pad_value=0)
+            if img.dtype == np.uint8:
+                img_fp32 = img.astype(np.float32) / 255.0
+            elif np.issubdtype(img.dtype, np.floating):
+                img_fp32 = img.astype(np.float32)
+            else:
+                msg = f"Unsupported image dtype: {img.dtype}"
+                raise ValueError(msg)
+
+            if img_fp32.ndim == 4 and img_fp32.shape[-1] == 3:  # noqa: PLR2004
+                img_fp32 = np.transpose(img_fp32, (0, 3, 1, 2))  # (B, H, W, C) to (B, C, H, W)
+
+            resized_img = self._resize_with_pad(img_fp32, *self.image_resolution, pad_value=0)
             resized_img = resized_img * 2.0 - 1.0
             bsize = resized_img.shape[0]
             mask = np.ones(bsize, dtype=np.bool)

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -39,7 +39,9 @@ class ResizeSmolVLA(Preprocessor):
         """Process and prepare images for model inference.
 
         Resizes images with padding, normalizes pixel values to [-1, 1] range,
-        and generates corresponding attention masks.
+        and generates corresponding attention masks. Supported image formats:
+        - (B, C, H, W) or (B, H, W, C) with float32 values in [0, 1]
+        - (B, C, H, W) or (B, H, W, C) with uint8 values in [0, 255]
 
         Args:
             inputs: Dictionary containing IMAGES key with numpy array(s) of shape

--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
 import numpy as np
 
 from physicalai.capture.errors import CaptureError
+from physicalai.inference.constants import IMAGES, STATE, TASK
 from physicalai.runtime._action_queue import ChunkedActionQueue  # noqa: PLC2701
 from physicalai.runtime._callback_bus import _CallbackBus  # noqa: PLC2701
 from physicalai.runtime.events import LifecycleEvent, TickEvent
@@ -452,17 +453,17 @@ class PolicyRuntime:
 
     def _build_model_input(self) -> dict[str, Any]:
         robot_obs = self._robot.get_observation()
-        model_input: dict[str, Any] = {"state": np.array([robot_obs.state], dtype=np.float32)}
+        model_input: dict[str, Any] = {STATE: np.array([robot_obs.state], dtype=np.float32)}
 
         # Merge robot-embedded images and external cameras
         if robot_obs.images:
             for name, frame in robot_obs.images.items():
-                model_input[f"images.{name}"] = frame.data[np.newaxis]
+                model_input[f"{IMAGES}.{name}"] = frame.data[np.newaxis]
         for name, cam in self._cameras.items():
-            model_input[f"images.{name}"] = cam.read_latest().data[np.newaxis]
+            model_input[f"{IMAGES}.{name}"] = cam.read_latest().data[np.newaxis]
 
         if self._task is not None:
-            model_input["task"] = [self._task]
+            model_input[TASK] = [self._task]
 
         return model_input
 
@@ -558,14 +559,14 @@ class PolicyRuntime:
         Returns:
             Dictionary ready to pass to the inference model.
         """
-        model_input: dict[str, Any] = {"state": np.array([robot_obs.state], dtype=np.float32)}
+        model_input: dict[str, Any] = {STATE: np.array([robot_obs.state], dtype=np.float32)}
         if robot_obs.images:
             for name, frame in robot_obs.images.items():
-                model_input[f"images.{name}"] = frame.data[np.newaxis]
+                model_input[f"{IMAGES}.{name}"] = frame.data[np.newaxis]
         for name, frame in camera_frames.items():
-            model_input[f"images.{name}"] = frame.data[np.newaxis]
+            model_input[f"{IMAGES}.{name}"] = frame.data[np.newaxis]
         if self._task is not None:
-            model_input["task"] = [self._task]
+            model_input[TASK] = [self._task]
         return model_input
 
     def _resilient_send(self, action: np.ndarray) -> None:

--- a/tests/unit/inference/preprocessors/test_resize.py
+++ b/tests/unit/inference/preprocessors/test_resize.py
@@ -86,3 +86,39 @@ class TestResizePreprocessor:
         img = np.random.rand(3, 32, 32).astype(np.float32)
         with pytest.raises(ValueError, match="expected"):
             prep({IMAGES: img})
+
+    def test_unsupported_dtype_raises(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64))
+        img = np.zeros((1, 3, 32, 32), dtype=np.int32)
+        with pytest.raises(ValueError, match="Unsupported image dtype"):
+            prep({IMAGES: img})
+
+    def test_uint8_is_normalized_to_unit_range(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(32, 32), mode=ResizeMode.STRETCH)
+        img = np.full((1, 3, 32, 32), 255, dtype=np.uint8)
+        result = prep({IMAGES: img})
+        out = result[IMAGES]
+        assert out.dtype == np.float32
+        assert np.allclose(out, 1.0)
+
+    def test_float_output_is_float32(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(32, 32), mode=ResizeMode.STRETCH)
+        img = np.random.rand(1, 3, 16, 16).astype(np.float64)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].dtype == np.float32
+
+    def test_channels_last_input_returns_channels_first(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(64, 64), mode=ResizeMode.STRETCH)
+        img = np.random.rand(1, 32, 16, 3).astype(np.float32)
+        result = prep({IMAGES: img})
+        # Channels-last input is converted to channels-first output.
+        assert result[IMAGES].shape == (1, 3, 64, 64)
+
+    def test_channels_last_uint8_is_normalized(self) -> None:
+        prep = ResizePreprocessor(image_resolution=(32, 32), mode=ResizeMode.STRETCH)
+        img = np.full((1, 16, 16, 3), 255, dtype=np.uint8)
+        result = prep({IMAGES: img})
+        out = result[IMAGES]
+        assert out.shape == (1, 3, 32, 32)
+        assert out.dtype == np.float32
+        assert np.allclose(out, 1.0)

--- a/tests/unit/inference/preprocessors/test_smolvla.py
+++ b/tests/unit/inference/preprocessors/test_smolvla.py
@@ -100,6 +100,56 @@ class TestResizeSmolVLACall:
         assert result[IMAGE_MASKS].all()
 
 
+class TestResizeSmolVLADtypeAndLayout:
+    def test_uint8_input_normalised(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        # uint8 255 → 1.0 → 1.0 * 2 - 1 = 1.0
+        img = np.full((1, 3, 64, 64), 255, dtype=np.uint8)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].dtype == np.float32
+        assert result[IMAGES].shape[1:] == img.shape
+        np.testing.assert_allclose(result[IMAGES].max(), 1.0, atol=1e-5)
+
+    def test_uint8_zeros_normalised(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        # uint8 0 → 0.0 → 0.0 * 2 - 1 = -1.0
+        img = np.zeros((1, 3, 64, 64), dtype=np.uint8)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].dtype == np.float32
+        assert result[IMAGES].shape[1:] == img.shape
+        np.testing.assert_allclose(result[IMAGES].min(), -1.0, atol=1e-5)
+
+    def test_non_float32_dtype_converted(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        img = np.ones((1, 3, 64, 64), dtype=np.float64)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].shape[1:] == img.shape
+        assert result[IMAGES].dtype == np.float32
+
+    def test_unsupported_dtype_raises(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        img = np.ones((1, 3, 64, 64), dtype=np.int32)
+        with pytest.raises(ValueError, match="Unsupported image dtype"):
+            prep({IMAGES: img})
+
+    def test_channels_last_transposed(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        # (B, H, W, C) input should be transposed to (B, C, H, W) internally
+        img = np.random.rand(1, 32, 32, 3).astype(np.float32)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].shape[2] == 3
+        assert result[IMAGES].shape[3] == 64
+        assert result[IMAGES].shape[4] == 64
+
+    def test_channels_last_uint8_matches_channels_first(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        chw = np.random.randint(0, 256, size=(1, 3, 48, 48), dtype=np.uint8)
+        hwc = np.transpose(chw, (0, 2, 3, 1))
+        result_chw = prep({IMAGES: chw})
+        result_hwc = prep({IMAGES: hwc})
+        np.testing.assert_array_equal(result_chw[IMAGES], result_hwc[IMAGES])
+
+
 class TestResizeSmolVLAResizeWithPad:
     def test_invalid_ndim_raises(self) -> None:
         with pytest.raises(ValueError, match="expected"):


### PR DESCRIPTION
## Summary

- Some of the resize functions didn't support hwc / int8 which caused failures when running `PolicyRuntime`

## Why

- The changes are necessary to fully enable some of the policies

## Validation

- Run `ACT` or `SmolVLA`
