### PR TITLE
fix: twin camera identity race

### DIFF
--- a/docs/explanation/cameras.md
+++ b/docs/explanation/cameras.md
@@ -26,6 +26,12 @@ observation["image.wrist"] = wrist_camera.read_latest()
 
 Camera instances are not thread-safe. Use one thread per camera instance or add external synchronization.
 
+## Device Identity
+
+`discover()` prefers a stable identifier over a video index, so a camera keeps
+the same `device_id` across reboot and replug. `id_stable=True` marks a
+`device_id` that is safe to persist in config.
+
 ## SharedCamera
 
 `SharedCamera` lets one publisher subprocess own a camera's exclusive hardware

--- a/src/physicalai/capture/cameras/uvc/_omnicamera.py
+++ b/src/physicalai/capture/cameras/uvc/_omnicamera.py
@@ -58,6 +58,8 @@ def _usb_identity(index: int) -> _UsbIdentity | None:
         Identity of the owning USB device, or None when it cannot be read
         (non-Linux, non-USB device, or unreadable sysfs).
     """
+    if not sys.platform.startswith("linux"):
+        return None
     try:
         path = (_SYSFS_V4L2 / f"video{index}" / "device").resolve(strict=True)
         while not (path / "idVendor").exists():
@@ -71,6 +73,26 @@ def _usb_identity(index: int) -> _UsbIdentity | None:
     except OSError:
         return None
     return _UsbIdentity(devpath=path.name, model_key=cast("tuple[str, str, str]", attrs))
+
+
+def _device_key(info: omni_camera.CameraInfo, usb: dict[int, _UsbIdentity | None]) -> str:
+    """Key a query entry by the physical device behind it.
+
+    Two entries share a key when they are the same camera. The USB device path
+    does that job: a camera's several ``/dev/videoN`` entries (capture,
+    metadata, ...) all sit on one path, and no two cameras share one -- unlike
+    a by-id path, which twins do share.
+
+    Args:
+        info: The query entry to key.
+        usb: Identity per video index, from :func:`_usb_identity`.
+
+    Returns:
+        The USB device path, or the entry's own video index where sysfs said
+        nothing (non-USB device, macOS, Windows), which keys it on its own.
+    """
+    identity = usb.get(info.index)
+    return identity.devpath if identity else str(info.index)
 
 
 class OmniCamera(Camera):
@@ -97,60 +119,67 @@ class OmniCamera(Camera):
         self._last_frame: np.ndarray | None = None
 
     @staticmethod
-    def _physical_devices(infos: list[omni_camera.CameraInfo]) -> tuple[list[omni_camera.CameraInfo], set[int]]:
-        """Reduce a query list to one entry per physical camera and flag ambiguous nodes.
+    def _physical_cameras(infos: list[omni_camera.CameraInfo]) -> list[omni_camera.CameraInfo]:
+        """Reduce a query list to one entry per physical camera.
+
+        V4L2 lists a camera several times, once per ``/dev/videoN`` it exposes
+        (capture, metadata, ...). Grouping those by USB device rather than by
+        by-id path is what keeps twins that share a by-id name from collapsing
+        into one camera.
 
         Args:
-            infos: Raw query list, one entry per V4L2 node.
+            infos: Raw query list.
 
         Returns:
-            The deduped infos, and the indices of every node -- including the
-            extra nodes of one camera -- whose advertised identity cannot single
-            out a physical device.
+            The lowest-indexed entry of each camera, which is its capture device.
         """
-        on_linux = sys.platform.startswith("linux")
-        usb = {info.index: _usb_identity(info.index) for info in infos} if on_linux else {}
+        usb = {info.index: _usb_identity(info.index) for info in infos}
+        by_device: dict[str, omni_camera.CameraInfo] = {}
+        for info in infos:
+            device = _device_key(info, usb)
+            if device not in by_device or info.index < by_device[device].index:
+                by_device[device] = info
+        return list(by_device.values())
 
-        def phys_key(info: omni_camera.CameraInfo) -> str:
-            # Without sysfs evidence every node counts as its own device.
-            identity = usb.get(info.index)
-            return identity.devpath if identity else str(info.index)
+    @classmethod
+    def _ambiguous_indices(cls, infos: list[omni_camera.CameraInfo]) -> set[int]:
+        """Find the video indices whose advertised identity denotes several cameras.
 
-        devices = infos
-        if on_linux:
-            # V4L2 exposes several /dev/videoN nodes per physical camera
-            # (capture, metadata, ...). Every node of one camera resolves to
-            # the same USB device path and no two cameras ever share one, so
-            # it groups nodes correctly even when by-id paths collide. Keep
-            # the lowest node index per device: that is the capture node.
-            phys_best: dict[str, omni_camera.CameraInfo] = {}
-            for info in infos:
-                key = phys_key(info)
-                if key not in phys_best or info.index < phys_best[key].index:
-                    phys_best[key] = info
-            devices = list(phys_best.values())
+        Args:
+            infos: Raw query list.
 
-        # Some vendors bake the same USB descriptors into every unit of a
-        # model. Both units then claim one /dev/v4l/by-id name, so the by-id
-        # that does exist denotes either camera and must not be trusted. Count
-        # physical devices per model to detect that; counting after dedup
-        # keeps the extra nodes of a single camera from looking like a twin.
-        model_counts = Counter(identity.model_key for info in devices if (identity := usb.get(info.index)) is not None)
-        # Backends without sysfs evidence (macOS, Windows) can only report the
-        # weaker signal of two devices literally advertising the same id.
-        duplicate_ids = {
-            uid for uid, count in Counter(info.unique_id for info in devices if info.unique_id).items() if count > 1
+        Returns:
+            The indices no configuration can single a camera out by, a camera's
+            extra entries included. Empty unless two cameras answer to one
+            identity.
+        """
+        usb = {info.index: _usb_identity(info.index) for info in infos}
+        cameras = cls._physical_cameras(infos)
+
+        # Vendors that ship one iSerial for every unit of a model -- or none,
+        # which udev likewise leaves out of the name -- have both units claim
+        # one by-id name, and udev materialises it for one of them, so it
+        # denotes either unit. Counting per camera rather than per entry keeps
+        # one camera's extra entries from looking like a twin.
+        cameras_per_model = Counter(
+            identity.model_key for info in cameras if (identity := usb.get(info.index)) is not None
+        )
+        # Without sysfs the only evidence left is two cameras advertising the
+        # same identifier outright.
+        duplicated_ids = {
+            uid for uid, count in Counter(info.unique_id for info in cameras if info.unique_id).items() if count > 1
         }
 
-        def collides(info: omni_camera.CameraInfo) -> bool:
+        def shares_identity(info: omni_camera.CameraInfo) -> bool:
             identity = usb.get(info.index)
-            return (identity is not None and model_counts[identity.model_key] > 1) or info.unique_id in duplicate_ids
+            return (identity is not None and cameras_per_model[identity.model_key] > 1) or (
+                info.unique_id in duplicated_ids
+            )
 
-        colliding_keys = {phys_key(info) for info in devices if collides(info)}
-        # The extra nodes of a flagged camera are ambiguous too: each carries
-        # its own by-id, and a twin claims that name just as it claims the
-        # capture node's.
-        return devices, {info.index for info in infos if phys_key(info) in colliding_keys}
+        shared_devices = {_device_key(info, usb) for info in cameras if shares_identity(info)}
+        # Every entry of a flagged camera is affected, not just its capture
+        # device: each carries a by-id name that the twin claims as well.
+        return {info.index for info in infos if _device_key(info, usb) in shared_devices}
 
     @staticmethod
     def _resolve_device_info(infos: list[omni_camera.CameraInfo], device_id: int | str) -> omni_camera.CameraInfo:
@@ -164,7 +193,7 @@ class OmniCamera(Camera):
         normalized_device_id: int
         if isinstance(device_id, str):
             # ``index:N`` is the backend's own spelling of a video index; it
-            # reports one for every node that owns no by-id name, so it can
+            # reports one for every camera that owns no by-id name, so it can
             # reach us through a persisted hardware_id.
             stripped = device_id.removeprefix("index:")
             if stripped.isdecimal():
@@ -198,42 +227,47 @@ class OmniCamera(Camera):
     ) -> omni_camera.CameraInfo | int:
         """Resolve *device_id* to something safe to hand to ``omni_camera.Camera``.
 
-        Handed a ``CameraInfo``, the backend prefers ``info.unique_id`` over
-        ``info.index``: on Linux it resolves the by-id symlink back to whichever
-        node it points at, elsewhere it asks the platform to look the id up. An
-        index request must not go through that, or the index escape hatch a
-        colliding device is demoted to would land on whichever unit owns the
-        shared identity. An index request therefore resolves to the bare index,
-        which the backend opens directly -- its own fallback for a camera that
-        reports no unique_id.
-
         Args:
             infos: Raw query list.
             device_id: Video index, ``/dev/videoN`` path, or unique_id.
 
         Returns:
-            The matched ``CameraInfo`` for an unambiguous unique_id request, or
-            the video index for an index request.
+            A bare index when *device_id* names a video index, the
+            ``CameraInfo`` when it names the camera's unique_id.
 
         Raises:
-            CaptureError: The requested unique_id denotes more than one device.
+            CaptureError: The requested unique_id denotes more than one camera.
         """
         info = cls._resolve_device_info(infos, device_id)
-        # ``index:N`` is what the backend synthesises for a node with no by-id
-        # name of its own. It denotes exactly one node, so it is an index
-        # request rather than an identity udev could have handed to a twin.
-        by_unique_id = isinstance(device_id, str) and info.unique_id == device_id and not device_id.startswith("index:")
-        if not by_unique_id:
+
+        # Did the config name the camera's unique_id, or a video index?
+        # ``index:N`` is an index: it is the backend's own spelling of one,
+        # reported for any camera with no by-id name of its own, and no twin
+        # can claim it.
+        def names_unique_id() -> bool:
+            if not isinstance(device_id, str) or info.unique_id != device_id:
+                return False
+            return not device_id.startswith("index:")
+
+        if not names_unique_id():
+            # Handing over the CameraInfo instead would let the backend prefer
+            # info.unique_id and resolve the by-id symlink, which for twins can
+            # be the *other* camera -- defeating the index that a colliding
+            # camera is demoted to. A bare index is opened directly; it is the
+            # backend's own fallback for a camera that reports no unique_id.
             return info.index
 
-        _, ambiguous = cls._physical_devices(infos)
-        if info.index in ambiguous:
+        if info.index in cls._ambiguous_indices(infos):
             msg = (
                 f"Camera identity {device_id!r} is shared by more than one connected device "
                 "(duplicate or absent USB serial), so it cannot select a specific camera. "
                 "Open the camera by video index (e.g. device=0 or device='/dev/video0') instead."
             )
             raise CaptureError(msg)
+
+        # The camera owns this unique_id, so hand over the CameraInfo and let
+        # the backend re-resolve it. That is what lets a stable id keep finding
+        # its camera after the video indices have shifted.
         return info
 
     def _resolve_format(self) -> omni_camera.CameraFormat:
@@ -397,11 +431,12 @@ class OmniCamera(Camera):
     def discover(cls, *, only_usable: bool = True) -> list[DeviceInfo]:
         from physicalai.capture.discovery import DeviceInfo  # noqa: PLC0415
 
-        infos, colliding = cls._physical_devices(omni_camera.query(only_usable=only_usable))
+        infos = omni_camera.query(only_usable=only_usable)
+        ambiguous = cls._ambiguous_indices(infos)
 
         devices: list[DeviceInfo] = []
-        for info in infos:
-            has_collision = info.index in colliding
+        for info in cls._physical_cameras(infos):
+            has_collision = info.index in ambiguous
             stable = bool(info.id_stable and info.unique_id and not has_collision)
             devices.append(
                 DeviceInfo(

--- a/src/physicalai/capture/cameras/uvc/_omnicamera.py
+++ b/src/physicalai/capture/cameras/uvc/_omnicamera.py
@@ -43,20 +43,14 @@ class _UsbIdentity(NamedTuple):
 
 
 def _usb_identity(index: int) -> _UsbIdentity | None:
-    """Read the USB identity of a V4L2 node from sysfs.
+    """Return USB identity for the device behind ``/dev/video<index>``.
 
-    This is used purely as *evidence about* the ``/dev/v4l/by-id`` paths and
-    never as an identifier itself. Those paths are derived from the USB
-    iSerial, so they cannot witness their own uniqueness: when a vendor ships
-    one serial for every unit of a model, two cameras claim the same by-id
-    name and udev materialises it for only one of them.
-
-    Args:
-        index: V4L2 node index, i.e. the ``N`` in ``/dev/videoN``.
+    On Linux, walk from ``/sys/class/video4linux/video<index>/device`` to the
+    owning USB node and read ``idVendor``, ``idProduct``, and ``serial``.
 
     Returns:
-        Identity of the owning USB device, or None when it cannot be read
-        (non-Linux, non-USB device, or unreadable sysfs).
+        The owning device's identity, or None on non-Linux platforms and when
+        sysfs does not expose the required attributes.
     """
     if not sys.platform.startswith("linux"):
         return None
@@ -76,20 +70,10 @@ def _usb_identity(index: int) -> _UsbIdentity | None:
 
 
 def _device_key(info: omni_camera.CameraInfo, usb: dict[int, _UsbIdentity | None]) -> str:
-    """Key a query entry by the physical device behind it.
-
-    Two entries share a key when they are the same camera. The USB device path
-    does that job: a camera's several ``/dev/videoN`` entries (capture,
-    metadata, ...) all sit on one path, and no two cameras share one -- unlike
-    a by-id path, which twins do share.
-
-    Args:
-        info: The query entry to key.
-        usb: Identity per video index, from :func:`_usb_identity`.
+    """Key an entry by the camera behind it: its USB device path, or its own index.
 
     Returns:
-        The USB device path, or the entry's own video index where sysfs said
-        nothing (non-USB device, macOS, Windows), which keys it on its own.
+        A key two entries share only when they are the same camera.
     """
     identity = usb.get(info.index)
     return identity.devpath if identity else str(info.index)

--- a/src/physicalai/capture/cameras/uvc/_omnicamera.py
+++ b/src/physicalai/capture/cameras/uvc/_omnicamera.py
@@ -97,6 +97,62 @@ class OmniCamera(Camera):
         self._last_frame: np.ndarray | None = None
 
     @staticmethod
+    def _physical_devices(infos: list[omni_camera.CameraInfo]) -> tuple[list[omni_camera.CameraInfo], set[int]]:
+        """Reduce a query list to one entry per physical camera and flag ambiguous nodes.
+
+        Args:
+            infos: Raw query list, one entry per V4L2 node.
+
+        Returns:
+            The deduped infos, and the indices of every node -- including the
+            extra nodes of one camera -- whose advertised identity cannot single
+            out a physical device.
+        """
+        on_linux = sys.platform.startswith("linux")
+        usb = {info.index: _usb_identity(info.index) for info in infos} if on_linux else {}
+
+        def phys_key(info: omni_camera.CameraInfo) -> str:
+            # Without sysfs evidence every node counts as its own device.
+            identity = usb.get(info.index)
+            return identity.devpath if identity else str(info.index)
+
+        devices = infos
+        if on_linux:
+            # V4L2 exposes several /dev/videoN nodes per physical camera
+            # (capture, metadata, ...). Every node of one camera resolves to
+            # the same USB device path and no two cameras ever share one, so
+            # it groups nodes correctly even when by-id paths collide. Keep
+            # the lowest node index per device: that is the capture node.
+            phys_best: dict[str, omni_camera.CameraInfo] = {}
+            for info in infos:
+                key = phys_key(info)
+                if key not in phys_best or info.index < phys_best[key].index:
+                    phys_best[key] = info
+            devices = list(phys_best.values())
+
+        # Some vendors bake the same USB descriptors into every unit of a
+        # model. Both units then claim one /dev/v4l/by-id name, so the by-id
+        # that does exist denotes either camera and must not be trusted. Count
+        # physical devices per model to detect that; counting after dedup
+        # keeps the extra nodes of a single camera from looking like a twin.
+        model_counts = Counter(identity.model_key for info in devices if (identity := usb.get(info.index)) is not None)
+        # Backends without sysfs evidence (macOS, Windows) can only report the
+        # weaker signal of two devices literally advertising the same id.
+        duplicate_ids = {
+            uid for uid, count in Counter(info.unique_id for info in devices if info.unique_id).items() if count > 1
+        }
+
+        def collides(info: omni_camera.CameraInfo) -> bool:
+            identity = usb.get(info.index)
+            return (identity is not None and model_counts[identity.model_key] > 1) or info.unique_id in duplicate_ids
+
+        colliding_keys = {phys_key(info) for info in devices if collides(info)}
+        # The extra nodes of a flagged camera are ambiguous too: each carries
+        # its own by-id, and a twin claims that name just as it claims the
+        # capture node's.
+        return devices, {info.index for info in infos if phys_key(info) in colliding_keys}
+
+    @staticmethod
     def _resolve_device_info(infos: list[omni_camera.CameraInfo], device_id: int | str) -> omni_camera.CameraInfo:
         # Try unique_id match first for string identifiers.
         if isinstance(device_id, str) and device_id:
@@ -107,8 +163,12 @@ class OmniCamera(Camera):
         # Fall back to index-based resolution.
         normalized_device_id: int
         if isinstance(device_id, str):
-            if device_id.isdecimal():
-                normalized_device_id = int(device_id)
+            # ``index:N`` is the backend's own spelling of a video index; it
+            # reports one for every node that owns no by-id name, so it can
+            # reach us through a persisted hardware_id.
+            stripped = device_id.removeprefix("index:")
+            if stripped.isdecimal():
+                normalized_device_id = int(stripped)
             elif device_id.startswith("/dev/video"):
                 suffix = device_id.removeprefix("/dev/video")
                 if not suffix.isdecimal():
@@ -127,6 +187,52 @@ class OmniCamera(Camera):
         info = next((candidate for candidate in infos if candidate.index == normalized_device_id), None)
         if info is None:
             msg = f"No camera found at index {normalized_device_id}"
+            raise CaptureError(msg)
+        return info
+
+    @classmethod
+    def _resolve_open_target(
+        cls,
+        infos: list[omni_camera.CameraInfo],
+        device_id: int | str,
+    ) -> omni_camera.CameraInfo | int:
+        """Resolve *device_id* to something safe to hand to ``omni_camera.Camera``.
+
+        Handed a ``CameraInfo``, the backend prefers ``info.unique_id`` over
+        ``info.index``: on Linux it resolves the by-id symlink back to whichever
+        node it points at, elsewhere it asks the platform to look the id up. An
+        index request must not go through that, or the index escape hatch a
+        colliding device is demoted to would land on whichever unit owns the
+        shared identity. An index request therefore resolves to the bare index,
+        which the backend opens directly -- its own fallback for a camera that
+        reports no unique_id.
+
+        Args:
+            infos: Raw query list.
+            device_id: Video index, ``/dev/videoN`` path, or unique_id.
+
+        Returns:
+            The matched ``CameraInfo`` for an unambiguous unique_id request, or
+            the video index for an index request.
+
+        Raises:
+            CaptureError: The requested unique_id denotes more than one device.
+        """
+        info = cls._resolve_device_info(infos, device_id)
+        # ``index:N`` is what the backend synthesises for a node with no by-id
+        # name of its own. It denotes exactly one node, so it is an index
+        # request rather than an identity udev could have handed to a twin.
+        by_unique_id = isinstance(device_id, str) and info.unique_id == device_id and not device_id.startswith("index:")
+        if not by_unique_id:
+            return info.index
+
+        _, ambiguous = cls._physical_devices(infos)
+        if info.index in ambiguous:
+            msg = (
+                f"Camera identity {device_id!r} is shared by more than one connected device "
+                "(duplicate or absent USB serial), so it cannot select a specific camera. "
+                "Open the camera by video index (e.g. device=0 or device='/dev/video0') instead."
+            )
             raise CaptureError(msg)
         return info
 
@@ -168,10 +274,10 @@ class OmniCamera(Camera):
         while not infos and time.monotonic() < query_deadline:
             time.sleep(0.1)
             infos = omni_camera.query(only_usable=False)
-        info = self._resolve_device_info(infos, self._device_id_raw)
+        target = self._resolve_open_target(infos, self._device_id_raw)
 
         try:
-            self._cam = omni_camera.Camera(info)
+            self._cam = omni_camera.Camera(target)
             fmt = self._resolve_format()
 
             self._cam.open(fmt)
@@ -291,42 +397,11 @@ class OmniCamera(Camera):
     def discover(cls, *, only_usable: bool = True) -> list[DeviceInfo]:
         from physicalai.capture.discovery import DeviceInfo  # noqa: PLC0415
 
-        infos = omni_camera.query(only_usable=only_usable)
-        on_linux = sys.platform.startswith("linux")
-        usb = {info.index: _usb_identity(info.index) for info in infos} if on_linux else {}
-
-        if on_linux:
-            # V4L2 exposes several /dev/videoN nodes per physical camera
-            # (capture, metadata, ...). Every node of one camera resolves to
-            # the same USB device path and no two cameras ever share one, so
-            # it groups nodes correctly even when by-id paths collide. Keep
-            # the lowest node index per device: that is the capture node.
-            phys_best: dict[str, omni_camera.CameraInfo] = {}
-            for info in infos:
-                identity = usb.get(info.index)
-                phys_key = identity.devpath if identity else str(info.index)
-                if phys_key not in phys_best or info.index < phys_best[phys_key].index:
-                    phys_best[phys_key] = info
-            infos = list(phys_best.values())
-
-        # Some vendors bake the same USB descriptors into every unit of a
-        # model. Both units then claim one /dev/v4l/by-id name, so the by-id
-        # that does exist denotes either camera and must not be trusted. Count
-        # physical devices per model to detect that; counting after dedup
-        # keeps the extra nodes of a single camera from looking like a twin.
-        model_counts = Counter(identity.model_key for info in infos if (identity := usb.get(info.index)) is not None)
-        # Backends without sysfs evidence (macOS, Windows) can only report the
-        # weaker signal of two devices literally advertising the same id.
-        duplicate_ids = {
-            uid for uid, count in Counter(info.unique_id for info in infos if info.unique_id).items() if count > 1
-        }
+        infos, colliding = cls._physical_devices(omni_camera.query(only_usable=only_usable))
 
         devices: list[DeviceInfo] = []
         for info in infos:
-            identity = usb.get(info.index)
-            has_collision = (identity is not None and model_counts[identity.model_key] > 1) or (
-                info.unique_id in duplicate_ids
-            )
+            has_collision = info.index in colliding
             stable = bool(info.id_stable and info.unique_id and not has_collision)
             devices.append(
                 DeviceInfo(
@@ -361,8 +436,7 @@ class OmniCamera(Camera):
         """
         infos = omni_camera.query(only_usable=False)
         resolved_id: int | str = int(device_id) if device_id.isdecimal() else device_id
-        info = cls._resolve_device_info(infos, resolved_id)
-        cam = omni_camera.Camera(info)
+        cam = omni_camera.Camera(cls._resolve_open_target(infos, resolved_id))
         fmts = cam.get_format_options()
         return sorted({(f.width, f.height, int(f.frame_rate)) for f in fmts})
 

--- a/src/physicalai/capture/cameras/uvc/_omnicamera.py
+++ b/src/physicalai/capture/cameras/uvc/_omnicamera.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import contextlib
-import re
 import sys
 import time
-from typing import TYPE_CHECKING, Any, cast
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import numpy as np
 import pynokhwa as omni_camera  # rename omni_camera references
@@ -23,6 +24,53 @@ if TYPE_CHECKING:
 
 _MISSING_DEP_PKG = "omni_camera"
 _MISSING_DEP_EXTRA = "capture"
+
+_SYSFS_V4L2 = Path("/sys/class/video4linux")
+
+
+class _UsbIdentity(NamedTuple):
+    """USB identity of the device owning a V4L2 node."""
+
+    devpath: str
+    """USB device path, e.g. ``3-6.1``. Unique per physical port."""
+
+    model_key: tuple[str, str, str]
+    """``(idVendor, idProduct, serial)``.
+
+    An unreported serial is empty, which is itself a collision key: udev omits
+    it from the by-id name, so every unit of such a model claims one path.
+    """
+
+
+def _usb_identity(index: int) -> _UsbIdentity | None:
+    """Read the USB identity of a V4L2 node from sysfs.
+
+    This is used purely as *evidence about* the ``/dev/v4l/by-id`` paths and
+    never as an identifier itself. Those paths are derived from the USB
+    iSerial, so they cannot witness their own uniqueness: when a vendor ships
+    one serial for every unit of a model, two cameras claim the same by-id
+    name and udev materialises it for only one of them.
+
+    Args:
+        index: V4L2 node index, i.e. the ``N`` in ``/dev/videoN``.
+
+    Returns:
+        Identity of the owning USB device, or None when it cannot be read
+        (non-Linux, non-USB device, or unreadable sysfs).
+    """
+    try:
+        path = (_SYSFS_V4L2 / f"video{index}" / "device").resolve(strict=True)
+        while not (path / "idVendor").exists():
+            if path.parent == path:
+                return None
+            path = path.parent
+        attrs = tuple(
+            (path / name).read_text().strip() if (path / name).exists() else ""
+            for name in ("idVendor", "idProduct", "serial")
+        )
+    except OSError:
+        return None
+    return _UsbIdentity(devpath=path.name, model_key=cast("tuple[str, str, str]", attrs))
 
 
 class OmniCamera(Camera):
@@ -244,40 +292,41 @@ class OmniCamera(Camera):
         from physicalai.capture.discovery import DeviceInfo  # noqa: PLC0415
 
         infos = omni_camera.query(only_usable=only_usable)
+        on_linux = sys.platform.startswith("linux")
+        usb = {info.index: _usb_identity(info.index) for info in infos} if on_linux else {}
 
-        if sys.platform.startswith("linux"):
-            # V4L2 exposes multiple /dev/videoN nodes per physical camera
-            # (e.g. capture + metadata with distinct by-id paths like
-            # ...-video-index0 and ...-video-index1). Keep only the lowest-
-            # index node per physical device (index0 = capture, index1+ = metadata).
+        if on_linux:
+            # V4L2 exposes several /dev/videoN nodes per physical camera
+            # (capture, metadata, ...). Every node of one camera resolves to
+            # the same USB device path and no two cameras ever share one, so
+            # it groups nodes correctly even when by-id paths collide. Keep
+            # the lowest node index per device: that is the capture node.
             phys_best: dict[str, omni_camera.CameraInfo] = {}
             for info in infos:
-                uid = info.unique_id or ""
-                # Only group by stripped key when the V4L2 multi-node
-                # suffix is present (e.g. ...-video-index0 / -video-index1).
-                # Cameras without that suffix keep their own index key so
-                # genuinely separate devices sharing a serial are not collapsed.
-                if uid and re.search(r"-video-index\d+$", uid):
-                    phys_key = re.sub(r"-video-index\d+$", "", uid)
-                else:
-                    phys_key = str(info.index)
+                identity = usb.get(info.index)
+                phys_key = identity.devpath if identity else str(info.index)
                 if phys_key not in phys_best or info.index < phys_best[phys_key].index:
                     phys_best[phys_key] = info
             infos = list(phys_best.values())
 
-        # Some vendors/models bake the same USB iSerial into every
-        # unit of a model. When a unique_id appears more than once it cannot
-        # identify a specific device, so demote those entries to index-based
-        # fingerprints and let the user manage cable-to-config mapping.
-        unique_id_counts: dict[str, int] = {}
-        for info in infos:
-            if info.unique_id:
-                unique_id_counts[info.unique_id] = unique_id_counts.get(info.unique_id, 0) + 1
-        colliding_ids = {uid for uid, count in unique_id_counts.items() if count > 1}
+        # Some vendors bake the same USB descriptors into every unit of a
+        # model. Both units then claim one /dev/v4l/by-id name, so the by-id
+        # that does exist denotes either camera and must not be trusted. Count
+        # physical devices per model to detect that; counting after dedup
+        # keeps the extra nodes of a single camera from looking like a twin.
+        model_counts = Counter(identity.model_key for info in infos if (identity := usb.get(info.index)) is not None)
+        # Backends without sysfs evidence (macOS, Windows) can only report the
+        # weaker signal of two devices literally advertising the same id.
+        duplicate_ids = {
+            uid for uid, count in Counter(info.unique_id for info in infos if info.unique_id).items() if count > 1
+        }
 
         devices: list[DeviceInfo] = []
         for info in infos:
-            has_collision = bool(info.unique_id) and info.unique_id in colliding_ids
+            identity = usb.get(info.index)
+            has_collision = (identity is not None and model_counts[identity.model_key] > 1) or (
+                info.unique_id in duplicate_ids
+            )
             stable = bool(info.id_stable and info.unique_id and not has_collision)
             devices.append(
                 DeviceInfo(

--- a/tests/unit/capture/test_omnicamera.py
+++ b/tests/unit/capture/test_omnicamera.py
@@ -465,7 +465,7 @@ def test_discover_returns_device_info(omnicamera_cls: tuple) -> None:
 
 
 def test_device_selector_path_string_maps_to_index(omnicamera_cls: tuple) -> None:
-    """connect() with /dev/videoN extracts N and uses it as the camera index."""
+    """connect() with /dev/videoN extracts N and opens that explicit index."""
     camera_cls, mock_omni_camera = omnicamera_cls
 
     cam_info_2 = mock.MagicMock()
@@ -483,7 +483,7 @@ def test_device_selector_path_string_maps_to_index(omnicamera_cls: tuple) -> Non
     cam = camera_cls(device_id="/dev/video2")
     cam.connect()
     assert cam.is_connected
-    mock_omni_camera.Camera.assert_called_with(cam_info_2)
+    mock_omni_camera.Camera.assert_called_with(2)
 
 
 def test_device_selector_invalid_path_raises_value_error(omnicamera_cls: tuple) -> None:
@@ -717,6 +717,258 @@ def test_discover_demotes_duplicate_ids_without_sysfs(
     assert [d.device_id for d in devices] == ["0", "1"]
     assert all(d.id_stable is False for d in devices)
     assert all(d.metadata["serial_collision"] is True for d in devices)
+
+
+# ------------------------------------------------------------------
+# Open-target tests: which camera a resolved id actually opens
+# ------------------------------------------------------------------
+
+
+_INNOMAKER_META_BY_ID = _INNOMAKER_BY_ID.replace("-video-index0", "-video-index1")
+
+
+def _install_innomaker_twins(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    loser_unique_ids: tuple[str, str] = ("index:42", "index:43"),
+) -> None:
+    """Fake two units of one model sharing an iSerial, as query() reports them.
+
+    Four V4L2 nodes over two USB ports. Both units claim the same by-id names,
+    udev materialises them for the winner only, so the loser's nodes fall back
+    to a synthetic ``index:N``.
+
+    Args:
+        omnicamera_cls: The ``(class, omni_camera mock)`` fixture value.
+        monkeypatch: Test monkeypatch.
+        loser_unique_ids: What the second unit's two nodes report. Override to
+            the winner's by-id paths to model a backend that hands the same
+            path to both units.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(41, _INNOMAKER_META_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(42, loser_unique_ids[0], name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+        _make_cam_info(43, loser_unique_ids[1], name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+    ]
+    _patch_usb_identity(
+        monkeypatch,
+        camera_cls,
+        {
+            40: ("3-6.1", _INNOMAKER_USB),
+            41: ("3-6.1", _INNOMAKER_USB),
+            42: ("3-6.2", _INNOMAKER_USB),
+            43: ("3-6.2", _INNOMAKER_USB),
+        },
+    )
+
+
+@pytest.mark.parametrize("device_id", [42, "42", "/dev/video42"], ids=["int", "decimal-string", "dev-path"])
+def test_connect_by_index_opens_that_index_verbatim(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+    device_id: int | str,
+) -> None:
+    """An index request opens the named node, never a by-id symlink.
+
+    Handed a CameraInfo the backend prefers ``unique_id`` and resolves the by-id
+    symlink, which for a colliding pair exists once and may point at the *other*
+    unit -- so the index that discover() demotes a colliding device to would open
+    the wrong camera. A bare index is opened directly.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    _install_innomaker_twins(omnicamera_cls, monkeypatch)
+
+    cam = camera_cls(device_id=device_id)
+    cam.connect()
+
+    assert cam.is_connected
+    mock_omni_camera.Camera.assert_called_with(42)
+
+
+def test_connect_by_index_bypasses_a_shared_unique_id_without_sysfs(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Off Linux an index request also bypasses the shared identity.
+
+    macOS and Windows have no by-id symlink to resolve, but the backend still
+    prefers ``unique_id`` and asks the platform to look it up, which for two
+    devices advertising one id can land on either.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "darwin")
+    mock_omni_camera.query.return_value = [_make_cam_info(0, "shared-uid"), _make_cam_info(1, "shared-uid")]
+
+    cam = camera_cls(device_id=1)
+    cam.connect()
+
+    assert cam.is_connected
+    mock_omni_camera.Camera.assert_called_with(1)
+
+
+def test_connect_by_unique_id_passes_camera_info(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unambiguous unique_id request still opens through the CameraInfo.
+
+    That is the point of a stable id: the backend re-resolves it, so the camera
+    is found again after its video index has changed.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    infos = [
+        _make_cam_info(0, _UGREEN_BY_ID, name="UGREEN Camera 2K"),
+        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+    ]
+    mock_omni_camera.query.return_value = infos
+    _patch_usb_identity(monkeypatch, camera_cls, {0: ("3-5", _UGREEN_USB), 40: ("3-6.1", _INNOMAKER_USB)})
+
+    cam = camera_cls(device_id=_INNOMAKER_BY_ID)
+    cam.connect()
+
+    assert cam.is_connected
+    mock_omni_camera.Camera.assert_called_with(infos[1])
+
+
+@pytest.mark.parametrize(("device_id", "expected"), [("index:42", 42), ("index:40", 40)], ids=["no-by-id", "has-by-id"])
+def test_connect_by_synthetic_index_id_is_an_index_request(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+    device_id: str,
+    expected: int,
+) -> None:
+    """An ``index:N`` identity opens node N and is never refused as ambiguous.
+
+    That is what the backend reports for a node with no by-id name of its own,
+    so it reaches us through ``hardware_id``. It names exactly one node, unlike
+    the by-id its twin also claims -- and it keeps naming that node after udev
+    has since given it a by-id, when it no longer matches any reported id.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    _install_innomaker_twins(omnicamera_cls, monkeypatch)
+
+    cam = camera_cls(device_id=device_id)
+    cam.connect()
+
+    assert cam.is_connected
+    mock_omni_camera.Camera.assert_called_with(expected)
+
+
+def test_connect_refuses_a_by_id_shared_by_two_units(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
+    """connect() refuses a by-id that udev could not disambiguate.
+
+    discover() stops offering it, but a config written before the second unit
+    was plugged in still names it. Opening it would silently stream whichever
+    unit currently owns the symlink -- and pairing it with the other unit's
+    index yields the same camera twice.
+    """
+    camera_cls, _ = omnicamera_cls
+    _install_innomaker_twins(omnicamera_cls, monkeypatch)
+
+    cam = camera_cls(device_id=_INNOMAKER_BY_ID)
+    with pytest.raises(CaptureError, match="video index"):
+        cam.connect()
+
+    assert not cam.is_connected
+
+
+def test_connect_refuses_a_by_id_of_an_extra_node(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The refusal covers the metadata nodes of a colliding camera too.
+
+    They are absent from discover() but reachable by hand, and each carries its
+    own by-id that a twin claims just as it claims the capture node's.
+    """
+    camera_cls, _ = omnicamera_cls
+    _install_innomaker_twins(omnicamera_cls, monkeypatch)
+
+    cam = camera_cls(device_id=_INNOMAKER_META_BY_ID)
+    with pytest.raises(CaptureError, match="video index"):
+        cam.connect()
+
+    assert not cam.is_connected
+
+
+def test_connect_refuses_a_by_id_reported_by_both_units(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A by-id that both units literally report is ambiguous by inspection."""
+    camera_cls, _ = omnicamera_cls
+    _install_innomaker_twins(
+        omnicamera_cls,
+        monkeypatch,
+        loser_unique_ids=(_INNOMAKER_BY_ID, _INNOMAKER_META_BY_ID),
+    )
+
+    cam = camera_cls(device_id=_INNOMAKER_BY_ID)
+    with pytest.raises(CaptureError, match="video index"):
+        cam.connect()
+
+    assert not cam.is_connected
+
+
+def test_connect_refuses_a_by_id_of_twins_without_serial(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two units of a model that reports no iSerial collide the same way."""
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    by_id = "/dev/v4l/by-id/usb-Innomaker_Innomaker-U20CAM-1080p-S1-video-index0"
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(40, by_id, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(42, "index:42", name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+    ]
+    no_serial = ("0c45", "6366", "")
+    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", no_serial), 42: ("3-6.2", no_serial)})
+
+    cam = camera_cls(device_id=by_id)
+    with pytest.raises(CaptureError, match="video index"):
+        cam.connect()
+
+    assert not cam.is_connected
+
+
+def test_connect_refuses_a_duplicate_unique_id_without_sysfs(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Off Linux a duplicated unique_id is refused on the same grounds."""
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "darwin")
+    mock_omni_camera.query.return_value = [_make_cam_info(0, "shared-uid"), _make_cam_info(1, "shared-uid")]
+
+    cam = camera_cls(device_id="shared-uid")
+    with pytest.raises(CaptureError, match="video index"):
+        cam.connect()
+
+    assert not cam.is_connected
+
+
+def test_query_formats_by_index_uses_the_index_token(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """query_formats() probes the named index, not the by-id symlink.
+
+    Otherwise a colliding device reports the other unit's capabilities.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    _install_innomaker_twins(omnicamera_cls, monkeypatch)
+
+    assert camera_cls.query_formats("42") == [(640, 480, 30)]
+    mock_omni_camera.Camera.assert_called_with(42)
+
+
+def test_query_formats_refuses_an_ambiguous_by_id(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
+    """query_formats() inherits the refusal: it resolves the same way connect() does."""
+    camera_cls, _ = omnicamera_cls
+    _install_innomaker_twins(omnicamera_cls, monkeypatch)
+
+    with pytest.raises(CaptureError, match="video index"):
+        camera_cls.query_formats(_INNOMAKER_BY_ID)
 
 
 def test_discover_falls_back_to_index_when_id_unstable(omnicamera_cls: tuple) -> None:

--- a/tests/unit/capture/test_omnicamera.py
+++ b/tests/unit/capture/test_omnicamera.py
@@ -16,12 +16,12 @@ import pytest
 from physicalai.capture.camera import ColorMode
 from physicalai.capture.cameras.uvc._camera_setting import CameraSetting
 from physicalai.capture.discovery import DeviceInfo
-from physicalai.capture.errors import CaptureError, CaptureTimeoutError, MissingDependencyError, NotConnectedError
+from physicalai.capture.errors import CaptureError, CaptureTimeoutError, NotConnectedError
 from physicalai.capture.frame import Frame
 
 
 @pytest.fixture
-def omnicamera_cls():  # noqa: ANN201
+def omnicamera_cls(monkeypatch: pytest.MonkeyPatch):  # noqa: ANN201
     """Inject a mock omni_camera module and reload OmniCamera with it.
 
     Yields:
@@ -66,6 +66,9 @@ def omnicamera_cls():  # noqa: ANN201
     sys.modules.pop("physicalai.capture.cameras.uvc._omnicamera", None)
 
     module = importlib.import_module("physicalai.capture.cameras.uvc._omnicamera")
+    # Keep discovery hermetic: the real helper reads /sys and would otherwise
+    # report whatever cameras happen to be plugged into the test machine.
+    monkeypatch.setattr(module, "_usb_identity", lambda _index: None)
     camera_cls = module.OmniCamera
 
     yield camera_cls, mock_omni_camera
@@ -517,37 +520,203 @@ def test_discover_uses_unique_id_when_stable(omnicamera_cls: tuple) -> None:
     assert devices[0].metadata["serial_collision"] is False
 
 
-def test_discover_demotes_colliding_unique_ids(omnicamera_cls: tuple) -> None:
-    """discover() falls back to index when multiple devices share unique_id (e.g. InnoMaker)."""
+def _make_cam_info(index: int, unique_id: str, *, name: str = "UVC Camera", id_stable: bool = True):  # noqa: ANN202
+    """Build a mock omni_camera CameraInfo."""
+    info = mock.MagicMock()
+    info.index = index
+    info.name = name
+    info.description = ""
+    info.misc = ""
+    info.unique_id = unique_id
+    info.id_stable = id_stable
+    info.can_open.return_value = True
+    return info
+
+
+def _patch_usb_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    camera_cls: type,
+    identities: dict[int, tuple[str, tuple[str, str, str]]],
+) -> None:
+    """Install a fake sysfs ``node index -> (devpath, model_key)`` map."""
+    module = sys.modules[camera_cls.__module__]
+    fake = {index: module._UsbIdentity(devpath, key) for index, (devpath, key) in identities.items()}  # noqa: SLF001
+    monkeypatch.setattr(module, "_usb_identity", fake.get)
+
+
+# Real values. The ``-video-indexN`` suffix numbers a camera's nodes *within*
+# that camera, so every unit's capture node wants the same ``-video-index0``
+# name -- which is why two units of one model collide. sysfs identity is
+# ``(idVendor, idProduct, serial)``: two *different* models ship the same
+# placeholder serial, so the serial alone cannot be the key.
+_INNOMAKER_BY_ID = "/dev/v4l/by-id/usb-Innomaker_Innomaker-U20CAM-1080p-S1_SN0001-video-index0"
+_UGREEN_BY_ID = "/dev/v4l/by-id/usb-UGREEN_Camera_2K_UGREEN_Camera_2K_SN0001-video-index0"
+_INNOMAKER_USB = ("0c45", "6366", "SN0001")
+_UGREEN_USB = ("0c45", "636f", "SN0001")
+
+
+def test_discover_demotes_by_id_when_a_same_model_twin_has_none(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """discover() must not hand out a by-id path that udev could not disambiguate.
+
+    "One symlink wins": two units sharing an iSerial claim the same
+    ``/dev/v4l/by-id`` name and udev materialises it once, so only the winner
+    reports a by-id and the loser falls back to a synthetic ``index:N``. No
+    value is duplicated, so counting duplicate by-ids finds no collision and
+    the winner keeps ``id_stable=True`` -- though its symlink denotes either
+    camera and can point at the other one after a reboot.
+    """
     camera_cls, mock_omni_camera = omnicamera_cls
-
-    cam_info_0 = mock.MagicMock()
-    cam_info_0.index = 0
-    cam_info_0.name = "InnoMaker UVC"
-    cam_info_0.description = ""
-    cam_info_0.misc = ""
-    cam_info_0.unique_id = "shared-serial"
-    cam_info_0.id_stable = True
-
-    cam_info_1 = mock.MagicMock()
-    cam_info_1.index = 1
-    cam_info_1.name = "InnoMaker UVC"
-    cam_info_1.description = ""
-    cam_info_1.misc = ""
-    cam_info_1.unique_id = "shared-serial"
-    cam_info_1.id_stable = True
-
-    mock_omni_camera.query.return_value = [cam_info_0, cam_info_1]
+    monkeypatch.setattr(sys, "platform", "linux")
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(42, "index:42", name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+    ]
+    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", _INNOMAKER_USB), 42: ("3-6.2", _INNOMAKER_USB)})
 
     devices = camera_cls.discover()
 
-    assert len(devices) == 2
-    assert devices[0].device_id == "0"
-    assert devices[1].device_id == "1"
-    assert devices[0].id_stable is False
-    assert devices[1].id_stable is False
-    assert devices[0].metadata["serial_collision"] is True
-    assert devices[1].metadata["serial_collision"] is True
+    assert [d.index for d in devices] == [40, 42]
+    # Neither camera may claim a stable fingerprint: the lone by-id cannot tell
+    # the two units apart, so both fall back to index-based ids.
+    assert [d.device_id for d in devices] == ["40", "42"]
+    assert all(d.id_stable is False for d in devices)
+    assert all(d.metadata["serial_collision"] is True for d in devices)
+    # The ambiguous identity stays available for diagnostics.
+    assert devices[0].hardware_id == _INNOMAKER_BY_ID
+
+
+def test_discover_keeps_distinct_models_sharing_a_generic_serial(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two different models with the same generic iSerial stay two stable devices.
+
+    Their by-id paths differ (vendor and product are baked in), so there is no
+    real collision and neither entry may be dropped or demoted. Regression guard
+    against a collision check that keys on the serial alone.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(0, _UGREEN_BY_ID, name="UGREEN Camera 2K"),
+        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+    ]
+    _patch_usb_identity(monkeypatch, camera_cls, {0: ("3-5", _UGREEN_USB), 40: ("3-6.1", _INNOMAKER_USB)})
+
+    devices = camera_cls.discover()
+
+    assert [d.device_id for d in devices] == [_UGREEN_BY_ID, _INNOMAKER_BY_ID]
+    assert all(d.id_stable is True for d in devices)
+    assert all(d.metadata["serial_collision"] is False for d in devices)
+
+
+def test_discover_collapses_multi_node_single_camera(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The capture and metadata nodes of one camera collapse to one entry.
+
+    Same by-id on both nodes as in the twin case below; only the devpath
+    differs, and it is the sole discriminator -- one camera's nodes share it,
+    two cameras never do. The lowest-index node survives, and the pair must not
+    be counted as two units of the same model.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(41, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+    ]
+    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", _INNOMAKER_USB), 41: ("3-6.1", _INNOMAKER_USB)})
+
+    devices = camera_cls.discover()
+
+    assert len(devices) == 1
+    assert devices[0].index == 40
+    assert devices[0].device_id == _INNOMAKER_BY_ID
+    assert devices[0].id_stable is True
+    assert devices[0].metadata["serial_collision"] is False
+
+
+def test_discover_demotes_colliding_unique_ids(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
+    """discover() keeps and demotes both cameras when they report the same by-id.
+
+    Reachable via ``discover(only_usable=False)``, where the losing twin can
+    still surface the winner's by-id. Keying the node dedup off that path maps
+    both cameras onto one entry, so a camera vanishes from discovery entirely.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(42, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+    ]
+    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", _INNOMAKER_USB), 42: ("3-6.2", _INNOMAKER_USB)})
+
+    devices = camera_cls.discover()
+
+    # Neither camera may be dropped: they are two separate physical devices
+    # that merely advertise the same identity.
+    assert [d.index for d in devices] == [40, 42]
+    assert [d.device_id for d in devices] == ["40", "42"]
+    assert all(d.id_stable is False for d in devices)
+    assert all(d.metadata["serial_collision"] is True for d in devices)
+    # The ambiguous identity stays available for diagnostics.
+    assert all(d.hardware_id == _INNOMAKER_BY_ID for d in devices)
+
+
+def test_discover_demotes_twins_that_report_no_serial(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two units of a model that reports no iSerial at all also collide.
+
+    udev simply omits the serial from the by-id name, so both units claim
+    ``usb-Vendor_Model-video-index0``. Regression guard against skipping
+    devices with an empty serial when counting units per model.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "linux")
+    by_id = "/dev/v4l/by-id/usb-Innomaker_Innomaker-U20CAM-1080p-S1-video-index0"
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(40, by_id, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(42, "index:42", name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+    ]
+    no_serial = ("0c45", "6366", "")
+    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", no_serial), 42: ("3-6.2", no_serial)})
+
+    devices = camera_cls.discover()
+
+    assert [d.device_id for d in devices] == ["40", "42"]
+    assert all(d.id_stable is False for d in devices)
+    assert all(d.metadata["serial_collision"] is True for d in devices)
+
+
+def test_discover_demotes_duplicate_ids_without_sysfs(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Off Linux there is no sysfs, so duplicate ids remain the only signal.
+
+    Regression guard against the sysfs evidence *replacing* rather than
+    augmenting the duplicate check, which would silently hand macOS and
+    Windows two stable devices sharing one identity.
+    """
+    camera_cls, mock_omni_camera = omnicamera_cls
+    monkeypatch.setattr(sys, "platform", "darwin")
+    mock_omni_camera.query.return_value = [
+        _make_cam_info(0, "shared-uid"),
+        _make_cam_info(1, "shared-uid"),
+    ]
+
+    devices = camera_cls.discover()
+
+    assert [d.device_id for d in devices] == ["0", "1"]
+    assert all(d.id_stable is False for d in devices)
+    assert all(d.metadata["serial_collision"] is True for d in devices)
 
 
 def test_discover_falls_back_to_index_when_id_unstable(omnicamera_cls: tuple) -> None:

--- a/tests/unit/capture/test_omnicamera.py
+++ b/tests/unit/capture/test_omnicamera.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import importlib
+import pathlib
 import sys
 from unittest import mock
 
@@ -550,6 +551,7 @@ def _patch_usb_identity(
 # ``(idVendor, idProduct, serial)``: two *different* models ship the same
 # placeholder serial, so the serial alone cannot be the key.
 _INNOMAKER_BY_ID = "/dev/v4l/by-id/usb-Innomaker_Innomaker-U20CAM-1080p-S1_SN0001-video-index0"
+_INNOMAKER_META_BY_ID = _INNOMAKER_BY_ID.replace("-video-index0", "-video-index1")
 _UGREEN_BY_ID = "/dev/v4l/by-id/usb-UGREEN_Camera_2K_UGREEN_Camera_2K_SN0001-video-index0"
 _INNOMAKER_USB = ("0c45", "6366", "SN0001")
 _UGREEN_USB = ("0c45", "636f", "SN0001")
@@ -619,16 +621,17 @@ def test_discover_collapses_multi_node_single_camera(
 ) -> None:
     """The capture and metadata nodes of one camera collapse to one entry.
 
-    Same by-id on both nodes as in the twin case below; only the devpath
-    differs, and it is the sole discriminator -- one camera's nodes share it,
-    two cameras never do. The lowest-index node survives, and the pair must not
-    be counted as two units of the same model.
+    udev names them ``-video-index0`` and ``-video-index1``, so grouping on the
+    identity keeps both and lists a metadata node as a camera. The USB device
+    path is the sole discriminator: one camera's nodes share it, two cameras
+    never do. The lowest-index node survives, and the pair must not be counted
+    as two units of the same model.
     """
     camera_cls, mock_omni_camera = omnicamera_cls
     monkeypatch.setattr(sys, "platform", "linux")
     mock_omni_camera.query.return_value = [
         _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
-        _make_cam_info(41, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
+        _make_cam_info(41, _INNOMAKER_META_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
     ]
     _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", _INNOMAKER_USB), 41: ("3-6.1", _INNOMAKER_USB)})
 
@@ -639,33 +642,6 @@ def test_discover_collapses_multi_node_single_camera(
     assert devices[0].device_id == _INNOMAKER_BY_ID
     assert devices[0].id_stable is True
     assert devices[0].metadata["serial_collision"] is False
-
-
-def test_discover_demotes_colliding_unique_ids(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
-    """discover() keeps and demotes both cameras when they report the same by-id.
-
-    Reachable via ``discover(only_usable=False)``, where the losing twin can
-    still surface the winner's by-id. Keying the node dedup off that path maps
-    both cameras onto one entry, so a camera vanishes from discovery entirely.
-    """
-    camera_cls, mock_omni_camera = omnicamera_cls
-    monkeypatch.setattr(sys, "platform", "linux")
-    mock_omni_camera.query.return_value = [
-        _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
-        _make_cam_info(42, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
-    ]
-    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", _INNOMAKER_USB), 42: ("3-6.2", _INNOMAKER_USB)})
-
-    devices = camera_cls.discover()
-
-    # Neither camera may be dropped: they are two separate physical devices
-    # that merely advertise the same identity.
-    assert [d.index for d in devices] == [40, 42]
-    assert [d.device_id for d in devices] == ["40", "42"]
-    assert all(d.id_stable is False for d in devices)
-    assert all(d.metadata["serial_collision"] is True for d in devices)
-    # The ambiguous identity stays available for diagnostics.
-    assert all(d.hardware_id == _INNOMAKER_BY_ID for d in devices)
 
 
 def test_discover_demotes_twins_that_report_no_serial(
@@ -719,20 +695,62 @@ def test_discover_demotes_duplicate_ids_without_sysfs(
     assert all(d.metadata["serial_collision"] is True for d in devices)
 
 
+@pytest.mark.parametrize(
+    ("attrs", "expected"),
+    [
+        ({"idVendor": "0c45", "idProduct": "6366", "serial": "SN0001"}, ("0c45", "6366", "SN0001")),
+        # udev leaves an unreported serial out of the by-id name, so an empty
+        # serial has to survive as a collision key of its own.
+        ({"idVendor": "0c45", "idProduct": "6366"}, ("0c45", "6366", "")),
+        # A PCI capture device (an IPU ISYS node, say) has no USB ancestor and
+        # must not be grouped or flagged with anything.
+        ({}, None),
+    ],
+    ids=["with-serial", "without-serial", "no-usb-parent"],
+)
+def test_usb_identity_reads_the_owning_usb_device(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+    attrs: dict[str, str],
+    expected: tuple[str, str, str] | None,
+) -> None:
+    """The sysfs read walks from a node's device link up to the USB descriptors.
+
+    Everything else trusts this: it is the only evidence that two cameras are
+    the same model, and the by-id paths cannot supply it.
+    """
+    camera_cls, _ = omnicamera_cls
+    # The fixture patches this helper away to keep discovery off the host's
+    # /sys; reload restores the real one for this test.
+    module = importlib.reload(sys.modules[camera_cls.__module__])
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    usb_device = tmp_path / "3-6.1"
+    interface = usb_device / "3-6.1:1.0"  # the UVC interface the node links to
+    interface.mkdir(parents=True)
+    for name, value in attrs.items():
+        (usb_device / name).write_text(f"{value}\n")
+    class_dir = tmp_path / "video4linux"
+    (class_dir / "video40").mkdir(parents=True)
+    (class_dir / "video40" / "device").symlink_to(interface)
+    monkeypatch.setattr(module, "_SYSFS_V4L2", class_dir)
+
+    identity = module._usb_identity(40)  # noqa: SLF001
+
+    if expected is None:
+        assert identity is None
+    else:
+        assert identity.devpath == "3-6.1"
+        assert identity.model_key == expected
+
+
 # ------------------------------------------------------------------
 # Open-target tests: which camera a resolved id actually opens
 # ------------------------------------------------------------------
 
 
-_INNOMAKER_META_BY_ID = _INNOMAKER_BY_ID.replace("-video-index0", "-video-index1")
-
-
-def _install_innomaker_twins(
-    omnicamera_cls: tuple,
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    loser_unique_ids: tuple[str, str] = ("index:42", "index:43"),
-) -> None:
+def _install_innomaker_twins(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
     """Fake two units of one model sharing an iSerial, as query() reports them.
 
     Four V4L2 nodes over two USB ports. Both units claim the same by-id names,
@@ -742,17 +760,14 @@ def _install_innomaker_twins(
     Args:
         omnicamera_cls: The ``(class, omni_camera mock)`` fixture value.
         monkeypatch: Test monkeypatch.
-        loser_unique_ids: What the second unit's two nodes report. Override to
-            the winner's by-id paths to model a backend that hands the same
-            path to both units.
     """
     camera_cls, mock_omni_camera = omnicamera_cls
     monkeypatch.setattr(sys, "platform", "linux")
     mock_omni_camera.query.return_value = [
         _make_cam_info(40, _INNOMAKER_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
         _make_cam_info(41, _INNOMAKER_META_BY_ID, name="Innomaker-U20CAM-1080p-S1"),
-        _make_cam_info(42, loser_unique_ids[0], name="Innomaker-U20CAM-1080p-S1", id_stable=False),
-        _make_cam_info(43, loser_unique_ids[1], name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+        _make_cam_info(42, "index:42", name="Innomaker-U20CAM-1080p-S1", id_stable=False),
+        _make_cam_info(43, "index:43", name="Innomaker-U20CAM-1080p-S1", id_stable=False),
     ]
     _patch_usb_identity(
         monkeypatch,
@@ -766,11 +781,9 @@ def _install_innomaker_twins(
     )
 
 
-@pytest.mark.parametrize("device_id", [42, "42", "/dev/video42"], ids=["int", "decimal-string", "dev-path"])
 def test_connect_by_index_opens_that_index_verbatim(
     omnicamera_cls: tuple,
     monkeypatch: pytest.MonkeyPatch,
-    device_id: int | str,
 ) -> None:
     """An index request opens the named node, never a by-id symlink.
 
@@ -782,7 +795,7 @@ def test_connect_by_index_opens_that_index_verbatim(
     camera_cls, mock_omni_camera = omnicamera_cls
     _install_innomaker_twins(omnicamera_cls, monkeypatch)
 
-    cam = camera_cls(device_id=device_id)
+    cam = camera_cls(device_id=42)
     cam.connect()
 
     assert cam.is_connected
@@ -832,7 +845,7 @@ def test_connect_by_unique_id_passes_camera_info(omnicamera_cls: tuple, monkeypa
     mock_omni_camera.Camera.assert_called_with(infos[1])
 
 
-@pytest.mark.parametrize(("device_id", "expected"), [("index:42", 42), ("index:40", 40)], ids=["no-by-id", "has-by-id"])
+@pytest.mark.parametrize(("device_id", "expected"), [("index:42", 42), ("index:40", 40)], ids=["reported", "stale"])
 def test_connect_by_synthetic_index_id_is_an_index_request(
     omnicamera_cls: tuple,
     monkeypatch: pytest.MonkeyPatch,
@@ -856,91 +869,24 @@ def test_connect_by_synthetic_index_id_is_an_index_request(
     mock_omni_camera.Camera.assert_called_with(expected)
 
 
-def test_connect_refuses_a_by_id_shared_by_two_units(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("by_id", [_INNOMAKER_BY_ID, _INNOMAKER_META_BY_ID], ids=["capture", "metadata"])
+def test_connect_refuses_a_by_id_shared_by_two_units(
+    omnicamera_cls: tuple,
+    monkeypatch: pytest.MonkeyPatch,
+    by_id: str,
+) -> None:
     """connect() refuses a by-id that udev could not disambiguate.
 
     discover() stops offering it, but a config written before the second unit
     was plugged in still names it. Opening it would silently stream whichever
     unit currently owns the symlink -- and pairing it with the other unit's
-    index yields the same camera twice.
+    index yields the same camera twice. A camera's metadata node is refused
+    too: it carries its own by-id that the twin claims just as well.
     """
     camera_cls, _ = omnicamera_cls
     _install_innomaker_twins(omnicamera_cls, monkeypatch)
-
-    cam = camera_cls(device_id=_INNOMAKER_BY_ID)
-    with pytest.raises(CaptureError, match="video index"):
-        cam.connect()
-
-    assert not cam.is_connected
-
-
-def test_connect_refuses_a_by_id_of_an_extra_node(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The refusal covers the metadata nodes of a colliding camera too.
-
-    They are absent from discover() but reachable by hand, and each carries its
-    own by-id that a twin claims just as it claims the capture node's.
-    """
-    camera_cls, _ = omnicamera_cls
-    _install_innomaker_twins(omnicamera_cls, monkeypatch)
-
-    cam = camera_cls(device_id=_INNOMAKER_META_BY_ID)
-    with pytest.raises(CaptureError, match="video index"):
-        cam.connect()
-
-    assert not cam.is_connected
-
-
-def test_connect_refuses_a_by_id_reported_by_both_units(
-    omnicamera_cls: tuple,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A by-id that both units literally report is ambiguous by inspection."""
-    camera_cls, _ = omnicamera_cls
-    _install_innomaker_twins(
-        omnicamera_cls,
-        monkeypatch,
-        loser_unique_ids=(_INNOMAKER_BY_ID, _INNOMAKER_META_BY_ID),
-    )
-
-    cam = camera_cls(device_id=_INNOMAKER_BY_ID)
-    with pytest.raises(CaptureError, match="video index"):
-        cam.connect()
-
-    assert not cam.is_connected
-
-
-def test_connect_refuses_a_by_id_of_twins_without_serial(
-    omnicamera_cls: tuple,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Two units of a model that reports no iSerial collide the same way."""
-    camera_cls, mock_omni_camera = omnicamera_cls
-    monkeypatch.setattr(sys, "platform", "linux")
-    by_id = "/dev/v4l/by-id/usb-Innomaker_Innomaker-U20CAM-1080p-S1-video-index0"
-    mock_omni_camera.query.return_value = [
-        _make_cam_info(40, by_id, name="Innomaker-U20CAM-1080p-S1"),
-        _make_cam_info(42, "index:42", name="Innomaker-U20CAM-1080p-S1", id_stable=False),
-    ]
-    no_serial = ("0c45", "6366", "")
-    _patch_usb_identity(monkeypatch, camera_cls, {40: ("3-6.1", no_serial), 42: ("3-6.2", no_serial)})
 
     cam = camera_cls(device_id=by_id)
-    with pytest.raises(CaptureError, match="video index"):
-        cam.connect()
-
-    assert not cam.is_connected
-
-
-def test_connect_refuses_a_duplicate_unique_id_without_sysfs(
-    omnicamera_cls: tuple,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Off Linux a duplicated unique_id is refused on the same grounds."""
-    camera_cls, mock_omni_camera = omnicamera_cls
-    monkeypatch.setattr(sys, "platform", "darwin")
-    mock_omni_camera.query.return_value = [_make_cam_info(0, "shared-uid"), _make_cam_info(1, "shared-uid")]
-
-    cam = camera_cls(device_id="shared-uid")
     with pytest.raises(CaptureError, match="video index"):
         cam.connect()
 
@@ -960,15 +906,6 @@ def test_query_formats_by_index_uses_the_index_token(
 
     assert camera_cls.query_formats("42") == [(640, 480, 30)]
     mock_omni_camera.Camera.assert_called_with(42)
-
-
-def test_query_formats_refuses_an_ambiguous_by_id(omnicamera_cls: tuple, monkeypatch: pytest.MonkeyPatch) -> None:
-    """query_formats() inherits the refusal: it resolves the same way connect() does."""
-    camera_cls, _ = omnicamera_cls
-    _install_innomaker_twins(omnicamera_cls, monkeypatch)
-
-    with pytest.raises(CaptureError, match="video index"):
-        camera_cls.query_formats(_INNOMAKER_BY_ID)
 
 
 def test_discover_falls_back_to_index_when_id_unstable(omnicamera_cls: tuple) -> None:


### PR DESCRIPTION
## Summary

All Innomakers U20CAM usb cameras use the same symlink id path since serial number is duplicated. This means that we never know which U20CAM we are connecting because the order can change when queried.

Fixes:

- Opening a camera by an ambiguous by-id identifier silently selected an arbitrary physical camera instead of failing.
- Format capabilities for the wrong camera could be returned.
- Discovery with only_usable=False could misclassify a camera's metadata node as a separate camera, creating phantom entries.

## Why

-

## Validation

-

## Breaking changes

- None

## Related issues

- Closes #
