### PR TITLE
fix: incorrect InferenceModel inputs with one camera setup

### DIFF
--- a/src/physicalai/runtime/runtime.py
+++ b/src/physicalai/runtime/runtime.py
@@ -453,18 +453,33 @@ class PolicyRuntime:
 
     def _build_model_input(self) -> dict[str, Any]:
         robot_obs = self._robot.get_observation()
-        model_input: dict[str, Any] = {STATE: np.array([robot_obs.state], dtype=np.float32)}
+        camera_frames = {name: cam.read_latest() for name, cam in self._cameras.items()}
 
+        return self._build_model_input_from(robot_obs, camera_frames)
+
+    def _build_model_input_from(self, robot_obs: RobotObservation, camera_frames: dict[str, Frame]) -> dict[str, Any]:
+        """Assemble model input dict from observation and camera frames.
+
+        Returns:
+            Dictionary ready to pass to the inference model.
+        """
+        model_input: dict[str, Any] = {STATE: np.array([robot_obs.state], dtype=np.float32)}
+        image_inputs: dict[str, np.ndarray] = {}
         # Merge robot-embedded images and external cameras
         if robot_obs.images:
             for name, frame in robot_obs.images.items():
-                model_input[f"{IMAGES}.{name}"] = frame.data[np.newaxis]
-        for name, cam in self._cameras.items():
-            model_input[f"{IMAGES}.{name}"] = cam.read_latest().data[np.newaxis]
+                image_inputs[name] = frame.data[np.newaxis]
+        for name, frame in camera_frames.items():
+            image_inputs[name] = frame.data[np.newaxis]
+
+        if len(image_inputs) > 1:
+            for name, data in image_inputs.items():
+                model_input[f"{IMAGES}.{name}"] = data
+        elif len(image_inputs) == 1:
+            model_input[IMAGES] = next(iter(image_inputs.values()))
 
         if self._task is not None:
             model_input[TASK] = [self._task]
-
         return model_input
 
     def _retry_robot_obs(self) -> tuple[RobotObservation | None, ConnectionError | OSError | None]:
@@ -552,22 +567,6 @@ class PolicyRuntime:
                 camera_frames[name] = stale_frame
 
         return robot_obs, camera_frames
-
-    def _build_model_input_from(self, robot_obs: RobotObservation, camera_frames: dict[str, Frame]) -> dict[str, Any]:
-        """Assemble model input dict from observation and camera frames.
-
-        Returns:
-            Dictionary ready to pass to the inference model.
-        """
-        model_input: dict[str, Any] = {STATE: np.array([robot_obs.state], dtype=np.float32)}
-        if robot_obs.images:
-            for name, frame in robot_obs.images.items():
-                model_input[f"{IMAGES}.{name}"] = frame.data[np.newaxis]
-        for name, frame in camera_frames.items():
-            model_input[f"{IMAGES}.{name}"] = frame.data[np.newaxis]
-        if self._task is not None:
-            model_input[TASK] = [self._task]
-        return model_input
 
     def _resilient_send(self, action: np.ndarray) -> None:
         last_error: ConnectionError | OSError | None = None

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -20,6 +20,7 @@ from physicalai.runtime.execution import SyncExecution, WorkerDiedError
 from physicalai.runtime.runtime import PolicyRuntime, RunStats
 from physicalai.robot.interface import RobotObservation
 from physicalai.inference.model import InferenceModel
+from physicalai.inference.constants import IMAGES, STATE, TASK
 
 from physicalai.capture import Frame
 
@@ -412,3 +413,123 @@ class TestFromConfig:
         runtime = PolicyRuntime.from_config(cfg_path)
 
         assert runtime._connected is False  # noqa: SLF001
+
+
+def _make_frame(value: int = 0) -> Frame:
+    return Frame(data=np.full((2, 2, 3), value, dtype=np.uint8), timestamp=0.0, sequence=0)
+
+
+class TestBuildModelInputFrom:
+    """Covers image-key layout in PolicyRuntime._build_model_input_from."""
+
+    @staticmethod
+    def _runtime(**kwargs: Any) -> PolicyRuntime:
+        defaults: dict[str, Any] = {
+            "robot": _make_mock_robot(),
+            "model": _make_mock_model(),
+            "execution": SyncExecution(),
+            "fps": 10.0,
+        }
+        defaults.update(kwargs)
+        return _make_runtime(**defaults)
+
+    def test_single_image_uses_bare_images_key(self) -> None:
+        """A single image input is placed under the bare ``images`` key."""
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images=None,
+        )
+        frame = _make_frame(1)
+        runtime = self._runtime(cameras={"cam0": MagicMock()})
+
+        model_input = runtime._build_model_input_from(robot_obs, {"cam0": frame})  # noqa: SLF001
+
+        assert IMAGES in model_input
+        assert f"{IMAGES}.cam0" not in model_input
+        np.testing.assert_array_equal(model_input[IMAGES], frame.data[np.newaxis])
+        np.testing.assert_array_equal(model_input[STATE], np.array([robot_obs.state], dtype=np.float32))
+
+    def test_multiple_images_use_namespaced_keys(self) -> None:
+        """Multiple image inputs are placed under ``images.<name>`` keys."""
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images=None,
+        )
+        frame0 = _make_frame(1)
+        frame1 = _make_frame(2)
+        runtime = self._runtime()
+
+        model_input = runtime._build_model_input_from(  # noqa: SLF001
+            robot_obs, {"cam0": frame0, "cam1": frame1}
+        )
+
+        assert IMAGES not in model_input
+        np.testing.assert_array_equal(model_input[f"{IMAGES}.cam0"], frame0.data[np.newaxis])
+        np.testing.assert_array_equal(model_input[f"{IMAGES}.cam1"], frame1.data[np.newaxis])
+
+    def test_single_robot_embedded_image_uses_bare_images_key(self) -> None:
+        """A single robot-embedded image also uses the bare ``images`` key."""
+        frame = _make_frame(3)
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images={"wrist": frame},
+        )
+        runtime = self._runtime()
+
+        model_input = runtime._build_model_input_from(robot_obs, {})  # noqa: SLF001
+
+        assert IMAGES in model_input
+        np.testing.assert_array_equal(model_input[IMAGES], frame.data[np.newaxis])
+
+    def test_robot_and_camera_images_combine_to_namespaced_keys(self) -> None:
+        """A robot-embedded image plus a camera frame yield namespaced keys."""
+        embedded = _make_frame(4)
+        camera = _make_frame(5)
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images={"wrist": embedded},
+        )
+        runtime = self._runtime()
+
+        model_input = runtime._build_model_input_from(robot_obs, {"cam0": camera})  # noqa: SLF001
+
+        assert IMAGES not in model_input
+        np.testing.assert_array_equal(model_input[f"{IMAGES}.wrist"], embedded.data[np.newaxis])
+        np.testing.assert_array_equal(model_input[f"{IMAGES}.cam0"], camera.data[np.newaxis])
+
+    def test_no_images_omits_image_keys(self) -> None:
+        """With no images, no ``images`` keys are present."""
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images=None,
+        )
+        runtime = self._runtime()
+
+        model_input = runtime._build_model_input_from(robot_obs, {})  # noqa: SLF001
+
+        assert IMAGES not in model_input
+        assert not any(key.startswith(f"{IMAGES}.") for key in model_input)
+
+    def test_task_included_when_set(self) -> None:
+        """The task string is forwarded when configured on the runtime."""
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.array([0.1, 0.2, 0.3], dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images=None,
+        )
+        runtime = self._runtime(task="pick the cube")
+
+        model_input = runtime._build_model_input_from(robot_obs, {"cam0": _make_frame(1)})  # noqa: SLF001
+
+        assert model_input[TASK] == ["pick the cube"]


### PR DESCRIPTION
## Summary

- Before fix, single-image policy input contract was broken: policies expect single image under `images` key

## Why

- Bugifx

## Validation

- UTs, policy run

## Breaking changes

- None

