### PR TITLE
chore(ci): add skills scanners in CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,11 +89,11 @@
 
     // Use regex versioning for open-edge-platform/geti-ci actions to parse tags like zizmor/v0.1.1
     {
-      enabled: true,
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
-      matchDepNames: ["open-edge-platform/geti-ci"],
-      versioning: "regex:^(?:[^/]+/)?v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      matchPackageNames: ["open-edge-platform/geti-ci"],
+      schedule: ["* * 1 * *"], // every month
+      versioning: "regex:^(?<compatibility>[^/]+)/v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
     },
   ],
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,7 +93,7 @@
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
       matchPackageNames: ["open-edge-platform/geti-ci"],
-      schedule: ["* * 1 * *"], // every month
+      schedule: ["* * 1,15 * *"], // twice a month
       versioning: "regex:^(?<compatibility>[^/]+)/v?(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
     },
   ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -89,6 +89,7 @@
 
     // Use regex versioning for open-edge-platform/geti-ci actions to parse tags like zizmor/v0.1.1
     {
+      enabled: true,
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
       matchPackageNames: ["open-edge-platform/geti-ci"],

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,7 +47,7 @@ jobs:
       - *checkout
 
       - name: Run Bandit scan
-        uses: open-edge-platform/geti-ci/actions/bandit@0bed754fc7db24b5f9f15e7ead2eb4acdb0c7263 # zizmor/v0.1.2
+        uses: open-edge-platform/geti-ci/actions/bandit@d5b1283a2618b816cfce50d597754e8b8ea3a2b6 # bandit/v0.1.1
         with:
           scan-scope: ${{ github.event_name == 'pull_request' && 'changed' || 'all' }}
           severity-level: ${{ github.event_name == 'pull_request' && 'MEDIUM' || 'LOW' }}

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -43,7 +43,7 @@ jobs:
         uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
         with:
           files_yaml: |
-            test:      
+            test:
               - skills/**
               - .claude/skills/**
               - .agents/skills/**
@@ -53,6 +53,8 @@ jobs:
   layout-check:
     name: Validate skills layout
     runs-on: ubuntu-latest
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
     permissions:
       contents: read
     steps:
@@ -64,7 +66,7 @@ jobs:
       - name: Validate skills and adapter symlinks
         run: python3 .github/scripts/skills/agent_skills.py validate
 
-  skill-scan:
+  SkillSpector-scan:
     name: SkillSpector scan
     runs-on: ubuntu-latest
     needs: check-paths
@@ -88,6 +90,8 @@ jobs:
   skill-validator-scan:
     name: skill-validator scan
     runs-on: ubuntu-latest
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
     permissions:
       contents: read
     steps:
@@ -109,7 +113,7 @@ jobs:
     needs:
       - check-paths
       - layout-check
-      - skill-scan
+      - SkillSpector-scan
       - skill-validator-scan
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Run skill-validator
         uses: open-edge-platform/geti-ci/actions/skill-validator@dd2b6e59ed10c4937d18c0596502b0a9408ab52a # skill-validator/v0.1.1
         with:
-          skills-path: .agents/skills/
+          skills-path: skills
           strict: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
           fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
 

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -4,20 +4,19 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "skills/**"
-      - ".claude/skills/**"
-      - ".agents/skills/**"
-      - ".github/scripts/skills/**"
-      - ".github/workflows/skills.yml"
   pull_request:
-    paths:
-      - "skills/**"
-      - ".claude/skills/**"
-      - ".agents/skills/**"
-      - ".github/scripts/skills/**"
-      - ".github/workflows/skills.yml"
   workflow_dispatch:
+    inputs:
+      severity:
+        description: "Severity level (CRITICAL, HIGH, MEDIUM, LOW)"
+        required: false
+        default: "LOW"
+        type: choice
+        options:
+          - CRITICAL
+          - HIGH
+          - MEDIUM
+          - LOW
 
 permissions: {}
 
@@ -26,7 +25,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
+  check-paths:
+    name: Check if workflow should run
+    runs-on: ubuntu-latest
+    outputs:
+      run_workflow: ${{ steps.check_paths.outputs.run }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Check paths
+        id: check_paths
+        uses: open-edge-platform/geti-ci/actions/check-paths@7e686c1248b3939f8ee8e04e2612da727e379d91
+        with:
+          files_yaml: |
+            test:      
+              - skills/**
+              - .claude/skills/**
+              - .agents/skills/**
+              - .github/scripts/skills/**
+              - .github/workflows/skills.yml
+
+  layout-check:
     name: Validate skills layout
     runs-on: ubuntu-latest
     permissions:
@@ -39,3 +63,65 @@ jobs:
 
       - name: Validate skills and adapter symlinks
         run: python3 .github/scripts/skills/agent_skills.py validate
+
+  skill-scan:
+    name: SkillSpector scan
+    runs-on: ubuntu-latest
+    needs: check-paths
+    if: needs.check-paths.outputs.run_workflow == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run SkillSpector scan
+        uses: open-edge-platform/geti-ci/actions/skill-scan@0745e2b1612e4c25c3e83eb37bddeba8743a2439 # skill-scan/v0.1.1
+        with:
+          severity-level: ${{ github.event_name == 'pull_request' && 'HIGH' || github.event.inputs.severity || 'LOW' }}
+          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          skills-path: skills
+
+  skill-validator-scan:
+    name: skill-validator scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run skill-validator
+        uses: open-edge-platform/geti-ci/actions/skill-validator@dd2b6e59ed10c4937d18c0596502b0a9408ab52a # skill-validator/v0.1.1
+        with:
+          skills-path: .agents/skills/
+          strict: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          fail-on-findings: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+
+  required-check:
+    name: Required Check skills
+    needs:
+      - check-paths
+      - layout-check
+      - skill-scan
+      - skill-validator-scan
+    runs-on: ubuntu-latest
+    env:
+      CHECKS: ${{ join(needs.*.result, ' ') }}
+    if: always() && !cancelled()
+    steps:
+      - name: Check jobs results
+        run: |
+          for check in ${CHECKS}; do
+            echo "::notice::check=${check}"
+            if [[ "$check" != "success" && "$check" != "skipped" ]]; then
+              echo "::error ::Required status checks failed. They must succeed before this pull request can be merged."
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary
This PR updates adds skills-focused scanners (SkillSpector and skill-validator based on on geti-ci actions), adjusts the Bandit action pin in the security scan workflow, and updates Renovate rules to better parse and group `open-edge-platform/geti-ci` action tags.
