### PR TITLE
feat: add agent skills foundation for runtime workflows

### DIFF
--- a/.agents/skills/capture-adding-a-camera-backend
+++ b/.agents/skills/capture-adding-a-camera-backend
@@ -1,0 +1,1 @@
+../../skills/capture/capture-adding-a-camera-backend

--- a/.agents/skills/inference-configuring-inference-pipeline
+++ b/.agents/skills/inference-configuring-inference-pipeline
@@ -1,0 +1,1 @@
+../../skills/inference/inference-configuring-inference-pipeline

--- a/.agents/skills/inference-loading-exported-policies
+++ b/.agents/skills/inference-loading-exported-policies
@@ -1,0 +1,1 @@
+../../skills/inference/inference-loading-exported-policies

--- a/.agents/skills/runtime-adding-a-robot-integration
+++ b/.agents/skills/runtime-adding-a-robot-integration
@@ -1,0 +1,1 @@
+../../skills/runtime/runtime-adding-a-robot-integration

--- a/.agents/skills/runtime-running-policy-on-robot
+++ b/.agents/skills/runtime-running-policy-on-robot
@@ -1,0 +1,1 @@
+../../skills/runtime/runtime-running-policy-on-robot

--- a/.claude/skills/capture-adding-a-camera-backend
+++ b/.claude/skills/capture-adding-a-camera-backend
@@ -1,0 +1,1 @@
+../../skills/capture/capture-adding-a-camera-backend

--- a/.claude/skills/inference-configuring-inference-pipeline
+++ b/.claude/skills/inference-configuring-inference-pipeline
@@ -1,0 +1,1 @@
+../../skills/inference/inference-configuring-inference-pipeline

--- a/.claude/skills/inference-loading-exported-policies
+++ b/.claude/skills/inference-loading-exported-policies
@@ -1,0 +1,1 @@
+../../skills/inference/inference-loading-exported-policies

--- a/.claude/skills/runtime-adding-a-robot-integration
+++ b/.claude/skills/runtime-adding-a-robot-integration
@@ -1,0 +1,1 @@
+../../skills/runtime/runtime-adding-a-robot-integration

--- a/.claude/skills/runtime-running-policy-on-robot
+++ b/.claude/skills/runtime-running-policy-on-robot
@@ -1,0 +1,1 @@
+../../skills/runtime/runtime-running-policy-on-robot

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+# GitHub Copilot Instructions
+
+Follow [`AGENTS.md`](../AGENTS.md) for repository guidance, build/test commands, and cross-repo rules.
+
+For coding standards, follow [`docs/development/coding-standards.md`](../docs/development/coding-standards.md).
+
+For runtime security rules, follow [`docs/development/security.md`](../docs/development/security.md) before changing `src/physicalai/`.
+
+For agent skills, see [`skills/README.md`](../skills/README.md).

--- a/.github/scripts/skills/agent_skills.py
+++ b/.github/scripts/skills/agent_skills.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Maintain Physical AI Runtime agent skills (adapters, layout, frontmatter)."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import re
+import subprocess
+from pathlib import Path
+
+_SCRIPT = "python3 .github/scripts/skills/agent_skills.py"
+
+_BUCKETS = ("inference", "capture", "runtime")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def skill_dirs(root: Path) -> list[tuple[str, str]]:
+    """Return (bucket, skill_name) for each canonical skill directory."""
+    found: list[tuple[str, str]] = []
+    for bucket in _BUCKETS:
+        bucket_path = root / "skills" / bucket
+        if not bucket_path.is_dir():
+            continue
+        found.extend(
+            (bucket, child.name)
+            for child in sorted(bucket_path.iterdir())
+            if child.is_dir() and (child / "SKILL.md").is_file()
+        )
+    return found
+
+
+def adapter_target(bucket: str, name: str) -> str:
+    return f"../../skills/{bucket}/{name}"
+
+
+def read_link(path: Path) -> str | None:
+    if path.is_symlink():
+        return Path(path).readlink()
+    return None
+
+
+def resolves_to(link: Path, expected_target: str) -> bool:
+    """Check if a symlink or junction points at the expected target.
+
+    On non-Windows, adapters are symlinks and ``read_link`` suffices.
+    On Windows, ``sync`` may fall back to a directory junction when
+    symlinks are unavailable; ``read_link`` returns ``None`` for those,
+    so resolve the link and compare against the resolved expected target.
+    """
+    if link.is_symlink():
+        return read_link(link) == expected_target
+    if link.is_dir():
+        return link.resolve() == (link.parent / expected_target).resolve()
+    return False
+
+
+def remove_adapter(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir() and not path.is_symlink():
+        msg = f"{path} is a real directory; remove it manually"
+        raise RuntimeError(msg)
+
+
+def create_adapter(link: Path, target: str) -> None:
+    link.parent.mkdir(parents=True, exist_ok=True)
+    remove_adapter(link)
+    abs_target = (link.parent / target).resolve()
+    if not abs_target.is_dir():
+        msg = f"canonical skill missing: {abs_target}"
+        raise RuntimeError(msg)
+
+    if platform.system() == "Windows":
+        _create_windows_link(link, abs_target)
+    else:
+        link.symlink_to(target, target_is_directory=True)
+
+
+def _create_windows_link(link: Path, abs_target: Path) -> None:
+    try:
+        link.symlink_to(abs_target, target_is_directory=True)
+        return
+    except OSError:
+        pass
+
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(abs_target)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def cmd_sync(root: Path) -> int:
+    adapters = (root / ".claude" / "skills", root / ".agents" / "skills")
+
+    for bucket, name in skill_dirs(root):
+        target = adapter_target(bucket, name)
+        for adapter_root in adapters:
+            link = adapter_root / name
+            current = read_link(link)
+            if current == target and link.exists():
+                continue
+            create_adapter(link, target)
+
+    names = sorted({name for _, name in skill_dirs(root)})
+    for adapter_root in adapters:
+        for name in names:
+            (adapter_root / name).exists()
+    return 0
+
+
+def cmd_check_adapters(root: Path) -> int:
+    errors: list[str] = []
+    adapters = (root / ".claude" / "skills", root / ".agents" / "skills")
+
+    for bucket, name in skill_dirs(root):
+        target = adapter_target(bucket, name)
+        for adapter_root in adapters:
+            link = adapter_root / name
+            if resolves_to(link, target):
+                continue
+            current = read_link(link)
+            errors.append(f"{link}: expected adapter to {target!r}, got {current!r}")
+
+    if errors:
+        for _msg in errors:
+            pass
+        return 1
+    return 0
+
+
+def frontmatter_name(skill_md: Path) -> str | None:
+    text = skill_md.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+    if not match:
+        return None
+    for line in match.group(1).splitlines():
+        if line.startswith("name:"):
+            return line.split(":", 1)[1].strip()
+    return None
+
+
+def cmd_validate(root: Path) -> int:
+    errors: list[str] = []
+
+    for bucket in _BUCKETS:
+        bucket_dir = root / "skills" / bucket
+        if not bucket_dir.is_dir():
+            errors.append(f"Missing {bucket_dir}")
+            continue
+
+        for child in sorted(bucket_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            skill_md = child / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+
+            name = child.name
+            fm_name = frontmatter_name(skill_md)
+            if not fm_name:
+                errors.append(f"{skill_md}: missing frontmatter name")
+            elif fm_name != name:
+                errors.append(f"{skill_md}: frontmatter name {fm_name!r} must match directory {name!r}")
+
+            for entry in child.iterdir():
+                if entry.is_symlink():
+                    errors.append(f"{child}: must not contain symlinks (canonical skill content only)")
+                    break
+
+            target = adapter_target(bucket, name)
+            for adapter_root in (root / ".claude" / "skills", root / ".agents" / "skills"):
+                link = adapter_root / name
+                if not link.exists():
+                    errors.append(f"Missing adapter {link} (run: {_SCRIPT} sync)")
+                    continue
+                if not resolves_to(link, target):
+                    errors.append(f"{link}: expected adapter to {target!r}, got {read_link(link)!r}")
+                    continue
+                if not (link / "SKILL.md").is_file():
+                    errors.append(f"Broken adapter {link}")
+
+    if errors:
+        for _msg in errors:
+            pass
+        return 1
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Maintain agent skills: sync .claude/.agents adapters and validate layout.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("sync", help="create or refresh client adapter symlinks")
+    sub.add_parser(
+        "validate",
+        help="check SKILL.md frontmatter, layout, and adapters (no writes)",
+    )
+    sub.add_parser(
+        "check-adapters",
+        help="verify adapter symlinks only (no writes)",
+    )
+    args = parser.parse_args()
+    root = repo_root()
+
+    if args.command == "sync":
+        return cmd_sync(root)
+    if args.command == "validate":
+        return cmd_validate(root)
+    if args.command == "check-adapters":
+        return cmd_check_adapters(root)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/skills/agent_skills.py
+++ b/.github/scripts/skills/agent_skills.py
@@ -7,9 +7,11 @@
 from __future__ import annotations
 
 import argparse
+import os
 import platform
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 _SCRIPT = "python3 .github/scripts/skills/agent_skills.py"
@@ -28,11 +30,9 @@ def skill_dirs(root: Path) -> list[tuple[str, str]]:
         bucket_path = root / "skills" / bucket
         if not bucket_path.is_dir():
             continue
-        found.extend(
-            (bucket, child.name)
-            for child in sorted(bucket_path.iterdir())
-            if child.is_dir() and (child / "SKILL.md").is_file()
-        )
+        for child in sorted(bucket_path.iterdir()):
+            if child.is_dir() and (child / "SKILL.md").is_file():
+                found.append((bucket, child.name))
     return found
 
 
@@ -42,7 +42,7 @@ def adapter_target(bucket: str, name: str) -> str:
 
 def read_link(path: Path) -> str | None:
     if path.is_symlink():
-        return Path(path).readlink()
+        return os.readlink(path)
     return None
 
 
@@ -53,6 +53,9 @@ def resolves_to(link: Path, expected_target: str) -> bool:
     On Windows, ``sync`` may fall back to a directory junction when
     symlinks are unavailable; ``read_link`` returns ``None`` for those,
     so resolve the link and compare against the resolved expected target.
+
+    Returns:
+        True if the adapter resolves to the expected relative target.
     """
     if link.is_symlink():
         return read_link(link) == expected_target
@@ -65,8 +68,7 @@ def remove_adapter(path: Path) -> None:
     if path.is_symlink() or path.is_file():
         path.unlink()
     elif path.is_dir() and not path.is_symlink():
-        msg = f"{path} is a real directory; remove it manually"
-        raise RuntimeError(msg)
+        raise RuntimeError(f"{path} is a real directory; remove it manually")
 
 
 def create_adapter(link: Path, target: str) -> None:
@@ -74,8 +76,7 @@ def create_adapter(link: Path, target: str) -> None:
     remove_adapter(link)
     abs_target = (link.parent / target).resolve()
     if not abs_target.is_dir():
-        msg = f"canonical skill missing: {abs_target}"
-        raise RuntimeError(msg)
+        raise RuntimeError(f"canonical skill missing: {abs_target}")
 
     if platform.system() == "Windows":
         _create_windows_link(link, abs_target)
@@ -86,16 +87,13 @@ def create_adapter(link: Path, target: str) -> None:
 def _create_windows_link(link: Path, abs_target: Path) -> None:
     try:
         link.symlink_to(abs_target, target_is_directory=True)
-        return
     except OSError:
-        pass
-
-    subprocess.run(
-        ["cmd", "/c", "mklink", "/J", str(link), str(abs_target)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+        subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(abs_target)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
 
 
 def cmd_sync(root: Path) -> int:
@@ -112,8 +110,10 @@ def cmd_sync(root: Path) -> int:
 
     names = sorted({name for _, name in skill_dirs(root)})
     for adapter_root in adapters:
+        print(f"{adapter_root.relative_to(root)}:")
         for name in names:
-            (adapter_root / name).exists()
+            if (adapter_root / name).exists():
+                print(f"  {name}")
     return 0
 
 
@@ -131,8 +131,9 @@ def cmd_check_adapters(root: Path) -> int:
             errors.append(f"{link}: expected adapter to {target!r}, got {current!r}")
 
     if errors:
-        for _msg in errors:
-            pass
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        print(f"Run: {_SCRIPT} sync", file=sys.stderr)
         return 1
     return 0
 
@@ -169,7 +170,9 @@ def cmd_validate(root: Path) -> int:
             if not fm_name:
                 errors.append(f"{skill_md}: missing frontmatter name")
             elif fm_name != name:
-                errors.append(f"{skill_md}: frontmatter name {fm_name!r} must match directory {name!r}")
+                errors.append(
+                    f"{skill_md}: frontmatter name {fm_name!r} must match directory {name!r}"
+                )
 
             for entry in child.iterdir():
                 if entry.is_symlink():
@@ -183,15 +186,19 @@ def cmd_validate(root: Path) -> int:
                     errors.append(f"Missing adapter {link} (run: {_SCRIPT} sync)")
                     continue
                 if not resolves_to(link, target):
-                    errors.append(f"{link}: expected adapter to {target!r}, got {read_link(link)!r}")
+                    errors.append(
+                        f"{link}: expected adapter to {target!r}, got {read_link(link)!r}"
+                    )
                     continue
                 if not (link / "SKILL.md").is_file():
                     errors.append(f"Broken adapter {link}")
 
     if errors:
-        for _msg in errors:
-            pass
+        for msg in errors:
+            print(f"::error::{msg}", file=sys.stderr)
+        print(f"Skills validation failed with {len(errors)} error(s).", file=sys.stderr)
         return 1
+    print("Skills validation passed.")
     return 0
 
 

--- a/.github/scripts/skills/agent_skills.py
+++ b/.github/scripts/skills/agent_skills.py
@@ -103,8 +103,7 @@ def cmd_sync(root: Path) -> int:
         target = adapter_target(bucket, name)
         for adapter_root in adapters:
             link = adapter_root / name
-            current = read_link(link)
-            if current == target and link.exists():
+            if resolves_to(link, target) and link.exists():
                 continue
             create_adapter(link, target)
 

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -1,0 +1,41 @@
+name: Skills
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "skills/**"
+      - ".claude/skills/**"
+      - ".agents/skills/**"
+      - ".github/scripts/skills/**"
+      - ".github/workflows/skills.yml"
+  pull_request:
+    paths:
+      - "skills/**"
+      - ".claude/skills/**"
+      - ".agents/skills/**"
+      - ".github/scripts/skills/**"
+      - ".github/workflows/skills.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: skills-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate skills layout
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Validate skills and adapter symlinks
+        run: python3 .github/scripts/skills/agent_skills.py validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,21 @@ repos:
     hooks:
       - id: gitleaks
 
+  - repo: local
+    hooks:
+      - id: agent-skills-sync
+        name: sync agent skill adapters
+        entry: python3 .github/scripts/skills/agent_skills.py sync
+        language: system
+        pass_filenames: false
+        files: ^skills/
+      - id: agent-skills-validate
+        name: validate agent skills layout
+        entry: python3 .github/scripts/skills/agent_skills.py validate
+        language: system
+        pass_filenames: false
+        files: ^skills/
+
   # ========================================================================== #
   # DOCUMENTATION FORMATTING (root-level docs)                                 #
   # ========================================================================== #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Physical AI Runtime Agent Guide
+
+Physical AI Runtime is the deployment-side repo for the Physical AI workflow: load policies exported from [Physical AI Studio](https://github.com/open-edge-platform/physical-ai-studio), run inference, and drive robots with cameras and a control loop.
+
+## Repository Layout
+
+- `src/physicalai/inference/`: `InferenceModel`, manifests, adapters, preprocessors/postprocessors, runners.
+- `src/physicalai/capture/`: unified camera API, discovery, transport.
+- `src/physicalai/runtime/`: `PolicyRuntime`, execution modes, action queues, callbacks.
+- `src/physicalai/robot/`: robot protocol and hardware integrations.
+- `src/physicalai/cli/`: `physicalai` / `pai` host CLI (`run` and entry-point subcommands from other packages).
+- `src/physicalai/benchmark/`: inference performance tooling.
+- `skills/inference/`, `skills/capture/`, `skills/runtime/`: agent skills (canonical). Adapter symlinks under `.claude/skills/` and `.agents/skills/` are committed so clones work out of the box. See `skills/README.md`.
+- `docs/`: user and contributor documentation (MkDocs).
+
+## Setup
+
+- Run `uv sync` from the repo root.
+- Install optional extras as needed (`physicalai[realsense]`, `[basler]`, `[so101]`, `[trossen]`, `[capture]`, `[transport]`, etc.) — see `pyproject.toml`.
+
+## Build, Test, Lint
+
+- Run tests with `uv run pytest` from the repo root.
+- Run repo hooks with `prek run --all-files`.
+- Type-check with `pyrefly check` (also run via pre-commit).
+
+## Cross-Repo Rules
+
+- Runtime owns the `physicalai` executable and `pai` alias. Studio contributes training/export subcommands through `physicalai.cli.subcommands` entry points.
+- Runtime-owned CLI surface includes `physicalai run` (policy on hardware from config).
+- Studio owns export; Runtime consumes exported artifacts via `InferenceModel` / `InferenceModel.from_pretrained(...)`.
+- Keep customer-facing instructions stable and avoid exposing internal scaffolding unless the user is contributing to the repo.
+
+## Contribution Notes
+
+- Use Conventional Commits for PR titles and commits.
+- Sign commits when committing changes.
+- Follow `docs/development/coding-standards.md` for repo-wide coding standards.
+- Follow `docs/development/security.md` before changing `src/physicalai/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code Instructions
+
+Refer to [AGENTS.md](./AGENTS.md) for repository guidance, build/test commands, and agent instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,11 @@ Write clear, concise messages. Reference issue numbers when applicable.
 - For security vulnerabilities, follow [SECURITY.md](./SECURITY.md) and do not open a public issue.
 - Participate according to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
+## Agent and Copilot Guidance
+
+- [AGENTS.md](./AGENTS.md) — canonical, vendor-neutral repo guide for humans and coding agents.
+- [skills/README.md](./skills/README.md) — repo-specific agent skills and authoring rules.
+
 ## Coding Standards
 
 See [.github/copilot-instructions.md](./.github/copilot-instructions.md) for detailed coding standards, style guides, and best practices.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,0 +1,6 @@
+# Development Docs
+
+Repository-wide contributor guidance.
+
+- [Coding Standards](coding-standards.md) — coding, writing, and testing standards for all contributors and agents.
+- [Security Rules](security.md) — security requirements for `src/physicalai/`.

--- a/docs/development/coding-standards.md
+++ b/docs/development/coding-standards.md
@@ -1,0 +1,36 @@
+# Coding Standards
+
+These standards apply to contributors and agents across the repository.
+
+## Python
+
+- Use `uv` for Python dependency and test commands; do not use `pip` directly in contributor docs or automation.
+- Add type hints to functions.
+- Prefer `pathlib.Path` over string path manipulation.
+- Use `ruff` for linting and formatting, and address all warnings.
+- Use Google-style docstrings for public Python APIs.
+- Use `loguru` logger in library code; avoid `print()` except in CLI output paths.
+- Prefer dataclasses or Pydantic models for structured data.
+
+## Writing Style
+
+This applies to comments, docstrings, commit messages, and PR descriptions.
+
+- State the point first.
+- Use active voice.
+- Avoid hedging (`may`, `might`, `could potentially`) unless uncertainty is real and relevant.
+- Cut filler such as "It is important to note that", "Furthermore", and "Moreover".
+- Comments explain why, not what.
+- Use Conventional Commits for commit messages and PR titles (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`).
+
+## Testing
+
+- Run Python tests with `uv run pytest` from the repo root.
+- Keep Python tests under `tests/unit/` (and integration tests under `tests/integration/` when added).
+- Mock external services and hardware unless a test is explicitly marked as integration or download-dependent.
+
+## AI and ML (runtime)
+
+- Lazy-load heavy optional dependencies (camera SDKs, robot drivers).
+- Account for inference latency and memory when changing adapters, preprocessors, or the control loop.
+- Do not add training-only dependencies to the core runtime install path.

--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -1,0 +1,31 @@
+# Runtime Security Rules
+
+These rules apply when writing, editing, or reviewing code under `src/physicalai/`.
+
+1. No `# nosec` / `# nosemgrep` without a justification comment explaining why the suppression is safe.
+
+2. No hardcoded secrets. No API keys, tokens, passwords, or credentials in any source file, test, config, or commit message.
+
+3. No path traversal. For user-supplied file paths (export directories, config paths, cache paths): resolve and verify containment using `pathlib.Path`. Never use `assert` for security checks. Correct pattern:
+
+   ```python
+   resolved = (base_dir / user_path).resolve()
+   if not resolved.is_relative_to(base_dir.resolve()):
+       raise ValueError(f"Path escapes base directory: {user_path!r}")
+   ```
+
+4. No arbitrary `class_path` import from untrusted manifests or YAML. `instantiate_component` in `inference/component_factory.py` resolves `class_path` via `ComponentRegistry` and `importlib`. Only register trusted short names; treat manifest `class_path` values as untrusted unless the export directory is trusted. Prefer registered `type` names for built-ins.
+
+5. Enforce component nesting limits. `_MAX_COMPONENT_DEPTH` in `component_factory.py` caps recursive manifest/YAML instantiation — do not raise or bypass without a security review.
+
+6. Never use `pickle`, `eval()`, `exec()`, `joblib`, `dill`, or `cloudpickle` on untrusted data. Prefer `json` for structured metadata, `safetensors` for weights, and `numpy.load(..., allow_pickle=False)` for arrays.
+
+7. Avoid `trust_remote_code=True` in Hugging Face loaders unless the repo id is a hardcoded first-party constant, the need is documented, and `revision=` is pinned to a commit SHA.
+
+8. Hugging Face Hub downloads (`inference/utils/_hub.py`): pin `revision=` to a commit SHA for reproducible loads when security matters; never log `HF_TOKEN` or tokens from the environment.
+
+9. Validate `manifest.json` and Hub-sourced JSON fields against expected types before use. Raise on unexpected errors in model loading and manifest parsing — do not silently fall back to insecure defaults.
+
+10. Prefer `.safetensors` over `.ckpt`/`.pt` for processor stats and weights when adding new artifact types.
+
+11. jsonargparse `parser.instantiate` in `cli/run.py` and runtime config loading can construct arbitrary registered classes from YAML — document new `class_path` targets and avoid exposing dangerous constructors through config without validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ exclude = [
     "notebooks",
 ]
 src = ["src", "tests"]
-extend-exclude = ["docs", "examples", "tests", "notebooks"]
+extend-exclude = ["docs", "examples", "tests", "notebooks", ".github/scripts"]
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -152,17 +152,6 @@ unfixable = []
 "src/physicalai/cli/*.py" = ["INP001"]
 "src/physicalai/capture/transport/_header.py" = ["RUF012"]
 "src/physicalai/capture/transport/_publisher.py" = ["S603"]
-".github/scripts/skills/agent_skills.py" = [
-    "D103",
-    "DOC201",
-    "TRY300",
-    "S404",
-    "S603",
-    "S607",
-    "C901",
-    "PLR0912",
-    "EXE001",
-]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,17 @@ unfixable = []
 "src/physicalai/cli/*.py" = ["INP001"]
 "src/physicalai/capture/transport/_header.py" = ["RUF012"]
 "src/physicalai/capture/transport/_publisher.py" = ["S603"]
+".github/scripts/skills/agent_skills.py" = [
+    "D103",
+    "DOC201",
+    "TRY300",
+    "S404",
+    "S603",
+    "S607",
+    "C901",
+    "PLR0912",
+    "EXE001",
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,11 +4,11 @@ Canonical, repo-specific agent skills for Physical AI Runtime. Skills are groupe
 
 ## Buckets
 
-| Bucket        | Path                       | Scope                                                                                                     |
-| ------------- | -------------------------- | --------------------------------------------------------------------------------------------------------- |
-| **Inference** | [`inference/`](inference/) | `src/physicalai/inference/`: `InferenceModel`, manifests, adapters, preprocessors/postprocessors, runners |
-| **Capture**   | [`capture/`](capture/)     | `src/physicalai/capture/`: cameras, discovery, transport                                                  |
-| **Runtime**   | [`runtime/`](runtime/)     | `src/physicalai/runtime/`, `robot/`, `cli/`: control loop, robots, `physicalai run`                       |
+| Bucket        | Path                       | Scope                                                                                                             |
+| ------------- | -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Inference** | [`inference/`](inference/) | `src/physicalai/inference/`: `InferenceModel`, manifests, adapters, preprocessors/postprocessors, runners         |
+| **Capture**   | [`capture/`](capture/)     | `src/physicalai/capture/`: cameras, discovery, transport                                                          |
+| **Runtime**   | [`runtime/`](runtime/)     | `src/physicalai/runtime/`, `src/physicalai/robot/`, `src/physicalai/cli/`: control loop, robots, `physicalai run` |
 
 Each bucket has its own skill list and [`EVALUATION.md`](inference/EVALUATION.md) scenarios.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,104 @@
+# Physical AI Runtime Agent Skills
+
+Canonical, repo-specific agent skills for Physical AI Runtime. Skills are grouped by modular subpackage so agents load the right paths and commands.
+
+## Buckets
+
+| Bucket        | Path                       | Scope                                                                                                     |
+| ------------- | -------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Inference** | [`inference/`](inference/) | `src/physicalai/inference/`: `InferenceModel`, manifests, adapters, preprocessors/postprocessors, runners |
+| **Capture**   | [`capture/`](capture/)     | `src/physicalai/capture/`: cameras, discovery, transport                                                  |
+| **Runtime**   | [`runtime/`](runtime/)     | `src/physicalai/runtime/`, `robot/`, `cli/`: control loop, robots, `physicalai run`                       |
+
+Each bucket has its own skill list and [`EVALUATION.md`](inference/EVALUATION.md) scenarios.
+
+## Layout
+
+```text
+skills/
+├── README.md                 # this file — global authoring rules
+├── inference/
+│   ├── README.md
+│   ├── EVALUATION.md
+│   └── <skill-name>/
+│       ├── SKILL.md
+│       └── references/
+├── capture/
+│   ├── README.md
+│   ├── EVALUATION.md
+│   └── <skill-name>/
+└── runtime/
+    ├── README.md
+    ├── EVALUATION.md
+    └── <skill-name>/
+```
+
+Client adapters are **committed symlinks** so a fresh clone works for agents (no setup step):
+
+- `.claude/skills/<name>` → `../../skills/<bucket>/<name>`
+- `.agents/skills/<name>` → `../../skills/<bucket>/<name>`
+
+When you add or rename a skill, run `python3 .github/scripts/skills/agent_skills.py sync` and commit the updated symlinks. Pre-commit runs `sync` then `validate` when `skills/` changes. **CI only runs `validate`** on what is in the PR (it does not regenerate symlinks). GitHub may show `\ No newline at end of file` on symlink diffs; that is normal and harmless.
+
+**Windows:** enable [Developer Mode](https://learn.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development) or clone with `git config core.symlinks true` so Git checks out symlinks. If symlink creation fails, `agent_skills.py sync` falls back to a directory junction for local use.
+
+## Authoring standard
+
+These skills follow the open [Agent Skills](https://agentskills.io) format (originated by Anthropic, adopted by Claude Code, opencode, Codex, Gemini CLI, Cursor, and others). Write to the **portable core** so a skill works across every agent, not just one.
+
+### Portability rules (non-negotiable)
+
+- **Frontmatter = the portable subset only:** `name`, `description`, and optionally `license`. These three are understood everywhere.
+- **Do not rely on vendor-only fields for behavior.** `disable-model-invocation` (Claude Code's "user-invoked" switch) is ignored by opencode/Codex/Gemini — never make a skill's correctness depend on it. Default to **model-invoked** skills.
+- Put any client-specific hints in a `metadata:` map (opencode reads it; others ignore it), not in top-level fields.
+- Use forward-slash paths; no Windows backslashes.
+
+### `name`
+
+- Lowercase, hyphenated, matches the directory name, regex `^[a-z0-9]+(-[a-z0-9]+)*$`.
+- Prefix with the bucket id: `inference-`, `capture-`, or `runtime-`.
+- Prefer gerund/verb phrasing (`inference-loading-exported-policies`, `capture-adding-a-camera-backend`).
+- Must not contain the reserved words `anthropic` or `claude`.
+
+### `description` (highest-leverage field)
+
+This is what an agent matches against to decide whether to load the skill. Get it right.
+
+- **Third person**, always: "Loads and validates…", never "I can…" / "You can…".
+- State **what it does and when to use it**, with concrete triggers (CLI names, class names, file paths, backends).
+- **One trigger per distinct branch** — collapse synonyms. Keep it under 1024 characters.
+
+### Body
+
+- **Be concise; assume the model is smart.** Only add what it can't infer. Every loaded token competes with real context. Keep `SKILL.md` well under 500 lines.
+- **Ground every claim in real paths** for that bucket (`src/physicalai/...`) and real commands. No invented flags.
+- **Numbered workflow steps, each ending in a checkable completion criterion** ("Done when: …") so the agent can tell done from not-done and doesn't stop early.
+- **Match freedom to fragility:** high freedom (prose) for open tasks; low freedom ("run exactly this, don't add flags") for fragile ops like hardware or manifest loading.
+- **Feedback loops** for quality-critical work: run → validate → fix → repeat, with the exact command.
+- Consistent terminology; no time-sensitive text (use a collapsed "old patterns" section if needed).
+- **Progressive disclosure:** push long detail into `references/*.md`, linked **one level deep** from `SKILL.md`. Add a table of contents to any reference file over ~100 lines.
+
+### Before you ship
+
+- Description has both _what_ and _when_, third person, distinct triggers.
+- Every path/command verified against the current tree.
+- Steps have checkable completion criteria.
+- References are one level deep.
+- Runs offline by default; tests needing downloads are marked `requires_download`.
+- Pass at least three scenarios in the bucket's `EVALUATION.md`.
+
+## Add a new skill
+
+```bash
+BUCKET=inference   # or capture, runtime
+NAME=inference-my-workflow
+mkdir -p "skills/$BUCKET/$NAME"
+$EDITOR "skills/$BUCKET/$NAME/SKILL.md"
+python3 .github/scripts/skills/agent_skills.py sync
+```
+
+Then dry-run the workflow in the skill end-to-end and fix any step where an agent could stall or guess.
+
+## Org skills catalog (`open-edge-platform/skills`)
+
+Runtime is the **source of truth** under `skills/`. The org [`open-edge-platform/skills`](https://github.com/open-edge-platform/skills) repo pulls from product repos on its own schedule. **Do not** open PRs from this repo into that catalog directly; register or update this product in the skills-repo automation instead.

--- a/skills/capture/EVALUATION.md
+++ b/skills/capture/EVALUATION.md
@@ -13,11 +13,11 @@ Expected rubric per scenario:
 
 ### Scenario 1: Scaffold a new USB camera variant
 
-> "Add a minimal UVC-like camera under `capture/cameras/` for a new V4L2 device path API. Mirror the existing UVCCamera layout and add a unit test with fakes."
+> "Add a minimal UVC-like camera under `src/physicalai/capture/cameras/` for a new V4L2 device path API. Mirror the existing UVCCamera layout and add a unit test with fakes."
 
 Expected behavior:
 
-- References `capture/cameras/uvc/` structure.
+- References `src/physicalai/capture/cameras/uvc/` structure.
 - Uses `tests/unit/capture/fake.py` or conftest patterns.
 - Runs `uv run pytest tests/unit/capture -k <name>`.
 
@@ -27,7 +27,7 @@ Expected behavior:
 
 Expected behavior:
 
-- Updates `factory.py` and `pyproject.toml` optional dependency.
+- Updates `src/physicalai/capture/factory.py` and `pyproject.toml` optional dependency.
 - Clear ImportError/message without the extra.
 
 ### Scenario 3: SharedCamera documentation

--- a/skills/capture/EVALUATION.md
+++ b/skills/capture/EVALUATION.md
@@ -1,0 +1,40 @@
+# Skill Evaluation Scenarios
+
+Use these prompts to test whether an agent correctly invokes and follows the capture skill. Run from the repo root.
+
+Expected rubric per scenario:
+
+- **Activates the right skill** — `capture-adding-a-camera-backend`.
+- **Uses real paths** — `src/physicalai/capture/...`, `tests/unit/capture/`.
+- **Follows workflow steps** with Done when criteria.
+- **Produces a checkable artifact** — test run or new module skeleton.
+
+## `capture-adding-a-camera-backend`
+
+### Scenario 1: Scaffold a new USB camera variant
+
+> "Add a minimal UVC-like camera under `capture/cameras/` for a new V4L2 device path API. Mirror the existing UVCCamera layout and add a unit test with fakes."
+
+Expected behavior:
+
+- References `capture/cameras/uvc/` structure.
+- Uses `tests/unit/capture/fake.py` or conftest patterns.
+- Runs `uv run pytest tests/unit/capture -k <name>`.
+
+### Scenario 2: Wire factory and optional extra
+
+> "Register camera type `myvendor` in `create_camera` behind optional extra `physicalai[myvendor]` with lazy import."
+
+Expected behavior:
+
+- Updates `factory.py` and `pyproject.toml` optional dependency.
+- Clear ImportError/message without the extra.
+
+### Scenario 3: SharedCamera documentation
+
+> "User wants two processes to read the same RealSense. What capture API and extra should they use?"
+
+Expected behavior:
+
+- Mentions `create_camera(..., shared=True)`, `SharedCamera`, `transport` / `capture` extra, iceoryx2 pin in pyproject.
+- Does not claim shared mode works without the extra.

--- a/skills/capture/README.md
+++ b/skills/capture/README.md
@@ -6,8 +6,8 @@ Run commands from the repo root (`uv run pytest tests/unit/capture/...`).
 
 ## Skills
 
-| Skill | Covers |
-| ----- | ------ |
+| Skill                             | Covers                                                                                          |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `capture-adding-a-camera-backend` | New camera types, `create_camera`, `Camera` base class, optional extras, unit tests with fakes. |
 
 New capture skills must pass at least three scenarios in [`EVALUATION.md`](EVALUATION.md).

--- a/skills/capture/README.md
+++ b/skills/capture/README.md
@@ -1,0 +1,24 @@
+# Capture agent skills
+
+Skills for `src/physicalai/capture/`: camera implementations, discovery, frames, and shared transport.
+
+Run commands from the repo root (`uv run pytest tests/unit/capture/...`).
+
+## Skills
+
+| Skill | Covers |
+| ----- | ------ |
+| `capture-adding-a-camera-backend` | New camera types, `create_camera`, `Camera` base class, optional extras, unit tests with fakes. |
+
+New capture skills must pass at least three scenarios in [`EVALUATION.md`](EVALUATION.md).
+
+## Add a capture skill
+
+```bash
+NAME=capture-my-workflow
+mkdir -p "skills/capture/$NAME"
+$EDITOR "skills/capture/$NAME/SKILL.md"
+python3 .github/scripts/skills/agent_skills.py sync
+```
+
+Global authoring rules: [`../README.md`](../README.md).

--- a/skills/capture/capture-adding-a-camera-backend/SKILL.md
+++ b/skills/capture/capture-adding-a-camera-backend/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: capture-adding-a-camera-backend
-description: Adds or modifies a camera backend under physicalai.capture. Use when implementing a new Camera type, extending create_camera in capture/factory.py, discovery helpers, optional pip extras for vendor SDKs, SharedCamera transport, or tests under tests/unit/capture with fake devices.
+description: Adds or modifies a camera backend under physicalai.capture. Use when implementing a new Camera type, extending create_camera in src/physicalai/capture/factory.py, discovery helpers, optional pip extras for vendor SDKs, SharedCamera transport, or tests under tests/unit/capture with fake devices.
 license: Apache-2.0
 ---
 
 # Adding a Camera Backend
 
-Cameras implement the `Camera` interface in `src/physicalai/capture/camera.py`. Factory entry: `create_camera()` in `capture/factory.py` maps lowercase type names (`uvc`, `realsense`, `basler`, …) to implementations. Reference layouts: `capture/cameras/uvc/`, `realsense/`, `basler/`.
+Cameras implement the `Camera` interface in `src/physicalai/capture/camera.py`. Factory entry: `create_camera()` in `src/physicalai/capture/factory.py` maps lowercase type names (`uvc`, `realsense`, `basler`, …) to implementations. Reference layouts: `src/physicalai/capture/cameras/uvc/`, `src/physicalai/capture/cameras/realsense/`, `src/physicalai/capture/cameras/basler/`.
 
 ## Workflow
 
 1. **Pick a reference backend** closest to the new hardware (UVC for USB video, RealSense for RGB-D, Basler for GenICam industrial).
    - Done when: you can list which modules to mirror (`_camera.py`, `_discover.py`, `__init__.py` exports).
-2. **Implement `Camera`**: `connect()`, `disconnect()`, `read()` / `read_latest()`, context manager support, monotonic timestamps on `Frame` (`capture/frame.py`).
+2. **Implement `Camera`**: `connect()`, `disconnect()`, `read()` / `read_latest()`, context manager support, monotonic timestamps on `Frame` (`src/physicalai/capture/frame.py`).
    - Done when: fake or mocked device tests can exercise connect/read without hardware.
-3. **Wire discovery** if the device is enumerable — add helpers under `capture/discovery.py` or backend-specific `_discover.py`.
-4. **Register the type** in `factory.py` and export public class from `capture/__init__.py` when user-facing.
+3. **Wire discovery** if the device is enumerable — add helpers under `src/physicalai/capture/discovery.py` or backend-specific `_discover.py`.
+4. **Register the type** in `src/physicalai/capture/factory.py` and export public class from `src/physicalai/capture/__init__.py` when user-facing.
 5. **Optional extra** in `pyproject.toml` for vendor SDKs; lazy-import inside the camera module so `pip install physicalai` stays light.
    - Done when: `import physicalai.capture` works without the extra; importing the camera class fails with a clear message if the extra is missing.
 6. **Tests** in `tests/unit/capture/` using existing fakes (`tests/unit/capture/fake.py`, `conftest.py` patterns).

--- a/skills/capture/capture-adding-a-camera-backend/SKILL.md
+++ b/skills/capture/capture-adding-a-camera-backend/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: capture-adding-a-camera-backend
+description: Adds or modifies a camera backend under physicalai.capture. Use when implementing a new Camera type, extending create_camera in capture/factory.py, discovery helpers, optional pip extras for vendor SDKs, SharedCamera transport, or tests under tests/unit/capture with fake devices.
+license: Apache-2.0
+---
+
+# Adding a Camera Backend
+
+Cameras implement the `Camera` interface in `src/physicalai/capture/camera.py`. Factory entry: `create_camera()` in `capture/factory.py` maps lowercase type names (`uvc`, `realsense`, `basler`, …) to implementations. Reference layouts: `capture/cameras/uvc/`, `realsense/`, `basler/`.
+
+## Workflow
+
+1. **Pick a reference backend** closest to the new hardware (UVC for USB video, RealSense for RGB-D, Basler for GenICam industrial).
+   - Done when: you can list which modules to mirror (`_camera.py`, `_discover.py`, `__init__.py` exports).
+2. **Implement `Camera`**: `connect()`, `disconnect()`, `read()` / `read_latest()`, context manager support, monotonic timestamps on `Frame` (`capture/frame.py`).
+   - Done when: fake or mocked device tests can exercise connect/read without hardware.
+3. **Wire discovery** if the device is enumerable — add helpers under `capture/discovery.py` or backend-specific `_discover.py`.
+4. **Register the type** in `factory.py` and export public class from `capture/__init__.py` when user-facing.
+5. **Optional extra** in `pyproject.toml` for vendor SDKs; lazy-import inside the camera module so `pip install physicalai` stays light.
+   - Done when: `import physicalai.capture` works without the extra; importing the camera class fails with a clear message if the extra is missing.
+6. **Tests** in `tests/unit/capture/` using existing fakes (`tests/unit/capture/fake.py`, `conftest.py` patterns).
+   - Done when: `uv run pytest tests/unit/capture -k <backend>` passes.
+
+## Shared transport
+
+For multi-process access, `create_camera(..., shared=True)` wraps with `SharedCamera` (`physicalai[capture]` / `transport` extra, iceoryx2). Only document shared mode when the transport extra is installed.
+
+## Required checks
+
+- `CameraType` or factory string is documented in `docs/reference/camera-api.md` when user-visible.
+- Frame shapes and dtypes match README examples (RGB `(H, W, 3)`).
+- No blocking discovery at import time.
+
+## Verify
+
+```bash
+uv run pytest tests/unit/capture -q
+prek run --all-files
+```

--- a/skills/inference/EVALUATION.md
+++ b/skills/inference/EVALUATION.md
@@ -38,7 +38,7 @@ Expected behavior:
 
 Expected behavior:
 
-- References `inference/adapters/onnx.py` and `onnxruntime` dependency.
+- References `src/physicalai/inference/adapters/onnx.py` and `onnxruntime` dependency.
 - Does not invent unsupported backends.
 
 ## `inference-configuring-inference-pipeline`
@@ -59,7 +59,7 @@ Expected behavior:
 
 Expected behavior:
 
-- Edits `component_factory.py` registry without breaking `_MAX_COMPONENT_DEPTH`.
+- Edits `src/physicalai/inference/component_factory.py` registry without breaking `_MAX_COMPONENT_DEPTH`.
 - Adds test under `tests/unit/inference/preprocessors/`.
 
 ### Scenario 6: Fix processor order bug

--- a/skills/inference/EVALUATION.md
+++ b/skills/inference/EVALUATION.md
@@ -1,0 +1,72 @@
+# Skill Evaluation Scenarios
+
+Use these prompts to test whether an agent correctly invokes and follows each inference skill. Run the agent from the repo root with no extra hints beyond the prompt.
+
+Expected rubric per scenario:
+
+- **Activates the right skill** — loaded `SKILL.md` matches the topic.
+- **Uses real paths and commands** — references `src/physicalai/inference/...`, `uv run pytest tests/unit/inference/...` as documented.
+- **Follows the workflow checklist** — does not skip Required checks / validation loop steps.
+- **Produces a checkable artifact** — a command run, a file written, or a test result.
+
+## `inference-loading-exported-policies`
+
+### Scenario 1: Load a local OpenVINO export
+
+> "Load the policy in `./exports/act_policy` with InferenceModel and run one `select_action` on a fake observation dict. Use auto-detection if possible."
+
+Expected behavior:
+
+- Uses `InferenceModel("./exports/act_policy")` or explicit `backend="openvino"` only if needed.
+- Calls `reset()` then `select_action`.
+- Does not implement a custom robot loop.
+- Points to manifest/adapter paths under `src/physicalai/inference/`.
+
+### Scenario 2: Hub load with pinned revision
+
+> "Load `OpenVINO/act-fp16-ov` from the Hub with a pinned commit SHA and explain what files are required in the snapshot."
+
+Expected behavior:
+
+- Uses `InferenceModel.from_pretrained(..., revision="<sha>")`.
+- Mentions `manifest.json` and model artifacts per export-load contract.
+- Marks full Hub test as `requires_download` if it cannot run offline.
+
+### Scenario 3: Debug missing backend dependency
+
+> "InferenceModel fails when loading a `.onnx` file on a machine without ONNX Runtime. What should the error path and docs say?"
+
+Expected behavior:
+
+- References `inference/adapters/onnx.py` and `onnxruntime` dependency.
+- Does not invent unsupported backends.
+
+## `inference-configuring-inference-pipeline`
+
+### Scenario 4: Add StatsNormalizer to a manifest
+
+> "Extend a manifest YAML to normalize observations using `stats.safetensors` in the export directory. Use the registered pattern from the how-to docs."
+
+Expected behavior:
+
+- Shows preprocessor spec with `type` or `class_path: physicalai.inference.preprocessors.StatsNormalizer`.
+- Mentions `resolve_artifact` / artifact relative paths.
+- Suggests `uv run pytest tests/unit/inference/preprocessors -q`.
+
+### Scenario 5: Register a short type name
+
+> "We added a new preprocessor class. Register a manifest-friendly short name in component_factory and add a unit test."
+
+Expected behavior:
+
+- Edits `component_factory.py` registry without breaking `_MAX_COMPONENT_DEPTH`.
+- Adds test under `tests/unit/inference/preprocessors/`.
+
+### Scenario 6: Fix processor order bug
+
+> "Actions are denormalized before the runner runs. Fix the manifest pipeline order and verify with tests."
+
+Expected behavior:
+
+- Correct order: preprocessors → runner → postprocessors.
+- Runs manifest or model unit tests.

--- a/skills/inference/README.md
+++ b/skills/inference/README.md
@@ -1,0 +1,25 @@
+# Inference agent skills
+
+Skills for `src/physicalai/inference/`: loading exported policies, manifests, adapters, and the pre/post inference pipeline.
+
+Run commands from the repo root unless noted otherwise (`uv sync`, `uv run pytest tests/unit/inference/...`).
+
+## Skills
+
+| Skill | Covers |
+| ----- | ------ |
+| `inference-loading-exported-policies` | `InferenceModel`, `Manifest`, Hub loads, ONNX/OpenVINO adapters, export/load contract (consumer side). |
+| `inference-configuring-inference-pipeline` | Preprocessors, postprocessors, `ComponentRegistry`, `instantiate_component`, manifest `type` vs `class_path`. |
+
+New inference skills must pass at least three scenarios in [`EVALUATION.md`](EVALUATION.md).
+
+## Add an inference skill
+
+```bash
+NAME=inference-my-workflow
+mkdir -p "skills/inference/$NAME"
+$EDITOR "skills/inference/$NAME/SKILL.md"
+python3 .github/scripts/skills/agent_skills.py sync
+```
+
+Global authoring rules: [`../README.md`](../README.md).

--- a/skills/inference/README.md
+++ b/skills/inference/README.md
@@ -6,9 +6,9 @@ Run commands from the repo root unless noted otherwise (`uv sync`, `uv run pytes
 
 ## Skills
 
-| Skill | Covers |
-| ----- | ------ |
-| `inference-loading-exported-policies` | `InferenceModel`, `Manifest`, Hub loads, ONNX/OpenVINO adapters, export/load contract (consumer side). |
+| Skill                                      | Covers                                                                                                        |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `inference-loading-exported-policies`      | `InferenceModel`, `Manifest`, Hub loads, ONNX/OpenVINO adapters, export/load contract (consumer side).        |
 | `inference-configuring-inference-pipeline` | Preprocessors, postprocessors, `ComponentRegistry`, `instantiate_component`, manifest `type` vs `class_path`. |
 
 New inference skills must pass at least three scenarios in [`EVALUATION.md`](EVALUATION.md).

--- a/skills/inference/inference-configuring-inference-pipeline/SKILL.md
+++ b/skills/inference/inference-configuring-inference-pipeline/SKILL.md
@@ -20,13 +20,16 @@ Core code:
    - Done when: you know whether specs use `type` (registry short name) or `class_path`.
 2. **Prefer `type` for built-ins** registered in `component_factory` (e.g. normalize/denormalize patterns in docs).
 3. **Use `class_path` + `init_args`** for explicit classes:
+
    ```yaml
    preprocessors:
      - class_path: physicalai.inference.preprocessors.StatsNormalizer
        init_args:
          artifact: stats.safetensors
    ```
+
    - Done when: `init_args` paths resolve relative to the export directory via `resolve_artifact`.
+
 4. **Add a new built-in processor**:
    - Implement subclass of `Preprocessor` / `Postprocessor` in the appropriate package.
    - Register a short `type` name in `component_factory` if manifest-friendly aliases are needed.

--- a/skills/inference/inference-configuring-inference-pipeline/SKILL.md
+++ b/skills/inference/inference-configuring-inference-pipeline/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: inference-configuring-inference-pipeline
+description: Configures preprocessors, postprocessors, and runners around InferenceModel via manifest specs and ComponentRegistry. Use when editing physicalai.inference.preprocessors or postprocessors, manifest preprocessor/postprocessor lists, instantiate_component, registered type names, or class_path init_args for inference pipeline components.
+license: Apache-2.0
+---
+
+# Configuring the Inference Pipeline
+
+Pipeline order: observation → preprocessors → runner → postprocessors → action output. See `docs/how-to/inference/configure-pre-post-processing.md`.
+
+Core code:
+
+- `src/physicalai/inference/component_factory.py` — `ComponentRegistry`, `instantiate_component`, `_MAX_COMPONENT_DEPTH`.
+- `src/physicalai/inference/model.py` — builds processor chains from manifest specs.
+- Built-ins under `preprocessors/` and `postprocessors/`; runners under `runners/`.
+
+## Workflow
+
+1. **Read the manifest slice** for `preprocessors`, `postprocessors`, and `model.runner`.
+   - Done when: you know whether specs use `type` (registry short name) or `class_path`.
+2. **Prefer `type` for built-ins** registered in `component_factory` (e.g. normalize/denormalize patterns in docs).
+3. **Use `class_path` + `init_args`** for explicit classes:
+   ```yaml
+   preprocessors:
+     - class_path: physicalai.inference.preprocessors.StatsNormalizer
+       init_args:
+         artifact: stats.safetensors
+   ```
+   - Done when: `init_args` paths resolve relative to the export directory via `resolve_artifact`.
+4. **Add a new built-in processor**:
+   - Implement subclass of `Preprocessor` / `Postprocessor` in the appropriate package.
+   - Register a short `type` name in `component_factory` if manifest-friendly aliases are needed.
+   - Add unit tests under `tests/unit/inference/preprocessors/` or `postprocessors/`.
+   - Done when: manifest using `type` or `class_path` instantiates in a minimal `InferenceModel` test.
+5. **Nested components** in `init_args` must stay within `_MAX_COMPONENT_DEPTH`; avoid cyclic specs.
+
+## Validation loop
+
+```bash
+uv run pytest tests/unit/inference/preprocessors tests/unit/inference/postprocessors tests/unit/inference/test_manifest.py -q
+```
+
+## Required checks
+
+- Processor order matches training/export semantics (normalization before runner, denormalization after).
+- Artifact file names in manifests do not traverse paths (`..`, absolute paths).
+- New public processors appear in `docs/reference/inference-api.md` or how-to docs when user-visible.
+- Runner choice (`SinglePass`, chunking runners) stays consistent with `predict_action_chunk` vs `select_action` docs.
+
+## References
+
+- `docs/reference/manifest-schema.md`
+- `docs/how-to/inference/use-manifest.md`

--- a/skills/inference/inference-loading-exported-policies/SKILL.md
+++ b/skills/inference/inference-loading-exported-policies/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: inference-loading-exported-policies
+description: Loads and validates policies exported from Physical AI Studio for Runtime deployment. Use when working on InferenceModel, InferenceModel.from_pretrained, manifest.json, adapter auto-detection (onnx, openvino), backend/device kwargs, Hugging Face Hub policy packages, or the Runtime side of the export/load contract that Studio produces with physicalai export.
+license: Apache-2.0
+---
+
+# Loading Exported Policies
+
+Runtime loads Studio export directories (or Hub snapshots that mirror them) through `InferenceModel` in `src/physicalai/inference/model.py`. Manifest parsing lives in `manifest.py`; backends register in `adapters/registry.py` (`onnx` → `.onnx`, `openvino` → `.xml`). Hub downloads use `inference/utils/_hub.py`.
+
+## Workflow
+
+1. **Identify the artifact**: local export directory or Hub `repo_id`, expected backend, and whether the user needs `select_action` vs `predict_action_chunk`.
+   - Done when: load path and API entry point are chosen before editing code.
+2. **Load with auto-detection first** (local):
+   ```python
+   from physicalai.inference import InferenceModel
+   model = InferenceModel("./exports/act_policy")
+   ```
+   - Done when: `model` constructs without explicit `backend=` when artifacts match a registered extension.
+3. **Hub load** when the package is published:
+   ```python
+   model = InferenceModel.from_pretrained("OpenVINO/act-fp16-ov", revision="<commit-sha>")
+   ```
+   - Done when: revision is pinned for reproducibility when security or CI matters.
+4. **Explicit backend** only when auto-detection is ambiguous:
+   ```python
+   model = InferenceModel("./exports/act_policy", backend="openvino", device="CPU")
+   ```
+5. **Validate structure** against `references/export-load-contract.md` and backend notes (`references/onnx.md`, `references/openvino.md`).
+   - Done when: manifest, model file, and processor artifacts resolve under the export directory.
+6. **Smoke inference** without owning robot timing:
+   ```python
+   model.reset()
+   action = model.select_action(observation)
+   ```
+   - Done when: one forward pass succeeds on representative observation keys/shapes. For hardware loops, hand off to `runtime-running-policy-on-robot`.
+
+## Validation loop
+
+```bash
+uv run pytest tests/unit/inference/test_model.py tests/unit/inference/test_manifest.py -q
+```
+
+For adapter changes, add or run targeted tests under `tests/unit/inference/`.
+
+## Required checks
+
+- Export directory contains backend model file(s) and `manifest.json` consistent with `docs/reference/manifest-schema.md`.
+- Metadata input/output/feature names align with preprocessors in the manifest.
+- Optional backends fail with clear install guidance (`onnxruntime`, OpenVINO).
+- Do not document a backend unless an adapter is registered in `inference/adapters/`.
+- Hub loads must not log tokens; prefer pinned `revision=` for production docs.
+
+## References
+
+- `references/export-load-contract.md` — consumer-side contract (coordinate with Studio export skill).
+- `references/onnx.md`, `references/openvino.md` — adapter constraints.

--- a/skills/inference/inference-loading-exported-policies/SKILL.md
+++ b/skills/inference/inference-loading-exported-policies/SKILL.md
@@ -6,7 +6,7 @@ license: Apache-2.0
 
 # Loading Exported Policies
 
-Runtime loads Studio export directories (or Hub snapshots that mirror them) through `InferenceModel` in `src/physicalai/inference/model.py`. Manifest parsing lives in `manifest.py`; backends register in `adapters/registry.py` (`onnx` → `.onnx`, `openvino` → `.xml`). Hub downloads use `inference/utils/_hub.py`.
+Runtime loads Studio export directories (or Hub snapshots that mirror them) through `InferenceModel` in `src/physicalai/inference/model.py`. Manifest parsing lives in `src/physicalai/inference/manifest.py`; backends register in `src/physicalai/inference/adapters/registry.py` (`onnx` → `.onnx`, `openvino` → `.xml`). Hub downloads use `src/physicalai/inference/utils/_hub.py`.
 
 ## Workflow
 
@@ -59,7 +59,7 @@ For adapter changes, add or run targeted tests under `tests/unit/inference/`.
 - Export directory contains backend model file(s) and `manifest.json` consistent with `docs/reference/manifest-schema.md`.
 - Metadata input/output/feature names align with preprocessors in the manifest.
 - Optional backends fail with clear install guidance (`onnxruntime`, OpenVINO).
-- Do not document a backend unless an adapter is registered in `inference/adapters/`.
+- Do not document a backend unless an adapter is registered in `src/physicalai/inference/adapters/`.
 - Hub loads must not log tokens; prefer pinned `revision=` for production docs.
 
 ## References

--- a/skills/inference/inference-loading-exported-policies/SKILL.md
+++ b/skills/inference/inference-loading-exported-policies/SKILL.md
@@ -13,27 +13,37 @@ Runtime loads Studio export directories (or Hub snapshots that mirror them) thro
 1. **Identify the artifact**: local export directory or Hub `repo_id`, expected backend, and whether the user needs `select_action` vs `predict_action_chunk`.
    - Done when: load path and API entry point are chosen before editing code.
 2. **Load with auto-detection first** (local):
+
    ```python
    from physicalai.inference import InferenceModel
    model = InferenceModel("./exports/act_policy")
    ```
+
    - Done when: `model` constructs without explicit `backend=` when artifacts match a registered extension.
+
 3. **Hub load** when the package is published:
+
    ```python
    model = InferenceModel.from_pretrained("OpenVINO/act-fp16-ov", revision="<commit-sha>")
    ```
+
    - Done when: revision is pinned for reproducibility when security or CI matters.
+
 4. **Explicit backend** only when auto-detection is ambiguous:
+
    ```python
    model = InferenceModel("./exports/act_policy", backend="openvino", device="CPU")
    ```
+
 5. **Validate structure** against `references/export-load-contract.md` and backend notes (`references/onnx.md`, `references/openvino.md`).
    - Done when: manifest, model file, and processor artifacts resolve under the export directory.
 6. **Smoke inference** without owning robot timing:
+
    ```python
    model.reset()
    action = model.select_action(observation)
    ```
+
    - Done when: one forward pass succeeds on representative observation keys/shapes. For hardware loops, hand off to `runtime-running-policy-on-robot`.
 
 ## Validation loop

--- a/skills/inference/inference-loading-exported-policies/references/export-load-contract.md
+++ b/skills/inference/inference-loading-exported-policies/references/export-load-contract.md
@@ -1,0 +1,22 @@
+# Export/Load Contract (Runtime)
+
+Studio produces deployment artifacts; Runtime loads them with `InferenceModel` / `InferenceModel.from_pretrained(...)`.
+
+## Required Artifact Properties
+
+- A backend-identifying model file exists in the export directory (e.g. `.onnx`, `.xml` + `.bin`).
+- `manifest.json` describes the policy, backend artifacts, preprocessors/postprocessors, runner, and action chunk semantics.
+- Runtime auto-detects the backend from registered file extensions or loads when `backend=` is set explicitly.
+- Optional backend dependencies fail with clear installation guidance.
+
+## Backend Ownership
+
+- Studio owns export implementation and export metadata generation.
+- Runtime owns adapter discovery, backend loading, preprocessing, inference execution, and action selection from exported artifacts.
+- Studio and Runtime must keep this contract synchronized conceptually. Update this file when Studio export metadata changes.
+
+## Compatibility Rules
+
+- Do not change expected manifest field semantics without coordinating Studio export changes.
+- Do not add a backend to user-facing instructions unless an adapter is registered under `src/physicalai/inference/adapters/`.
+- Treat numerical parity (Studio export validation) and deployment latency as separate checks.

--- a/skills/inference/inference-loading-exported-policies/references/onnx.md
+++ b/skills/inference/inference-loading-exported-policies/references/onnx.md
@@ -1,0 +1,6 @@
+# ONNX adapter
+
+- Registry key: `onnx`, extension `.onnx`.
+- Implementation: `src/physicalai/inference/adapters/onnx.py` (`ONNXAdapter`).
+- Dependency: `onnxruntime` (core install includes it).
+- `device` kwargs follow ONNX Runtime providers (`cpu`, `cuda`, etc.) — verify against the adapter before documenting new values.

--- a/skills/inference/inference-loading-exported-policies/references/openvino.md
+++ b/skills/inference/inference-loading-exported-policies/references/openvino.md
@@ -1,0 +1,6 @@
+# OpenVINO adapter
+
+- Registry key: `openvino`, extension `.xml` (`.bin` alongside).
+- Implementation: `src/physicalai/inference/adapters/openvino.py` (`OpenVINOAdapter`).
+- Dependency: `openvino` (core install pins a version in `pyproject.toml`).
+- Default device string is OpenVINO-style (`CPU`, `GPU`, `NPU`, `AUTO`).

--- a/skills/runtime/EVALUATION.md
+++ b/skills/runtime/EVALUATION.md
@@ -1,0 +1,67 @@
+# Skill Evaluation Scenarios
+
+Use these prompts to test runtime bucket skills from the repo root.
+
+Expected rubric per scenario:
+
+- **Activates the right skill** — matches `runtime-running-policy-on-robot` or `runtime-adding-a-robot-integration`.
+- **Uses real paths and commands** — `src/physicalai/runtime/`, `physicalai run`, `uv run pytest tests/unit/runtime/`.
+- **Follows workflow checklists**.
+- **Produces a checkable artifact**.
+
+## `runtime-running-policy-on-robot`
+
+### Scenario 1: YAML-driven run
+
+> "Write a `runtime.yaml` that runs an exported policy on SO-101 with one wrist UVC camera for 30 seconds, then give the exact `physicalai run` command."
+
+Expected behavior:
+
+- Nested `class_path` / `init_args` for `PolicyRuntime`, `SO101`, `InferenceModel`, `UVCCamera`, `SyncExecution`.
+- Command includes `--config` and duration override pattern from `cli/run.py` docs.
+
+### Scenario 2: Execution mode choice
+
+> "User needs lower inference latency with chunked actions. Which execution class should they use and where is it documented?"
+
+Expected behavior:
+
+- Points to `docs/how-to/runtime/use-execution-modes.md` and RTC/sync modules under `runtime/`.
+- Does not reimplement timing inside `InferenceModel.select_action`.
+
+### Scenario 3: Runtime test with fakes
+
+> "Add a unit test that PolicyRuntime steps one tick with a fake robot and fake model."
+
+Expected behavior:
+
+- Uses patterns from `tests/unit/runtime/test_runtime.py`.
+- Runs `uv run pytest tests/unit/runtime -k <test>`.
+
+## `runtime-adding-a-robot-integration`
+
+### Scenario 4: New protocol-compliant robot stub
+
+> "Create a minimal fake robot class that satisfies the Robot protocol for use in runtime tests."
+
+Expected behavior:
+
+- Implements methods from `robot/interface.py`; cites `references/robot-protocol.md`.
+- `isinstance(..., Robot)` check in test.
+
+### Scenario 5: SO-101 port validation
+
+> "User passes `port='../../etc/passwd'` to SO101. What should the integration do?"
+
+Expected behavior:
+
+- Path validation / rejection per security rules; no shelling out with raw path.
+
+### Scenario 6: Export new robot from package
+
+> "Add a new arm driver package under `robot/myarm/` with optional extra and unit tests."
+
+Expected behavior:
+
+- Lazy SDK import, `pyproject.toml` extra, tests under `tests/unit/robot/`.
+- Documents joint_names ordering.

--- a/skills/runtime/EVALUATION.md
+++ b/skills/runtime/EVALUATION.md
@@ -18,7 +18,7 @@ Expected rubric per scenario:
 Expected behavior:
 
 - Nested `class_path` / `init_args` for `PolicyRuntime`, `SO101`, `InferenceModel`, `UVCCamera`, `SyncExecution`.
-- Command includes `--config` and duration override pattern from `cli/run.py` docs.
+- Command includes `--config` and duration override pattern from `src/physicalai/cli/run.py` docs.
 
 ### Scenario 2: Execution mode choice
 
@@ -26,7 +26,7 @@ Expected behavior:
 
 Expected behavior:
 
-- Points to `docs/how-to/runtime/use-execution-modes.md` and RTC/sync modules under `runtime/`.
+- Points to `docs/how-to/runtime/use-execution-modes.md` and RTC/sync modules under `src/physicalai/runtime/`.
 - Does not reimplement timing inside `InferenceModel.select_action`.
 
 ### Scenario 3: Runtime test with fakes
@@ -46,7 +46,7 @@ Expected behavior:
 
 Expected behavior:
 
-- Implements methods from `robot/interface.py`; cites `references/robot-protocol.md`.
+- Implements methods from `src/physicalai/robot/interface.py`; cites `references/robot-protocol.md`.
 - `isinstance(..., Robot)` check in test.
 
 ### Scenario 5: SO-101 port validation
@@ -59,7 +59,7 @@ Expected behavior:
 
 ### Scenario 6: Export new robot from package
 
-> "Add a new arm driver package under `robot/myarm/` with optional extra and unit tests."
+> "Add a new arm driver package under `src/physicalai/robot/myarm/` with optional extra and unit tests."
 
 Expected behavior:
 

--- a/skills/runtime/README.md
+++ b/skills/runtime/README.md
@@ -6,9 +6,9 @@ Run commands from the repo root (`uv run pytest tests/unit/runtime/...`, `physic
 
 ## Skills
 
-| Skill | Covers |
-| ----- | ------ |
-| `runtime-running-policy-on-robot` | `PolicyRuntime`, execution modes, YAML config, `physicalai run`, callbacks. |
+| Skill                                | Covers                                                                          |
+| ------------------------------------ | ------------------------------------------------------------------------------- |
+| `runtime-running-policy-on-robot`    | `PolicyRuntime`, execution modes, YAML config, `physicalai run`, callbacks.     |
 | `runtime-adding-a-robot-integration` | `Robot` protocol, concrete drivers (SO-101, WidowX), `verify`, optional extras. |
 
 New runtime skills must pass at least three scenarios in [`EVALUATION.md`](EVALUATION.md).

--- a/skills/runtime/README.md
+++ b/skills/runtime/README.md
@@ -1,0 +1,25 @@
+# Runtime agent skills
+
+Skills for deployment orchestration: `src/physicalai/runtime/`, `src/physicalai/robot/`, and `src/physicalai/cli/` (`physicalai run`).
+
+Run commands from the repo root (`uv run pytest tests/unit/runtime/...`, `physicalai run --help`).
+
+## Skills
+
+| Skill | Covers |
+| ----- | ------ |
+| `runtime-running-policy-on-robot` | `PolicyRuntime`, execution modes, YAML config, `physicalai run`, callbacks. |
+| `runtime-adding-a-robot-integration` | `Robot` protocol, concrete drivers (SO-101, WidowX), `verify`, optional extras. |
+
+New runtime skills must pass at least three scenarios in [`EVALUATION.md`](EVALUATION.md).
+
+## Add a runtime skill
+
+```bash
+NAME=runtime-my-workflow
+mkdir -p "skills/runtime/$NAME"
+$EDITOR "skills/runtime/$NAME/SKILL.md"
+python3 .github/scripts/skills/agent_skills.py sync
+```
+
+Global authoring rules: [`../README.md`](../README.md).

--- a/skills/runtime/runtime-adding-a-robot-integration/SKILL.md
+++ b/skills/runtime/runtime-adding-a-robot-integration/SKILL.md
@@ -6,7 +6,7 @@ license: Apache-2.0
 
 # Adding a Robot Integration
 
-Robots satisfy the structural `Robot` protocol in `src/physicalai/robot/interface.py` — no base class inheritance required. References: `robot/so101/`, `robot/trossen/` (WidowX). Connection helpers: `robot/connect.py`; validation: `robot/verify.py`.
+Robots satisfy the structural `Robot` protocol in `src/physicalai/robot/interface.py` — no base class inheritance required. References: `src/physicalai/robot/so101/`, `src/physicalai/robot/trossen/` (WidowX). Connection helpers: `src/physicalai/robot/connect.py`; validation: `src/physicalai/robot/verify.py`.
 
 ## Workflow
 

--- a/skills/runtime/runtime-adding-a-robot-integration/SKILL.md
+++ b/skills/runtime/runtime-adding-a-robot-integration/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: runtime-adding-a-robot-integration
+description: Adds or modifies robot hardware integrations under physicalai.robot. Use when implementing the Robot protocol, SO101 or Trossen WidowX drivers, robot connect helpers, verify.py checks, optional extras so101 or trossen, or tests in tests/unit/robot.
+license: Apache-2.0
+---
+
+# Adding a Robot Integration
+
+Robots satisfy the structural `Robot` protocol in `src/physicalai/robot/interface.py` — no base class inheritance required. References: `robot/so101/`, `robot/trossen/` (WidowX). Connection helpers: `robot/connect.py`; validation: `robot/verify.py`.
+
+## Workflow
+
+1. **Read `references/robot-protocol.md`** and an existing integration (SO-101 for serial servos, WidowX for arms).
+   - Done when: required methods and observation shape are listed.
+2. **Implement connect lifecycle**: idempotent `connect()`, `disconnect()`, `is_connected()`.
+3. **Observations**: return a type exposing `joint_positions`, `timestamp` (`time.monotonic()`), optional `sensor_data` / `images`; implement `state` property when inference expects more than positions.
+4. **Actions**: `send_action(action, *, goal_time=...)` with `action` shape matching training data conventions; document joint order via `joint_names`.
+5. **Optional extra** in `pyproject.toml` (`physicalai[so101]`, `physicalai[trossen]`); lazy-import vendor SDKs.
+6. **Export** public class from `physicalai.robot` when user-facing.
+7. **Tests** under `tests/unit/robot/` with mocked hardware.
+   - Done when: `uv run pytest tests/unit/robot -k <name>` passes.
+8. **Verification CLI/docs** — wire `verify.py` patterns if the robot supports automated checks.
+
+## Required checks
+
+- `isinstance(robot, Robot)` at runtime (`@runtime_checkable` protocol).
+- No action sent when disconnected.
+- Joint count and `joint_names` stay stable across connect/disconnect.
+- Security: validate user-supplied port/path strings; no shell invocation with unsanitized device paths.
+
+## References
+
+- `references/robot-protocol.md`
+- `docs/explanation/robots.md`

--- a/skills/runtime/runtime-adding-a-robot-integration/references/robot-protocol.md
+++ b/skills/runtime/runtime-adding-a-robot-integration/references/robot-protocol.md
@@ -1,0 +1,35 @@
+# Robot protocol
+
+Structural interface: `src/physicalai/robot/interface.py`.
+
+## Robot
+
+Required methods:
+
+- `connect()` — idempotent; safe to call when already connected.
+- `disconnect()` — release hardware resources.
+- `is_connected() -> bool`
+- `get_observation()` — returns an object satisfying `RobotObservation`.
+- `send_action(action: np.ndarray, *, goal_time: float = ...)` — send command vector.
+
+Class attribute:
+
+- `joint_names: list[str]` — order matches `joint_positions` and training action layout.
+
+## RobotObservation
+
+Attributes:
+
+- `joint_positions: np.ndarray` shape `(N,)`
+- `timestamp: float` — `time.monotonic()` at capture
+- `sensor_data: dict[str, np.ndarray] | None`
+- `images: dict[str, Frame] | None` — embedded cameras only; external cameras use `physicalai.capture`
+
+Property:
+
+- `state` — defaults to `joint_positions`; override when inference expects concatenated state.
+
+## Design notes
+
+- Use `@runtime_checkable` protocol checks in tests: `isinstance(instance, Robot)`.
+- External cameras are configured on `PolicyRuntime`, not inside the robot driver, unless the hardware truly provides embedded frames via `images`.

--- a/skills/runtime/runtime-running-policy-on-robot/SKILL.md
+++ b/skills/runtime/runtime-running-policy-on-robot/SKILL.md
@@ -6,7 +6,7 @@ license: Apache-2.0
 
 # Running a Policy on a Robot
 
-`PolicyRuntime` (`src/physicalai/runtime/runtime.py`) owns the control loop; `InferenceModel` owns policy math. Execution strategy lives under `runtime/execution.py` and `rtc_execution.py`. CLI: `physicalai run` in `cli/run.py` instantiates from YAML via jsonargparse.
+`PolicyRuntime` (`src/physicalai/runtime/runtime.py`) owns the control loop; `InferenceModel` owns policy math. Execution strategy lives under `src/physicalai/runtime/execution.py` and `src/physicalai/runtime/rtc_execution.py`. CLI: `physicalai run` in `src/physicalai/cli/run.py` instantiates from YAML via jsonargparse.
 
 ## Workflow
 

--- a/skills/runtime/runtime-running-policy-on-robot/SKILL.md
+++ b/skills/runtime/runtime-running-policy-on-robot/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: runtime-running-policy-on-robot
+description: Runs exported policies on hardware with PolicyRuntime, execution modes, and physicalai run. Use when wiring PolicyRuntime, SyncExecution or RTC execution, runtime YAML configs, action queues, runtime callbacks, or docs/how-to/runtime run-policy-on-robot and execution modes.
+license: Apache-2.0
+---
+
+# Running a Policy on a Robot
+
+`PolicyRuntime` (`src/physicalai/runtime/runtime.py`) owns the control loop; `InferenceModel` owns policy math. Execution strategy lives under `runtime/execution.py` and `rtc_execution.py`. CLI: `physicalai run` in `cli/run.py` instantiates from YAML via jsonargparse.
+
+## Workflow
+
+1. **Choose API vs config**: Python for notebooks/tests; YAML + `physicalai run` for reproducible deployment.
+   - Done when: entry point matches the user's task.
+2. **Python minimal loop** (see `docs/how-to/runtime/run-policy-on-robot.md`):
+   ```python
+   from physicalai.runtime import PolicyRuntime, SyncExecution
+   from physicalai.inference import InferenceModel
+   from physicalai.robot import SO101
+   from physicalai.capture import UVCCamera
+
+   runtime = PolicyRuntime(
+       fps=30,
+       robot=SO101(port="/dev/ttyACM0"),
+       model=InferenceModel("./exports/act_policy"),
+       cameras={"wrist": UVCCamera(device="/dev/video0", width=640, height=480)},
+       execution=SyncExecution(),
+   )
+   with runtime:
+       runtime.run(duration_s=60)
+   ```
+   - Done when: components connect and the loop runs in a test or dry-run with fakes.
+3. **YAML config** — nest `class_path` / `init_args` for robot, model, cameras, execution; run:
+   ```bash
+   physicalai run --config runtime.yaml --run.duration_s=60
+   ```
+4. **Execution mode** — pick sync vs RTC per `docs/how-to/runtime/use-execution-modes.md`; do not build ad-hoc timing around `InferenceModel.select_action` when `PolicyRuntime` should own the queue.
+5. **Callbacks** — register via runtime callback APIs (`docs/how-to/runtime/add-runtime-callbacks.md`) for telemetry/latency, not inside inference adapters.
+
+## Validation loop
+
+```bash
+uv run pytest tests/unit/runtime/ -q
+```
+
+Use fake robots/cameras from runtime tests when hardware is unavailable.
+
+## Required checks
+
+- `fps` and camera read rates are consistent.
+- Action dimensions match robot `send_action` expectations.
+- Config `class_path` targets are importable without training packages.
+- Document breaking changes to runtime config schema in `docs/reference/config-schema.md`.
+
+## References
+
+- `docs/how-to/runtime/run-policy-on-robot.md`
+- `docs/how-to/config/write-runtime-config.md`

--- a/skills/runtime/runtime-running-policy-on-robot/SKILL.md
+++ b/skills/runtime/runtime-running-policy-on-robot/SKILL.md
@@ -13,6 +13,7 @@ license: Apache-2.0
 1. **Choose API vs config**: Python for notebooks/tests; YAML + `physicalai run` for reproducible deployment.
    - Done when: entry point matches the user's task.
 2. **Python minimal loop** (see `docs/how-to/runtime/run-policy-on-robot.md`):
+
    ```python
    from physicalai.runtime import PolicyRuntime, SyncExecution
    from physicalai.inference import InferenceModel
@@ -29,11 +30,15 @@ license: Apache-2.0
    with runtime:
        runtime.run(duration_s=60)
    ```
+
    - Done when: components connect and the loop runs in a test or dry-run with fakes.
+
 3. **YAML config** — nest `class_path` / `init_args` for robot, model, cameras, execution; run:
+
    ```bash
    physicalai run --config runtime.yaml --run.duration_s=60
    ```
+
 4. **Execution mode** — pick sync vs RTC per `docs/how-to/runtime/use-execution-modes.md`; do not build ad-hoc timing around `InferenceModel.select_action` when `PolicyRuntime` should own the queue.
 5. **Callbacks** — register via runtime callback APIs (`docs/how-to/runtime/add-runtime-callbacks.md`) for telemetry/latency, not inside inference adapters.
 


### PR DESCRIPTION
## Summary

- Add vendor-neutral agent guidance (`AGENTS.md`, thin `CLAUDE.md` / Copilot adapters) and contributor docs under `docs/development/`.
- Introduce canonical skills in `skills/{inference,capture,runtime}/` with five initial workflows, evaluation scenarios, and committed `.claude`/`.agents` symlink adapters.
- Add `agent_skills.py` sync/validate, pre-commit hooks, and CI workflow mirroring Physical AI Studio PR #698.