### PR TITLE
fix: allow HuggingFace Hub snapshot symlinks

### DIFF
--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -137,22 +137,27 @@ def resolve_artifact(spec: ComponentSpec, export_dir: Path) -> ComponentSpec:
     # are still rejected.
     norm_export = Path(export_dir).resolve()
 
-    def _safe_resolve(artifact: str) -> str:
-        candidate = Path(os.path.normpath(export_dir / artifact))
+    def _resolve_artifact_path(artifact: str) -> str:
+        # Reject manifest paths that escape the export directory via
+        # "../" traversal (e.g. "../../etc/passwd").  The check is intentionally
+        # lexical (normpath, no symlink following) so that HuggingFace Hub
+        # snapshot symlinks which point from snapshot/ into a sibling blobs/
+        # store are accepted without error.
+        candidate = Path(os.path.normpath(norm_export / artifact))
         if not candidate.is_relative_to(norm_export):
             msg = f"artifact path {artifact!r} escapes the export directory"
             raise ValueError(msg)
-        return str((export_dir / artifact).resolve())
+        return str(candidate)
 
     flat = spec.flat_params
     if "artifact" in flat and not Path(flat["artifact"]).is_absolute():
-        new_params = {**flat, "artifact": _safe_resolve(flat["artifact"])}
+        new_params = {**flat, "artifact": _resolve_artifact_path(flat["artifact"])}
         return type(spec).model_validate({"type": spec.type, **new_params})
 
     if spec.class_path and "artifact" in spec.init_args:
         artifact = spec.init_args["artifact"]
         if not Path(artifact).is_absolute():
-            new_init_args = {**spec.init_args, "artifact": _safe_resolve(artifact)}
+            new_init_args = {**spec.init_args, "artifact": _resolve_artifact_path(artifact)}
             return type(spec).model_validate({"class_path": spec.class_path, "init_args": new_init_args})
 
     return spec

--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -131,15 +131,15 @@ def resolve_artifact(spec: ComponentSpec, export_dir: Path) -> ComponentSpec:
         The spec with resolved artifact path, or the original spec
         unchanged if no resolution is needed.
     """
-    # Use normpath (no symlink following) for the traversal check so that
+    # Use abspath (no symlink following) for the traversal check so that
     # HuggingFace Hub snapshot symlinks pointing into the sibling blobs/
     # store are allowed while "../../" escapes in manifest artifact paths
     # are still rejected.
-    norm_export = Path(os.path.normpath(export_dir))
+    norm_export = Path(os.path.abspath(export_dir))
 
     def _safe_resolve(artifact: str) -> str:
         candidate = export_dir / artifact
-        if not Path(os.path.normpath(candidate)).is_relative_to(norm_export):
+        if not Path(os.path.abspath(candidate)).is_relative_to(norm_export):
             msg = f"artifact path {artifact!r} escapes the export directory"
             raise ValueError(msg)
         return str(candidate.resolve())

--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -14,7 +14,6 @@ to an object instance, supporting both ``type`` + flat params and
 from __future__ import annotations
 
 import importlib
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -135,11 +134,11 @@ def resolve_artifact(spec: ComponentSpec, export_dir: Path) -> ComponentSpec:
     # HuggingFace Hub snapshot symlinks pointing into the sibling blobs/
     # store are allowed while "../../" escapes in manifest artifact paths
     # are still rejected.
-    norm_export = Path(os.path.abspath(export_dir))
+    norm_export = Path(Path(export_dir).resolve())
 
     def _safe_resolve(artifact: str) -> str:
         candidate = export_dir / artifact
-        if not Path(os.path.abspath(candidate)).is_relative_to(norm_export):
+        if not Path(Path(candidate).resolve()).is_relative_to(norm_export):
             msg = f"artifact path {artifact!r} escapes the export directory"
             raise ValueError(msg)
         return str(candidate.resolve())

--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -131,10 +131,6 @@ def resolve_artifact(spec: ComponentSpec, export_dir: Path) -> ComponentSpec:
         The spec with resolved artifact path, or the original spec
         unchanged if no resolution is needed.
     """
-    # Use normpath (no symlink following) for the traversal check so that
-    # HuggingFace Hub snapshot symlinks pointing into the sibling blobs/
-    # store are allowed while "../../" escapes in manifest artifact paths
-    # are still rejected.
     norm_export = Path(export_dir).resolve()
 
     def _resolve_artifact_path(artifact: str) -> str:

--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -14,6 +14,7 @@ to an object instance, supporting both ``type`` + flat params and
 from __future__ import annotations
 
 import importlib
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -130,17 +131,18 @@ def resolve_artifact(spec: ComponentSpec, export_dir: Path) -> ComponentSpec:
         The spec with resolved artifact path, or the original spec
         unchanged if no resolution is needed.
     """
-    # Canonicalize the export root once before containment checks.  Using
-    # resolve() ensures `..` segments are collapsed and symlinks are followed
-    # so `is_relative_to()` is applied to the final filesystem locations.
-    resolved_export = export_dir.resolve()
+    # Use normpath (no symlink following) for the traversal check so that
+    # HuggingFace Hub snapshot symlinks pointing into the sibling blobs/
+    # store are allowed while "../../" escapes in manifest artifact paths
+    # are still rejected.
+    norm_export = Path(os.path.normpath(export_dir))
 
     def _safe_resolve(artifact: str) -> str:
-        resolved = (export_dir / artifact).resolve()
-        if not resolved.is_relative_to(resolved_export):
+        candidate = export_dir / artifact
+        if not Path(os.path.normpath(candidate)).is_relative_to(norm_export):
             msg = f"artifact path {artifact!r} escapes the export directory"
             raise ValueError(msg)
-        return str(resolved)
+        return str(candidate.resolve())
 
     flat = spec.flat_params
     if "artifact" in flat and not Path(flat["artifact"]).is_absolute():

--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -14,6 +14,7 @@ to an object instance, supporting both ``type`` + flat params and
 from __future__ import annotations
 
 import importlib
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -130,18 +131,18 @@ def resolve_artifact(spec: ComponentSpec, export_dir: Path) -> ComponentSpec:
         The spec with resolved artifact path, or the original spec
         unchanged if no resolution is needed.
     """
-    # Use abspath (no symlink following) for the traversal check so that
+    # Use normpath (no symlink following) for the traversal check so that
     # HuggingFace Hub snapshot symlinks pointing into the sibling blobs/
     # store are allowed while "../../" escapes in manifest artifact paths
     # are still rejected.
-    norm_export = Path(Path(export_dir).resolve())
+    norm_export = Path(export_dir).resolve()
 
     def _safe_resolve(artifact: str) -> str:
-        candidate = export_dir / artifact
-        if not Path(Path(candidate).resolve()).is_relative_to(norm_export):
+        candidate = Path(os.path.normpath(export_dir / artifact))
+        if not candidate.is_relative_to(norm_export):
             msg = f"artifact path {artifact!r} escapes the export directory"
             raise ValueError(msg)
-        return str(candidate.resolve())
+        return str((export_dir / artifact).resolve())
 
     flat = spec.flat_params
     if "artifact" in flat and not Path(flat["artifact"]).is_absolute():

--- a/tests/unit/inference/test_manifest.py
+++ b/tests/unit/inference/test_manifest.py
@@ -652,23 +652,30 @@ class TestResolveArtifact:
         with pytest.raises(ValueError, match="escapes the export directory"):
             resolve_artifact(spec, tmp_path)
 
-    def test_allows_hf_hub_symlink_outside_snapshot_dir(self, tmp_path: Path) -> None:
-        """HuggingFace Hub uses relative symlinks from the snapshot dir into a sibling blobs/ dir.
+    def test_hf_hub_symlink_sibling_files_discoverable(self, tmp_path: Path) -> None:
+        """The resolved artifact path must keep sibling files (e.g. OV .bin) discoverable.
 
-        snapshot/model.xml -> ../blobs/sha256_aaa  (relative, points outside snapshot/)
-
-        resolve_artifact must not raise even though the symlink target resolves
-        outside the snapshot (export) directory.
+        OpenVINO expects model.bin to live next to model.xml.  If resolve_artifact
+        followed the HF Hub symlink and returned the blob path, OV would look for
+        the .bin inside blobs/ where it does not exist.
         """
-        blob_file = tmp_path / "blobs" / "sha256_aaa"
-        blob_file.parent.mkdir()
-        blob_file.write_bytes(b"model-data")
+        blob_xml = tmp_path / "blobs" / "sha256_xml"
+        blob_bin = tmp_path / "blobs" / "sha256_bin"
+        blob_xml.parent.mkdir()
+        blob_xml.write_bytes(b"<xml/>")
+        blob_bin.write_bytes(b"bin-weights")
 
         snapshot_dir = tmp_path / "snapshot"
         snapshot_dir.mkdir()
-        symlink = snapshot_dir / "model.xml"
-        symlink.symlink_to(Path("../blobs/sha256_aaa"))  # relative, mirrors HF Hub layout
+        (snapshot_dir / "model.xml").symlink_to(Path("../blobs/sha256_xml"))
+        (snapshot_dir / "model.bin").symlink_to(Path("../blobs/sha256_bin"))
 
         spec = ComponentSpec.model_validate({"type": "normalize", "artifact": "model.xml"})
         resolved = resolve_artifact(spec, snapshot_dir)
-        assert resolved.flat_params["artifact"] == str(blob_file.resolve())
+
+        artifact_path = Path(resolved.flat_params["artifact"])
+        sibling_bin = artifact_path.with_suffix(".bin")
+        assert sibling_bin.exists(), (
+            f"Expected {sibling_bin} to exist next to the artifact, "
+            f"but artifact resolved to {artifact_path}"
+        )

--- a/tests/unit/inference/test_manifest.py
+++ b/tests/unit/inference/test_manifest.py
@@ -651,3 +651,24 @@ class TestResolveArtifact:
         })
         with pytest.raises(ValueError, match="escapes the export directory"):
             resolve_artifact(spec, tmp_path)
+
+    def test_allows_hf_hub_symlink_outside_snapshot_dir(self, tmp_path: Path) -> None:
+        """HuggingFace Hub uses relative symlinks from the snapshot dir into a sibling blobs/ dir.
+
+        snapshot/model.xml -> ../blobs/sha256_aaa  (relative, points outside snapshot/)
+
+        resolve_artifact must not raise even though the symlink target resolves
+        outside the snapshot (export) directory.
+        """
+        blob_file = tmp_path / "blobs" / "sha256_aaa"
+        blob_file.parent.mkdir()
+        blob_file.write_bytes(b"model-data")
+
+        snapshot_dir = tmp_path / "snapshot"
+        snapshot_dir.mkdir()
+        symlink = snapshot_dir / "model.xml"
+        symlink.symlink_to(Path("../blobs/sha256_aaa"))  # relative, mirrors HF Hub layout
+
+        spec = ComponentSpec.model_validate({"type": "normalize", "artifact": "model.xml"})
+        resolved = resolve_artifact(spec, snapshot_dir)
+        assert resolved.flat_params["artifact"] == str(blob_file.resolve())


### PR DESCRIPTION
This PR update `_safe_resolve` -> ` _resolve_artifact_path` to use `normpath` for the traversal check so that HuggingFace Hub snapshot symlinks.