### PR TITLE
feat(config): unify Config API and absorb Studio config module

### DIFF
--- a/.agents/skills/physicalai-runtime-working-with-config
+++ b/.agents/skills/physicalai-runtime-working-with-config
@@ -1,0 +1,1 @@
+../../skills/config/physicalai-runtime-working-with-config

--- a/.claude/skills/physicalai-runtime-working-with-config
+++ b/.claude/skills/physicalai-runtime-working-with-config
@@ -1,0 +1,1 @@
+../../skills/config/physicalai-runtime-working-with-config

--- a/.github/scripts/skills/agent_skills.py
+++ b/.github/scripts/skills/agent_skills.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 _SCRIPT = "python3 .github/scripts/skills/agent_skills.py"
 
-_BUCKETS = ("inference", "capture", "runtime")
+_BUCKETS = ("inference", "capture", "runtime", "config")
 
 
 def repo_root() -> Path:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,14 @@ Physical AI Runtime is the deployment-side repo for the Physical AI workflow: lo
 
 ## Repository Layout
 
+- `src/physicalai/config/`: unified `Config` construction recipes — `Config.from_instance()` / `instantiate()`, `@export_config`, typed dataclass configs, YAML. Shared with Studio (runtime owns `physicalai.config`).
 - `src/physicalai/inference/`: `InferenceModel`, manifests, adapters, preprocessors/postprocessors, runners.
 - `src/physicalai/capture/`: unified camera API, discovery, transport.
 - `src/physicalai/runtime/`: `PolicyRuntime`, execution modes, action queues, callbacks.
 - `src/physicalai/robot/`: robot protocol and hardware integrations.
 - `src/physicalai/cli/`: `physicalai` / `pai` host CLI (`run` and entry-point subcommands from other packages).
 - `src/physicalai/benchmark/`: inference performance tooling.
-- `skills/inference/`, `skills/capture/`, `skills/runtime/`: agent skills (canonical). Adapter symlinks under `.claude/skills/` and `.agents/skills/` are committed so clones work out of the box. See `skills/README.md`.
+- `skills/inference/`, `skills/capture/`, `skills/runtime/`, `skills/config/`: agent skills (canonical). Adapter symlinks under `.claude/skills/` and `.agents/skills/` are committed so clones work out of the box. See `skills/README.md`.
 - `docs/`: user and contributor documentation (MkDocs).
 
 ## Setup
@@ -27,6 +28,7 @@ Physical AI Runtime is the deployment-side repo for the Physical AI workflow: lo
 ## Cross-Repo Rules
 
 - Runtime owns the `physicalai` executable and `pai` alias. Studio contributes training/export subcommands through `physicalai.cli.subcommands` entry points.
+- Runtime owns `physicalai.config` (single `Config` object). Studio consumes it from the runtime package; Studio must not ship its own `physicalai/config/` package.
 - Runtime-owned CLI surface includes `physicalai run` (policy on hardware from config).
 - Studio owns export; Runtime consumes exported artifacts via `InferenceModel` / `InferenceModel.from_pretrained(...)`.
 - Keep customer-facing instructions stable and avoid exposing internal scaffolding unless the user is contributing to the repo.

--- a/docs/development/security.md
+++ b/docs/development/security.md
@@ -29,7 +29,7 @@ These rules apply when writing, editing, or reviewing code under `src/physicalai
 5. Enforce component nesting limits. `_MAX_COMPONENT_DEPTH` in
    `component_factory.py` caps recursive manifest/YAML instantiation;
    `_MAX_CONFIG_DEPTH` in `physicalai.config` caps recursive
-   `to_config` / `instantiate` trees — do not raise or bypass either without a
+   `Config.from_instance` / `instantiate` trees — do not raise or bypass either without a
    security review.
 
 6. Never use `pickle`, `eval()`, `exec()`, `joblib`, `dill`, or `cloudpickle` on untrusted data. Prefer `json` for structured metadata, `safetensors` for weights, and `numpy.load(..., allow_pickle=False)` for arrays.

--- a/docs/explanation/cameras.md
+++ b/docs/explanation/cameras.md
@@ -41,7 +41,7 @@ connected holder causes open failure.
 
 ```python
 from physicalai.capture import SharedCamera
-from physicalai.config import to_config
+from physicalai.config import Config
 
 # Prefer config-only / disconnected export — no live direct camera held open
 shared = SharedCamera.from_config(
@@ -50,8 +50,8 @@ shared = SharedCamera.from_config(
         "init_args": {"device": "/dev/video0", "backend": "v4l2"},
     },
 )
-# Equivalent after to_config(disconnected_driver):
-# shared = SharedCamera.from_config(to_config(driver))
+# Equivalent from a disconnected live driver:
+# shared = SharedCamera.from_config(Config.from_instance(driver))
 shared.connect()
 
 # Safe to read from multiple threads/processes

--- a/docs/explanation/configuration.md
+++ b/docs/explanation/configuration.md
@@ -5,7 +5,7 @@ can describe the same runtime graph.
 
 ## Construction Recipes
 
-A `ComponentConfig` names one class and the arguments needed to create it.
+A `Config` names one class and the arguments needed to create it.
 
 ```yaml
 class_path: physicalai.capture.UVCCamera
@@ -15,16 +15,17 @@ init_args:
   height: 480
 ```
 
-Classes opt in to exporting this recipe with `@export_config`. `to_config()`
+Classes opt in to exporting this recipe with `@export_config`.
+`Config.from_instance()`
 captures construction intent rather than mutable runtime state: supplied
 arguments are preserved, omitted defaults remain omitted, and connections or
 open handles are never exported.
 
 ```text
-live opted-in component -> to_config() -> JSON/YAML -> instantiate() -> new component
+live opted-in component -> Config.from_instance() -> JSON/YAML -> config.instantiate() -> new component
 ```
 
-`instantiate()` calls constructors only. The application remains responsible
+`Config.instantiate()` calls constructors only. The application remains responsible
 for lifecycle methods such as `connect()` and `run()`.
 
 ## Workflow Documents
@@ -32,7 +33,7 @@ for lifecycle methods such as `connect()` and `run()`.
 A workflow document adds command-level structure around components. For
 example, `physicalai run` expects runtime constructor arguments under
 `runtime:` and optional run-method arguments under `run:`. A bare exported
-`RobotRuntime` ComponentConfig is also accepted and reshaped by the loader.
+`RobotRuntime` Config is also accepted and reshaped by the loader.
 
 Nested components retain the same `class_path` + `init_args` form, so a robot,
 action source, model, camera map, and callbacks form one recursive recipe.
@@ -42,10 +43,25 @@ action source, model, camera map, and callbacks form one recursive recipe.
 An inference manifest describes an exported policy package: artifacts,
 features, processors, runners, and compatibility metadata. Its
 `ComponentSpec` supports registry aliases and artifact handling and remains
-separate from strict captured `ComponentConfig` data.
+separate from strict captured `Config` data.
 
 Use workflow configuration for deployment intent. Use manifests for package
 metadata produced during export.
+
+## Generic instantiation (Training and plugins)
+
+Runtime also ships helpers used heavily by Physical AI Studio and
+`jsonargparse`-driven CLIs:
+
+| Entry point | Use when |
+| ----------- | -------- |
+| [`instantiate_obj`](../how-to/config/instantiate-objects.md) | Generic loaders; class chosen by config |
+| [`FromConfig` / `@from_config`](../how-to/config/use-from-config.md) | Class-level `from_yaml`, `from_dict`, `from_config` |
+| [`Config` dataclass subclasses](../how-to/config/instantiate-components.md) | Typed hyperparameter objects with save/load |
+
+Code and tests live under `src/physicalai/config/` and `tests/unit/config/`.
+Studio consumes this package and does not ship a duplicate `physicalai.config`
+tree.
 
 ## Trust
 

--- a/docs/explanation/configuration.md
+++ b/docs/explanation/configuration.md
@@ -53,11 +53,11 @@ metadata produced during export.
 Runtime also ships helpers used heavily by Physical AI Studio and
 `jsonargparse`-driven CLIs:
 
-| Entry point | Use when |
-| ----------- | -------- |
-| [`instantiate_obj`](../how-to/config/instantiate-objects.md) | Generic loaders; class chosen by config |
-| [`FromConfig` / `@from_config`](../how-to/config/use-from-config.md) | Class-level `from_yaml`, `from_dict`, `from_config` |
-| [`Config` dataclass subclasses](../how-to/config/instantiate-components.md) | Typed hyperparameter objects with save/load |
+| Entry point                                                                 | Use when                                            |
+| --------------------------------------------------------------------------- | --------------------------------------------------- |
+| [`instantiate_obj`](../how-to/config/instantiate-objects.md)                | Generic loaders; class chosen by config             |
+| [`FromConfig` / `@from_config`](../how-to/config/use-from-config.md)        | Class-level `from_yaml`, `from_dict`, `from_config` |
+| [`Config` dataclass subclasses](../how-to/config/instantiate-components.md) | Typed hyperparameter objects with save/load         |
 
 Code and tests live under `src/physicalai/config/` and `tests/unit/config/`.
 Studio consumes this package and does not ship a duplicate `physicalai.config`

--- a/docs/explanation/configuration.md
+++ b/docs/explanation/configuration.md
@@ -59,9 +59,10 @@ Runtime also ships helpers used heavily by Physical AI Studio and
 | [`FromConfig` / `@from_config`](../how-to/config/use-from-config.md)        | Class-level `from_yaml`, `from_dict`, `from_config` |
 | [`Config` dataclass subclasses](../how-to/config/instantiate-components.md) | Typed hyperparameter objects with save/load         |
 
-Code and tests live under `src/physicalai/config/` and `tests/unit/config/`.
-Studio consumes this package and does not ship a duplicate `physicalai.config`
-tree.
+Strict captured recipes use the package-level :func:`instantiate`; generic
+loaders use the package-level :func:`instantiate_obj`. Both are intentionally
+available from one public import surface. Generic loader helpers are
+implemented in `physicalai.config.loading`.
 
 ## Trust
 

--- a/docs/how-to/config/instantiate-components.md
+++ b/docs/how-to/config/instantiate-components.md
@@ -1,6 +1,6 @@
 # Instantiate Components
 
-A `ComponentConfig` is a construction recipe with one importable class and
+A `Config` is a construction recipe with one importable class and
 its supplied constructor arguments.
 
 ```yaml
@@ -11,17 +11,18 @@ init_args:
   height: 480
 ```
 
-Use `instantiate()` to construct trusted local configuration. It calls the
+Use `Config.instantiate()` to construct trusted local configuration. It calls the
 constructor but does not call lifecycle methods such as `connect()`, `run()`,
 or `start()`.
 
 ```python
-from physicalai.config import instantiate
+from physicalai.config import Config
 
-camera = instantiate({
+config = Config.from_dict({
     "class_path": "physicalai.capture.UVCCamera",
     "init_args": {"device": "/dev/video0", "width": 640, "height": 480},
 })
+camera = config.instantiate()
 camera.connect()
 ```
 
@@ -32,10 +33,10 @@ the caller supplied, so omitted constructor defaults remain omitted.
 
 ```python
 from physicalai.capture import UVCCamera
-from physicalai.config import to_config
+from physicalai.config import Config
 
 camera = UVCCamera(device="/dev/video0", width=640, height=480)
-config = to_config(camera)
+config = Config.from_instance(camera)
 ```
 
 Nested opted-in components use the same shape recursively. Configs contain
@@ -51,7 +52,7 @@ save_yaml(camera, "camera.yaml")
 ## Trust boundary
 
 `class_path` selects Python code to import and execute. Pass only trusted
-application or user-authored configuration to `instantiate()`. Do not
+application or user-authored configuration to `Config.instantiate()`. Do not
 instantiate robot metadata, camera metadata, shared-memory messages, or other
 peer-controlled payloads.
 

--- a/docs/how-to/config/instantiate-objects.md
+++ b/docs/how-to/config/instantiate-objects.md
@@ -1,6 +1,6 @@
 # Instantiate Objects from Config
 
-`physicalai.config.instantiate_obj` is the generic entry point for turning
+`physicalai.config.instantiate_obj()` is the generic entry point for turning
 config-like inputs into Python objects. Training CLIs, Lightning integration,
 and infrastructure code use it when the concrete class may come from YAML or
 when you do not want a `FromConfig` mixin on the target type.

--- a/docs/how-to/config/instantiate-objects.md
+++ b/docs/how-to/config/instantiate-objects.md
@@ -1,0 +1,101 @@
+# Instantiate Objects from Config
+
+`physicalai.config.instantiate_obj` is the generic entry point for turning
+config-like inputs into Python objects. Training CLIs, Lightning integration,
+and infrastructure code use it when the concrete class may come from YAML or
+when you do not want a `FromConfig` mixin on the target type.
+
+## Main API
+
+```python
+from physicalai.config import instantiate_obj
+
+obj = instantiate_obj(config, *, key=None, target_cls=None)
+```
+
+`config` may be:
+
+- `dict`
+- YAML or JSON file path (`str` or `pathlib.Path`)
+- dataclass instance
+- Pydantic `BaseModel`
+
+All paths converge on `instantiate_obj_from_dict`, which:
+
+1. Applies `key` to select a nested sub-config when provided.
+2. Instantiates via `class_path` when present (imports and calls the class).
+3. Otherwise calls `target_cls(**config)` when `target_cls` is provided.
+4. Recursively instantiates nested `class_path` blocks inside dicts, lists, and tuples.
+
+If both `class_path` and `target_cls` are present, `class_path` wins.
+
+## Examples
+
+### Import from `class_path`
+
+```python
+optimizer = instantiate_obj({
+    "class_path": "torch.optim.Adam",
+    "init_args": {"lr": 1e-3},
+})
+```
+
+### Direct kwargs via `target_cls`
+
+```python
+model = instantiate_obj(
+    {"hidden_size": 256, "num_layers": 3},
+    target_cls=MyModel,
+)
+```
+
+### YAML or JSON file
+
+```python
+policy = instantiate_obj("config.yaml")
+model = instantiate_obj("train.json", key="model")
+```
+
+### Dataclass or Pydantic source
+
+```python
+model = instantiate_obj(dataclass_cfg, target_cls=MyModel)
+model = instantiate_obj(pydantic_cfg, target_cls=MyModel)
+```
+
+### Nested components
+
+```python
+policy = instantiate_obj({
+    "class_path": "mypkg.Policy",
+    "init_args": {
+        "model": {
+            "class_path": "mypkg.Model",
+            "init_args": {"hidden_size": 256},
+        },
+    },
+})
+```
+
+## When to use it
+
+Prefer `instantiate_obj` when:
+
+- the config decides the concrete class;
+- the target class should not inherit `FromConfig`; or
+- you are writing generic loaders (trainer wiring, plugins, tests).
+
+For strict captured construction recipes (`Config.from_instance`, transport
+export), use [`Instantiate Components`](instantiate-components.md) and
+[`Configuration`](../../explanation/configuration.md) instead.
+
+## Trust
+
+`class_path` imports and executes local Python code. Pass only trusted
+application or user-authored configuration. See
+[`Configuration`](../../explanation/configuration.md#trust).
+
+## Related
+
+- Implementation: `src/physicalai/config/instantiate.py`
+- Tests: `tests/unit/config/`

--- a/docs/how-to/config/use-from-config.md
+++ b/docs/how-to/config/use-from-config.md
@@ -1,0 +1,97 @@
+# Use FromConfig and @from_config
+
+`FromConfig` and `@from_config` add class-level helpers on top of
+`instantiate_obj`. Physical AI Studio policies and other Lightning-facing types
+use them so YAML, dict, Pydantic, and dataclass inputs share one construction
+path.
+
+## Mixin and decorator
+
+```python
+from physicalai.config import FromConfig, from_config
+
+class MyModel(FromConfig):
+    def __init__(self, hidden_size: int, num_layers: int = 3) -> None:
+        ...
+
+@from_config
+class LegacyModel:
+    def __init__(self, hidden_size: int) -> None:
+        ...
+```
+
+Both expose:
+
+- `from_yaml(path, *, key=None)`
+- `from_dict(config, *, key=None)`
+- `from_pydantic(config, *, key=None, recursive=False)`
+- `from_dataclass(config, *, key=None, recursive=False)`
+- `from_config(config, *, key=None, recursive=False)` — dispatches by input type
+
+Use the decorator when you cannot change the class inheritance.
+
+## Direct kwargs vs `class_path`
+
+### Direct kwargs
+
+```python
+model = MyModel.from_dict({"hidden_size": 256, "num_layers": 4})
+```
+
+### `class_path` / `init_args`
+
+```python
+model = MyModel.from_dict({
+    "class_path": "mypkg.models.BigModel",
+    "init_args": {"hidden_size": 512},
+})
+```
+
+This matches the shape used by `jsonargparse` and Lightning-style CLIs.
+
+## Nested instantiation
+
+Nested `class_path` blocks are instantiated before the constructor runs:
+
+```python
+policy = Policy.from_dict({
+    "model": {
+        "class_path": "mypkg.models.Backbone",
+        "init_args": {"hidden_size": 256},
+    },
+})
+```
+
+## Dataclass and Pydantic sources
+
+```python
+model = MyModel.from_dataclass(ModelConfig())
+model = MyModel.from_pydantic(ModelConfig())
+```
+
+### `recursive` flag
+
+With `recursive=False` (default), nested dataclass or Pydantic instances are
+passed through to the constructor unchanged. With `recursive=True`, nested
+objects are flattened to plain dicts first — use that when `__init__` expects
+mappings, not nested config objects.
+
+## Typed policy configs
+
+Studio policy families define `<Name>Config(Config)` dataclasses in
+`config.py` and construct policies via `from_config` or Lightning CLI
+`class_path` wiring. The shared `Config` base lives in Runtime; see
+[`Instantiate Components`](instantiate-components.md) for export and strict
+recipes.
+
+## Validation
+
+Validation belongs in Pydantic models, dataclass `__post_init__`, or
+constructors — not in the instantiator. Import and constructor errors surface
+as `ConfigError`, `ConfigImportError`, or exceptions from the target class.
+
+## Related
+
+- [`instantiate_obj`](instantiate-objects.md) — backend without mixins
+- [`Configuration`](../../explanation/configuration.md) — recipes, export, trust
+- Implementation: `src/physicalai/config/mixin.py`

--- a/docs/how-to/config/write-inference-config.md
+++ b/docs/how-to/config/write-inference-config.md
@@ -21,6 +21,6 @@ action = model.select_action(observation)
 Use workflow config to express user-authored intent. Use a manifest to describe exported package metadata.
 
 To export a model's supplied constructor arguments from Python, call
-`physicalai.config.to_config(model)`. Rebuild that trusted local recipe with
-`physicalai.config.instantiate(config)`; construction loads the model package
+`Config.from_instance(model)`. Rebuild that trusted local recipe with
+`config.instantiate()`; construction loads the model package
 and can allocate substantial resources.

--- a/docs/how-to/runtime/share-a-robot.md
+++ b/docs/how-to/runtime/share-a-robot.md
@@ -32,7 +32,8 @@ driver = SO101(
     port="/dev/ttyUSB0",
     calibration="~/.cache/calibration/so101.json",  # path stays relative/as given
 )
-robot = SharedRobot.from_config(Config.from_instance(driver), name="left-arm")
+robot = SharedRobot.from_config(driver, name="left-arm")
+# equivalent: SharedRobot.from_config(Config.from_instance(driver), name="left-arm")
 # or: SharedRobot("left-arm", robot={"class_path": "physicalai.robot.SO101", "init_args": {...}})
 robot.connect()
 

--- a/docs/how-to/runtime/share-a-robot.md
+++ b/docs/how-to/runtime/share-a-robot.md
@@ -25,14 +25,14 @@ directly to the constructor or exported explicitly:
 
 ```python
 import numpy as np
-from physicalai.config import to_config
+from physicalai.config import Config
 from physicalai.robot import SO101, SharedRobot
 
 driver = SO101(
     port="/dev/ttyUSB0",
     calibration="~/.cache/calibration/so101.json",  # path stays relative/as given
 )
-robot = SharedRobot.from_config(to_config(driver), name="left-arm")
+robot = SharedRobot.from_config(Config.from_instance(driver), name="left-arm")
 # or: SharedRobot("left-arm", robot={"class_path": "physicalai.robot.SO101", "init_args": {...}})
 robot.connect()
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -34,7 +34,7 @@ with runtime:
 physicalai robot serve --config examples/so101/serve.yaml
 ```
 
-The YAML fields are `name`, required `robot` (a ComponentConfig with
+The YAML fields are `name`, required `robot` (a `Config` with
 `class_path` + `init_args`), optional `allow_remote` (default `false`), and
 optional positive `rate_hz` (default 100 Hz). Direct CLI arguments use the same
 names, including nested robot constructor values such as

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -1,8 +1,8 @@
 # Config Schema Reference
 
-## ComponentConfig
+## Config
 
-`physicalai.config.ComponentConfig` uses the jsonargparse-compatible
+`physicalai.config.Config` uses the jsonargparse-compatible
 `class_path` + `init_args` shape.
 
 ```yaml
@@ -20,7 +20,7 @@ Omitted `init_args` means an empty mapping. No other top-level keys are
 accepted.
 
 Values may be `null`, booleans, integers, finite floats, strings, lists, or
-string-keyed mappings. Nested components use another `ComponentConfig`.
+string-keyed mappings. Nested components use another `Config`.
 Every mapping containing `class_path` is reserved as a nested component and
 must contain only `class_path` and optional `init_args`. Nesting through
 components, lists, and mappings is limited to 10 levels.
@@ -54,14 +54,14 @@ run:
 ```
 
 `physicalai run --config` and `RobotRuntime.from_config()` also accept a bare
-exported `RobotRuntime` ComponentConfig whose top-level `class_path` is
+exported `RobotRuntime` Config whose top-level `class_path` is
 `physicalai.runtime.RobotRuntime`.
 
 ## Manifest ComponentSpec
 
 Inference manifests retain their separate `ComponentSpec` compatibility
 model. It supports registry `type` aliases, artifact resolution, and existing
-extra-field behavior. It is not the strict captured `ComponentConfig` schema;
+extra-field behavior. It is not the strict captured `Config` schema;
 manifest unification is a separate design decision.
 
 ## Security

--- a/docs/reference/inference-api.md
+++ b/docs/reference/inference-api.md
@@ -17,7 +17,7 @@ InferenceModel(
 ```
 
 The model can be constructed directly from an export directory or nested in a
-trusted workflow ComponentConfig.
+trusted workflow `Config`.
 
 ## Constructors
 

--- a/examples/runtime/async_inference.py
+++ b/examples/runtime/async_inference.py
@@ -43,7 +43,7 @@ import signal
 from pathlib import Path
 
 from physicalai.capture import select_cameras_interactive
-from physicalai.config import save_yaml, to_config
+from physicalai.config import Config, save_yaml
 from physicalai.inference import InferenceModel
 from physicalai.runtime import (
     AsyncExecution,
@@ -89,7 +89,10 @@ def main() -> None:
     # Cameras
     cam_group = parser.add_argument_group("cameras")
     cam_group.add_argument(
-        "--camera", action="append", dest="cameras", metavar="NAME:DRIVER:DEVICE",
+        "--camera",
+        action="append",
+        dest="cameras",
+        metavar="NAME:DRIVER:DEVICE",
         help="Camera as name:driver:device_id (repeatable). Omit for interactive selection.",
     )
     cam_group.add_argument("--cam-width", type=int, default=640, help="Camera width (default: 640)")
@@ -101,9 +104,20 @@ def main() -> None:
     rt_group.add_argument("--fps", type=float, default=30.0, help="Control loop FPS (default: 30)")
     rt_group.add_argument("--duration-s", type=float, default=60.0, help="Duration in seconds")
     rt_group.add_argument("--task", type=str, default=None, help="Task string for the model (e.g. 'pick up the can')")
-    rt_group.add_argument("--shared-camera", action="store_true", help="Use shared memory cameras (iceoryx2) — faster but incompatible with debugger")
-    rt_group.add_argument("--request-threshold", type=float, default=0.75, help="Request new inference when queue drops below this fraction of chunk_size (default: 0.75 = trigger when 75%% of actions remain)")
-    rt_group.add_argument("--lerp-frames", type=int, default=3, help="LerpSmoother blend duration in frames (default: 3)")
+    rt_group.add_argument(
+        "--shared-camera",
+        action="store_true",
+        help="Use shared memory cameras (iceoryx2) — faster but incompatible with debugger",
+    )
+    rt_group.add_argument(
+        "--request-threshold",
+        type=float,
+        default=0.75,
+        help="Request new inference when queue drops below this fraction of chunk_size (default: 0.75 = trigger when 75%% of actions remain)",
+    )
+    rt_group.add_argument(
+        "--lerp-frames", type=int, default=3, help="LerpSmoother blend duration in frames (default: 3)"
+    )
     rt_group.add_argument(
         "--export-config",
         type=Path,
@@ -117,8 +131,15 @@ def main() -> None:
     rr_group.add_argument("--rerun-save-path", default="run.rrd")
     rr_group.add_argument("--rerun-no-images", action="store_true", help="Scalars only")
     rr_group.add_argument("--rerun-image-decimation", type=int, default=1, help="Only send 1/N frames to Rerun")
-    rr_group.add_argument("--rerun-jpeg-quality", type=int, default=None, help="JPEG quality for Rerun images (0-100, default: no re-encoding)")
-    rr_group.add_argument("--rerun-image-max-dim", type=int, default=None, help="Max width/height for Rerun images (default: no resizing)")
+    rr_group.add_argument(
+        "--rerun-jpeg-quality",
+        type=int,
+        default=None,
+        help="JPEG quality for Rerun images (0-100, default: no re-encoding)",
+    )
+    rr_group.add_argument(
+        "--rerun-image-max-dim", type=int, default=None, help="Max width/height for Rerun images (default: no resizing)"
+    )
 
     args = parser.parse_args()
 
@@ -130,7 +151,9 @@ def main() -> None:
     # ── Build robot & cameras ──
     robot = build_robot(args)
     if args.cameras:
-        cameras = parse_camera_specs(args.cameras, args.cam_width, args.cam_height, args.cam_fps, shared=args.shared_camera)
+        cameras = parse_camera_specs(
+            args.cameras, args.cam_width, args.cam_height, args.cam_fps, shared=args.shared_camera
+        )
     else:
         cameras = select_cameras_interactive(args.cam_width, args.cam_height, args.cam_fps)
 
@@ -166,7 +189,7 @@ def main() -> None:
     )
 
     if args.export_config:
-        save_yaml(to_config(runtime), args.export_config)
+        save_yaml(Config.from_instance(runtime), args.export_config)
         print(f"Saved runtime config to {args.export_config}")
         return
 
@@ -178,8 +201,10 @@ def main() -> None:
             print(f"  {name}: {w}x{h} @ {f}fps" if w and h else f"  {name}: connected")
         print(f"Running at {args.fps} fps for {args.duration_s}s...")
         steps = runtime.run(duration_s=args.duration_s)
-        print(f"\nDone — {steps} steps, {execution.inference_count} inferences, "
-              f"{policy_source.action_queue.total_holds} holds")
+        print(
+            f"\nDone — {steps} steps, {execution.inference_count} inferences, "
+            f"{policy_source.action_queue.total_holds} holds"
+        )
         prompt_torque_disable(robot)
 
 

--- a/examples/runtime/rtc_inference.py
+++ b/examples/runtime/rtc_inference.py
@@ -38,7 +38,7 @@ import signal
 from pathlib import Path
 
 from physicalai.capture import select_cameras_interactive
-from physicalai.config import save_yaml, to_config
+from physicalai.config import Config, save_yaml
 from physicalai.inference import InferenceModel
 from physicalai.inference.callbacks import RTCLatencyTracker
 from physicalai.runtime import (
@@ -83,7 +83,10 @@ def main() -> None:
     # Cameras
     cam_group = parser.add_argument_group("cameras")
     cam_group.add_argument(
-        "--camera", action="append", dest="cameras", metavar="NAME:DRIVER:DEVICE",
+        "--camera",
+        action="append",
+        dest="cameras",
+        metavar="NAME:DRIVER:DEVICE",
         help="Camera as name:driver:device_id (repeatable). Omit for interactive selection.",
     )
     cam_group.add_argument("--cam-width", type=int, default=640, help="Camera width (default: 640)")
@@ -93,9 +96,15 @@ def main() -> None:
     # Runtime
     rt_group = parser.add_argument_group("runtime")
     rt_group.add_argument("--fps", type=float, default=30.0, help="Control loop FPS (default: 30)")
-    rt_group.add_argument("--duration-s", type=float, default=None, help="Run duration in seconds (default: run indefinitely)")
+    rt_group.add_argument(
+        "--duration-s", type=float, default=None, help="Run duration in seconds (default: run indefinitely)"
+    )
     rt_group.add_argument("--task", type=str, default=None, help="Task string for the model (e.g. 'pick up the can')")
-    rt_group.add_argument("--shared-camera", action="store_true", help="Use shared memory cameras (iceoryx2) — faster but incompatible with debugger")
+    rt_group.add_argument(
+        "--shared-camera",
+        action="store_true",
+        help="Use shared memory cameras (iceoryx2) — faster but incompatible with debugger",
+    )
     rt_group.add_argument(
         "--export-config",
         type=Path,
@@ -109,7 +118,12 @@ def main() -> None:
     rtc_group.add_argument("--max-action-dim", type=int, default=32)
     rtc_group.add_argument("--max-guidance-weight", type=float, default=7.0)
     rtc_group.add_argument("--queue-threshold", type=int, default=30)
-    rtc_group.add_argument("--low-pass-alpha", type=float, default=None, help="Alpha parameter for stateful LowPassFilterCallback. E.g. 0.5. Defaults to None (disabled).")
+    rtc_group.add_argument(
+        "--low-pass-alpha",
+        type=float,
+        default=None,
+        help="Alpha parameter for stateful LowPassFilterCallback. E.g. 0.5. Defaults to None (disabled).",
+    )
 
     # Rerun
     rr_group = parser.add_argument_group("rerun")
@@ -118,8 +132,15 @@ def main() -> None:
     rr_group.add_argument("--rerun-save-path", default="run.rrd")
     rr_group.add_argument("--rerun-no-images", action="store_true", help="Scalars only")
     rr_group.add_argument("--rerun-image-decimation", type=int, default=1, help="Only send 1/N frames to Rerun")
-    rr_group.add_argument("--rerun-jpeg-quality", type=int, default=None, help="JPEG quality for Rerun images (0-100, default: no re-encoding)")
-    rr_group.add_argument("--rerun-image-max-dim", type=int, default=None, help="Max width/height for Rerun images (default: no resizing)")
+    rr_group.add_argument(
+        "--rerun-jpeg-quality",
+        type=int,
+        default=None,
+        help="JPEG quality for Rerun images (0-100, default: no re-encoding)",
+    )
+    rr_group.add_argument(
+        "--rerun-image-max-dim", type=int, default=None, help="Max width/height for Rerun images (default: no resizing)"
+    )
 
     args = parser.parse_args()
 
@@ -137,7 +158,9 @@ def main() -> None:
     # ── Build robot & cameras ──
     robot = build_robot(args)
     if args.cameras:
-        cameras = parse_camera_specs(args.cameras, args.cam_width, args.cam_height, args.cam_fps, shared=args.shared_camera)
+        cameras = parse_camera_specs(
+            args.cameras, args.cam_width, args.cam_height, args.cam_fps, shared=args.shared_camera
+        )
     else:
         cameras = select_cameras_interactive(args.cam_width, args.cam_height, args.cam_fps)
 
@@ -184,7 +207,7 @@ def main() -> None:
     )
 
     if args.export_config:
-        save_yaml(to_config(runtime), args.export_config)
+        save_yaml(Config.from_instance(runtime), args.export_config)
         print(f"Saved runtime config to {args.export_config}")
         return
 
@@ -194,10 +217,7 @@ def main() -> None:
             h = getattr(cam, "actual_height", None)
             f = getattr(cam, "actual_fps", None)
             print(f"  {name}: {w}x{h} @ {f}fps" if w and h else f"  {name}: connected")
-        print(
-            f"Running RTC — chunk={args.chunk_size}, "
-            f"horizon={args.execution_horizon}, fps={args.fps}"
-        )
+        print(f"Running RTC — chunk={args.chunk_size}, horizon={args.execution_horizon}, fps={args.fps}")
         if args.task:
             print(f"  task: {args.task!r}")
         steps = runtime.run(duration_s=args.duration_s)
@@ -205,10 +225,7 @@ def main() -> None:
             f"\nDone — {steps} steps, {execution.inference_count} inferences, "
             f"{policy_source.action_queue.total_holds} holds"
         )
-        print(
-            f"Latency — max={latency_tracker.max_latency_s:.3f}s, "
-            f"p95={latency_tracker.percentile_s(95):.3f}s"
-        )
+        print(f"Latency — max={latency_tracker.max_latency_s:.3f}s, p95={latency_tracker.percentile_s(95):.3f}s")
         prompt_torque_disable(robot)
 
 

--- a/examples/runtime/sync_inference.py
+++ b/examples/runtime/sync_inference.py
@@ -33,7 +33,7 @@ import signal
 from pathlib import Path
 
 from physicalai.capture import select_cameras_interactive
-from physicalai.config import save_yaml, to_config
+from physicalai.config import Config, save_yaml
 from physicalai.inference import InferenceModel
 from physicalai.runtime import (
     ChunkedActionQueue,
@@ -76,7 +76,10 @@ def main() -> None:
     # Cameras
     cam_group = parser.add_argument_group("cameras")
     cam_group.add_argument(
-        "--camera", action="append", dest="cameras", metavar="NAME:DRIVER:DEVICE",
+        "--camera",
+        action="append",
+        dest="cameras",
+        metavar="NAME:DRIVER:DEVICE",
         help="Camera as name:driver:device_id (repeatable). Omit for interactive selection.",
     )
     cam_group.add_argument("--cam-width", type=int, default=640, help="Camera width (default: 640)")
@@ -88,7 +91,12 @@ def main() -> None:
     rt_group.add_argument("--fps", type=float, default=30.0, help="Control loop FPS (default: 30)")
     rt_group.add_argument("--duration-s", type=float, default=60.0, help="Duration in seconds")
     rt_group.add_argument("--task", type=str, default=None, help="Task string for the model (e.g. 'pick up the can')")
-    rt_group.add_argument("--request-threshold", type=float, default=0.5, help="Request new inference when queue drops below this fraction of chunk_size (default: 0.75 = trigger when 75%% of actions remain)")
+    rt_group.add_argument(
+        "--request-threshold",
+        type=float,
+        default=0.5,
+        help="Request new inference when queue drops below this fraction of chunk_size (default: 0.75 = trigger when 75%% of actions remain)",
+    )
     rt_group.add_argument(
         "--export-config",
         type=Path,
@@ -144,7 +152,7 @@ def main() -> None:
     )
 
     if args.export_config:
-        save_yaml(to_config(runtime), args.export_config)
+        save_yaml(Config.from_instance(runtime), args.export_config)
         print(f"Saved runtime config to {args.export_config}")
         return
 
@@ -154,8 +162,10 @@ def main() -> None:
             print(f"  task: {args.task!r}")
         print("  (inference blocks the loop — expect pauses)")
         steps = runtime.run(duration_s=args.duration_s)
-        print(f"\nDone — {steps} steps, {execution.inference_count} inferences, "
-              f"{policy_source.action_queue.total_holds} holds")
+        print(
+            f"\nDone — {steps} steps, {execution.inference_count} inferences, "
+            f"{policy_source.action_queue.total_holds} holds"
+        )
         prompt_torque_disable(robot)
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
           - Write Runtime Config: how-to/config/write-runtime-config.md
           - Write Inference Config: how-to/config/write-inference-config.md
           - Instantiate Components: how-to/config/instantiate-components.md
+          - Instantiate Objects: how-to/config/instantiate-objects.md
+          - Use FromConfig: how-to/config/use-from-config.md
       - CLI:
           - Run: how-to/cli/run.md
   - Explanation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,10 @@ unfixable = []
 "src/physicalai/capture/transport/_header.py" = ["RUF012"]
 "src/physicalai/capture/transport/_publisher.py" = ["S603"]
 "src/physicalai/robot/transport/_owner.py" = ["S603"]
+"src/physicalai/config/base.py" = ["DOC201", "DOC501", "PLC0415", "ANN401", "A002"]
+"src/physicalai/config/instantiate.py" = ["DOC201", "DOC501", "ANN401", "TRY004"]
+"src/physicalai/config/mixin.py" = ["DOC201", "DOC501"]
+"src/physicalai/config/serializable.py" = ["DOC201", "DOC501", "PLR0911", "BLE001"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,10 +153,6 @@ unfixable = []
 "src/physicalai/capture/transport/_header.py" = ["RUF012"]
 "src/physicalai/capture/transport/_publisher.py" = ["S603"]
 "src/physicalai/robot/transport/_owner.py" = ["S603"]
-"src/physicalai/config/base.py" = ["DOC201", "DOC501", "PLC0415", "ANN401", "A002"]
-"src/physicalai/config/instantiate.py" = ["DOC201", "DOC501", "ANN401", "TRY004"]
-"src/physicalai/config/mixin.py" = ["DOC201", "DOC501"]
-"src/physicalai/config/serializable.py" = ["DOC201", "DOC501", "PLR0911", "BLE001"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/skills/README.md
+++ b/skills/README.md
@@ -9,6 +9,7 @@ Canonical, repo-specific agent skills for Physical AI Runtime. Skills are groupe
 | **Inference** | [`inference/`](inference/) | `src/physicalai/inference/`: `InferenceModel`, manifests, adapters, preprocessors/postprocessors, runners         |
 | **Capture**   | [`capture/`](capture/)     | `src/physicalai/capture/`: cameras, discovery, transport                                                          |
 | **Runtime**   | [`runtime/`](runtime/)     | `src/physicalai/runtime/`, `src/physicalai/robot/`, `src/physicalai/cli/`: control loop, robots, `physicalai run` |
+| **Config**    | [`config/`](config/)       | `src/physicalai/config/`: `Config`, export, instantiation, YAML, shared with Studio                               |
 
 Each bucket has its own skill list and [`EVALUATION.md`](inference/EVALUATION.md) scenarios.
 
@@ -30,6 +31,9 @@ skills/
 └── runtime/
     ├── README.md
     ├── EVALUATION.md
+    └── <skill-name>/
+└── config/
+    ├── README.md
     └── <skill-name>/
 ```
 

--- a/skills/config/README.md
+++ b/skills/config/README.md
@@ -1,0 +1,16 @@
+# Config (`physicalai.config`)
+
+Agent skills for the shared configuration package in `src/physicalai/config/`.
+Runtime owns this module; Physical AI Studio imports it from the `physicalai`
+dependency.
+
+## Skills
+
+| Skill | Scope |
+| ----- | ----- |
+| [`physicalai-runtime-working-with-config`](physicalai-runtime-working-with-config/SKILL.md) | `Config`, `@export_config`, `instantiate_obj`, `FromConfig`, YAML, trust boundary |
+
+## Docs
+
+- Explanation: [`docs/explanation/configuration.md`](../../docs/explanation/configuration.md)
+- How-to: [`docs/how-to/config/`](../../docs/how-to/config/)

--- a/skills/config/README.md
+++ b/skills/config/README.md
@@ -6,8 +6,8 @@ dependency.
 
 ## Skills
 
-| Skill | Scope |
-| ----- | ----- |
+| Skill                                                                                       | Scope                                                                             |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | [`physicalai-runtime-working-with-config`](physicalai-runtime-working-with-config/SKILL.md) | `Config`, `@export_config`, `instantiate_obj`, `FromConfig`, YAML, trust boundary |
 
 ## Docs

--- a/skills/config/physicalai-runtime-working-with-config/SKILL.md
+++ b/skills/config/physicalai-runtime-working-with-config/SKILL.md
@@ -13,7 +13,8 @@ Physical AI Studio.
 
 1. **Pick the API** — strict transport/export uses `Config`, `@export_config`,
    and `instantiate()` from `physicalai.config`; generic CLI/YAML loaders use
-   `instantiate_obj` and `FromConfig` from `physicalai.config.instantiate` /
+   `instantiate_obj` and `FromConfig` from `physicalai.config` /
+   `physicalai.config.loading` /
    `physicalai.config.mixin`; typed policy hyperparameters subclass
    `physicalai.config.base.Config`.
    - Done when: the change touches the module that matches the call site.

--- a/skills/config/physicalai-runtime-working-with-config/SKILL.md
+++ b/skills/config/physicalai-runtime-working-with-config/SKILL.md
@@ -9,28 +9,49 @@ license: Apache-2.0
 Runtime owns `src/physicalai/config/`. Do not add a parallel config tree in
 Physical AI Studio.
 
-## Entry points
+## Workflow
 
-| API | Module | Use |
-| --- | ------ | --- |
-| `Config`, `export_config`, strict `instantiate` | `physicalai.config` | Captured construction recipes, transport export |
-| `instantiate_obj`, `import_class` | `physicalai.config.instantiate` | Generic Lightning/CLI loaders |
-| `FromConfig`, `from_config` | `physicalai.config.mixin` | `from_yaml`, `from_dict`, `from_config` on classes |
-| Typed dataclass `Config` | `physicalai.config.base` | Policy hyperparameters, save/load |
+1. **Pick the API** — strict transport/export uses `Config`, `@export_config`,
+   and `instantiate()` from `physicalai.config`; generic CLI/YAML loaders use
+   `instantiate_obj` and `FromConfig` from `physicalai.config.instantiate` /
+   `physicalai.config.mixin`; typed policy hyperparameters subclass
+   `physicalai.config.base.Config`.
+   - Done when: the change touches the module that matches the call site.
+2. **Author or edit a recipe** — use `class_path` + `init_args` for dynamic
+   dispatch; nest recipes inside `init_args` only for trusted local configs.
+   See `docs/how-to/config/instantiate-components.md`.
+   - Done when: YAML/dict round-trips through `validate_config` without
+     `ConfigError`.
+3. **Export live components** — decorate constructors with `@export_config`,
+   capture with `Config.from_instance(obj)` or `to_config(obj)`, persist with
+   `save_yaml`. Never feed network or untrusted payloads into `instantiate`.
+   - Done when: exported YAML reloads via `instantiate()` on a test double.
+4. **Use FromConfig in user code** — add `from_yaml` / `from_dict` via
+   `FromConfig` or `@from_config` when a class should construct itself from
+   config; prefer `instantiate_obj` in infrastructure that picks the target
+   class from YAML alone (`docs/how-to/config/use-from-config.md`).
+5. **Document and test** — update `docs/explanation/configuration.md` or the
+   relevant how-to under `docs/how-to/config/`; extend `tests/unit/config/`.
 
-## Docs (canonical)
+## Validation loop
 
-- [`docs/explanation/configuration.md`](../../docs/explanation/configuration.md)
-- [`docs/how-to/config/instantiate-components.md`](../../docs/how-to/config/instantiate-components.md)
-- [`docs/how-to/config/instantiate-objects.md`](../../docs/how-to/config/instantiate-objects.md)
-- [`docs/how-to/config/use-from-config.md`](../../docs/how-to/config/use-from-config.md)
+```bash
+uv run pytest tests/unit/config/ -q
+prek run ruff-check --all-files
+```
 
-## Tests
+## Required checks
 
-- `tests/unit/config/` — unit tests for the package
+- Recursive walkers respect `_MAX_CONFIG_DEPTH` and raise `ConfigError` on overflow.
+- `class_path` strings resolve only from trusted local config (see
+  `docs/development/security.md`).
+- Studio must import `Config` from the runtime package, not ship
+  `library/src/physicalai/config/`.
 
-## Trust
+## References
 
-Only trusted local YAML/dict configs reach `class_path` resolution. See
-`docs/development/security.md` and the trust section in
-`docs/explanation/configuration.md`.
+- `docs/explanation/configuration.md`
+- `docs/how-to/config/instantiate-components.md`
+- `docs/how-to/config/instantiate-objects.md`
+- `docs/how-to/config/use-from-config.md`
+- `tests/unit/config/`

--- a/skills/config/physicalai-runtime-working-with-config/SKILL.md
+++ b/skills/config/physicalai-runtime-working-with-config/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: physicalai-runtime-working-with-config
+description: Works with the shared physicalai.config package (Config recipes, FromConfig, instantiate_obj, export_config, YAML). Use when changing src/physicalai/config, wiring class_path configs, policy or runtime construction from YAML, or docs under docs/how-to/config and docs/explanation/configuration.md. Runtime owns this module; Studio consumes it.
+license: Apache-2.0
+---
+
+# Working with `physicalai.config`
+
+Runtime owns `src/physicalai/config/`. Do not add a parallel config tree in
+Physical AI Studio.
+
+## Entry points
+
+| API | Module | Use |
+| --- | ------ | --- |
+| `Config`, `export_config`, strict `instantiate` | `physicalai.config` | Captured construction recipes, transport export |
+| `instantiate_obj`, `import_class` | `physicalai.config.instantiate` | Generic Lightning/CLI loaders |
+| `FromConfig`, `from_config` | `physicalai.config.mixin` | `from_yaml`, `from_dict`, `from_config` on classes |
+| Typed dataclass `Config` | `physicalai.config.base` | Policy hyperparameters, save/load |
+
+## Docs (canonical)
+
+- [`docs/explanation/configuration.md`](../../docs/explanation/configuration.md)
+- [`docs/how-to/config/instantiate-components.md`](../../docs/how-to/config/instantiate-components.md)
+- [`docs/how-to/config/instantiate-objects.md`](../../docs/how-to/config/instantiate-objects.md)
+- [`docs/how-to/config/use-from-config.md`](../../docs/how-to/config/use-from-config.md)
+
+## Tests
+
+- `tests/unit/config/` — unit tests for the package
+
+## Trust
+
+Only trusted local YAML/dict configs reach `class_path` resolution. See
+`docs/development/security.md` and the trust section in
+`docs/explanation/configuration.md`.

--- a/src/physicalai/capture/transport/_publisher.py
+++ b/src/physicalai/capture/transport/_publisher.py
@@ -25,7 +25,7 @@ class CameraPublisher:
     self-terminates via idle timeout when zero subscribers remain.
 
     Args:
-        spec: Camera construction specification (``camera: ComponentConfig``).
+        spec: Camera construction specification (``camera: Config``).
         service_name: iceoryx2 service name for the pub-sub channel.
         idle_timeout: Seconds with zero subscribers before self-exit.
         max_subscribers: Maximum concurrent subscribers.

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -132,7 +132,7 @@ def build_camera(config: dict) -> Camera:
     """Instantiate a camera from a JSON config dict.
 
     Args:
-        config: Publisher envelope with ``camera: ComponentConfig``, and
+        config: Publisher envelope with ``camera: Config``, and
             optional ``_factory_override`` for tests.
 
     Returns:
@@ -159,7 +159,7 @@ def build_camera(config: dict) -> Camera:
 
 
 def _camera_fps_from_config(config: dict[str, object]) -> int:
-    """Extract fps from camera ComponentConfig init_args.
+    """Extract fps from camera Config init_args.
 
     Returns:
         Requested fps value, or 0 when absent or invalid.

--- a/src/physicalai/capture/transport/_shared_camera.py
+++ b/src/physicalai/capture/transport/_shared_camera.py
@@ -3,7 +3,7 @@
 
 """Shared-memory camera subscriber transport based on iceoryx2.
 
-Construction is :class:`~physicalai.config.ComponentConfig`-only via
+Construction is :class:`~physicalai.config.Config`-only via
 ``camera=`` or :meth:`SharedCamera.from_config`. ``camera`` is declared as an
 ``@export_config(config_args=...)`` argument, so a nested
 :func:`~physicalai.config.instantiate` hands over the recipe instead of
@@ -27,7 +27,7 @@ from loguru import logger
 
 from physicalai.capture.camera import Camera, ColorMode
 from physicalai.capture.errors import CaptureError, CaptureTimeoutError, NotConnectedError
-from physicalai.config import export_config
+from physicalai.config import Config, export_config
 
 from ._header import FrameHeader, decode_header, decode_rgb
 from ._spec import derive_service_name, normalize_camera_config, validate_reconfigure_request
@@ -35,7 +35,6 @@ from ._spec import derive_service_name, normalize_camera_config, validate_reconf
 if TYPE_CHECKING:
     from physicalai.capture.frame import Frame
     from physicalai.capture.transport._publisher import CameraPublisher
-    from physicalai.config import ComponentConfig
 
 
 _SERVICE_NAME_EXPECTED_PARTS = 5
@@ -95,12 +94,12 @@ class SharedCamera(Camera):
     for zero-copy fan-out.
 
     Prefer :meth:`from_config` when sharing; never keep a direct camera open
-    while sharing. The constructor takes ``camera: ComponentConfig`` to spawn,
+    while sharing. The constructor takes ``camera: Config`` to spawn,
     or ``camera=None`` + ``service_name`` for attach-only
     (:meth:`from_publisher` is the explicit form).
 
     Opted into :func:`~physicalai.config.export_config` as a **construction
-    recipe** only (nested ``camera`` ComponentConfig, ``service_name``,
+    recipe** only (nested ``camera`` Config, ``service_name``,
     ``color_mode``, transport knobs). Publisher / iceoryx2 session / frame
     state is never part of :func:`~physicalai.config.to_config`.
 
@@ -109,7 +108,7 @@ class SharedCamera(Camera):
     hand off an already-open device into the child.
 
     Args:
-        camera: Camera :class:`~physicalai.config.ComponentConfig` from local
+        camera: Camera :class:`~physicalai.config.Config` from local
             config input (same boundary as CLI/app args), used to spawn if no
             publisher exists yet for the derived or explicit ``service_name``.
             ``None`` means attach-only. Declared as an ``@export_config``
@@ -139,7 +138,7 @@ class SharedCamera(Camera):
     def __init__(
         self,
         *,
-        camera: ComponentConfig | Mapping[str, object] | None = None,
+        camera: Config | Mapping[str, object] | None = None,
         color_mode: ColorMode | str = ColorMode.RGB,
         zero_copy: bool = False,
         service_name: str | None = None,
@@ -148,7 +147,7 @@ class SharedCamera(Camera):
         idle_timeout: float = 5.0,
     ) -> None:
         if camera is None and service_name is None:
-            msg = "must provide camera ComponentConfig or service_name"
+            msg = "must provide camera Config or service_name"
             raise ValueError(msg)
 
         recipe = None if camera is None else normalize_camera_config(camera)
@@ -178,13 +177,13 @@ class SharedCamera(Camera):
     @classmethod
     def _physicalai_normalize_captured_init_args(cls, supplied: dict[str, object]) -> None:
         camera = supplied.get("camera")
-        if isinstance(camera, Mapping):
-            supplied["camera"] = normalize_camera_config(camera)
+        if isinstance(camera, Mapping) or type(camera) is Config:
+            supplied["camera"] = normalize_camera_config(camera).to_dict()
 
     @classmethod
     def from_config(
         cls,
-        config: ComponentConfig | Mapping[str, object],
+        config: Config | Mapping[str, object],
         *,
         service_name: str | None = None,
         color_mode: ColorMode | str = ColorMode.RGB,
@@ -193,7 +192,7 @@ class SharedCamera(Camera):
         overwrite_settings: bool = False,
         idle_timeout: float = 5.0,
     ) -> SharedCamera:
-        """Primary API: spawn/attach from a local camera ComponentConfig.
+        """Primary API: spawn/attach from a local camera Config.
 
         Args:
             config: Local ``class_path`` + ``init_args`` for the camera.
@@ -205,7 +204,7 @@ class SharedCamera(Camera):
             idle_timeout: Idle self-exit timeout for a spawned publisher.
 
         Returns:
-            A ``SharedCamera`` that stores the normalized ComponentConfig and
+            A ``SharedCamera`` that stores the normalized Config and
             writes only the new publisher stdin shape on spawn.
         """
         return cls(
@@ -439,7 +438,7 @@ class SharedCamera(Camera):
             CaptureError: If this camera has no valid reconfigurable settings.
         """
         if self._camera is None:
-            msg = "reconfigure requires a camera ComponentConfig (attach-only SharedCamera has none)"
+            msg = "reconfigure requires a camera Config (attach-only SharedCamera has none)"
             raise CaptureError(msg)
 
         init_args = self._camera["init_args"]

--- a/src/physicalai/capture/transport/_spec.py
+++ b/src/physicalai/capture/transport/_spec.py
@@ -220,7 +220,7 @@ class CameraPublisherConfig:
         Raises:
             TypeError: If the instantiated object does not satisfy ``Camera``.
         """
-        from physicalai.capture.camera import Camera
+        from physicalai.capture.camera import Camera  # noqa: PLC0415
 
         driver = normalize_camera_config(self.camera).instantiate()
         if not isinstance(driver, Camera):

--- a/src/physicalai/capture/transport/_spec.py
+++ b/src/physicalai/capture/transport/_spec.py
@@ -3,7 +3,7 @@
 
 """Serializable camera construction spec for transport endpoints.
 
-Private publisher stdin is ``camera: ComponentConfig`` only. The publisher
+Private publisher stdin is ``camera: Config`` only. The publisher
 envelope is validated schema-positively: required ``camera``, known transport
 keys, and rejection of unknown keys (including legacy flat
 ``camera_type`` / ``camera_kwargs``) before import or hardware access. Public
@@ -22,9 +22,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from physicalai.config import (
-    ComponentConfig,
-    instantiate,
-    normalize_component_config,
+    Config,
+    normalize_config,
     validate_envelope,
 )
 
@@ -45,11 +44,11 @@ _RECONFIGURE_REQUEST_KEYS = frozenset({"kind", "settings"})
 _RECONFIGURABLE_SETTINGS = frozenset({"width", "height", "fps"})
 
 
-def validate_publisher_config(data: Mapping[str, Any]) -> Mapping[str, object]:
+def validate_publisher_config(data: Mapping[str, Any]) -> Config:
     """Validate a publisher stdin payload schema-positively.
 
     Returns:
-        The validated ``camera`` ComponentConfig mapping (see
+        The validated ``camera`` Config mapping (see
         :func:`normalize_camera_config` for the JSON-serializability check).
     """
     return validate_envelope(
@@ -110,13 +109,13 @@ def validate_reconfigure_request(request: Mapping[str, Any]) -> dict[str, int]:
     return validated
 
 
-def normalize_camera_config(camera: Mapping[str, object]) -> ComponentConfig:
-    """Validate a camera ComponentConfig without importing its ``class_path``.
+def normalize_camera_config(camera: Config | Mapping[str, object]) -> Config:
+    """Validate a camera Config without importing its ``class_path``.
 
     Returns:
         A validated config whose ``class_path`` is a dotted import path.
     """
-    return normalize_component_config(
+    return normalize_config(
         camera,
         component_key="camera",
         class_label="camera class_path",
@@ -124,11 +123,11 @@ def normalize_camera_config(camera: Mapping[str, object]) -> ComponentConfig:
 
 
 def derive_service_name(
-    camera: Mapping[str, object],
+    camera: Config | Mapping[str, object],
     *,
     service_name: str | None = None,
 ) -> str:
-    """Resolve iceoryx2 ``service_name`` for a camera ComponentConfig.
+    """Resolve iceoryx2 ``service_name`` for a camera Config.
 
     Derives ``physicalai/camera/{class_name}/{device_id}/frame`` from the
     terminal segment of ``class_path``, without importing it. The bare class
@@ -136,7 +135,7 @@ def derive_service_name(
     classes sharing a name and device id need an explicit *service_name*.
 
     Args:
-        camera: Normalized or raw camera ComponentConfig.
+        camera: Normalized or raw camera Config.
         service_name: Explicit override; when set, returned unchanged.
 
     Returns:
@@ -166,10 +165,10 @@ class CameraPublisherConfig:
         camera: Local construction config (``class_path`` + ``init_args``).
     """
 
-    camera: Mapping[str, object]
+    camera: Config | Mapping[str, object]
 
     def __post_init__(self) -> None:
-        """Normalize ``camera`` to a public ComponentConfig."""
+        """Normalize ``camera`` to a public Config."""
         object.__setattr__(self, "camera", normalize_camera_config(self.camera))
 
     def to_json_dict(self) -> dict[str, Any]:
@@ -179,19 +178,8 @@ class CameraPublisherConfig:
             Dictionary with ``camera`` only (transport fields are merged by
             the publisher).
 
-        Raises:
-            TypeError: If ``camera.init_args`` is not a mapping.
         """
-        init_args = self.camera["init_args"]
-        if not isinstance(init_args, dict):
-            msg = f"camera.init_args must be a mapping, got {type(init_args).__name__}"
-            raise TypeError(msg)
-        return {
-            "camera": {
-                "class_path": self.camera["class_path"],
-                "init_args": dict(init_args),
-            },
-        }
+        return {"camera": normalize_camera_config(self.camera).to_dict()}
 
     @classmethod
     def from_json_dict(cls, data: dict[str, Any]) -> CameraPublisherConfig:
@@ -222,7 +210,7 @@ class CameraPublisherConfig:
         """Instantiate the camera described by this spec.
 
         Uses :func:`physicalai.config.instantiate` on the ``camera``
-        ComponentConfig, then verifies the :class:`~physicalai.capture.camera.Camera`
+        Config, then verifies the :class:`~physicalai.capture.camera.Camera`
         protocol. Does not route through :func:`~physicalai.capture.create_camera`,
         so third-party class paths work without a registry entry.
 
@@ -232,9 +220,9 @@ class CameraPublisherConfig:
         Raises:
             TypeError: If the instantiated object does not satisfy ``Camera``.
         """
-        from physicalai.capture.camera import Camera  # noqa: PLC0415
+        from physicalai.capture.camera import Camera
 
-        driver = instantiate(self.camera)  # type: ignore[arg-type]
+        driver = normalize_camera_config(self.camera).instantiate()
         if not isinstance(driver, Camera):
             msg = f"{self.camera['class_path']!r} does not satisfy the Camera protocol (got {type(driver).__name__})"
             raise TypeError(msg)

--- a/src/physicalai/cli/robot.py
+++ b/src/physicalai/cli/robot.py
@@ -17,7 +17,7 @@ from jsonargparse import ActionConfigFile, ArgumentParser
 from loguru import logger
 
 from physicalai.cli._spec import SubcommandSpec  # noqa: PLC2701
-from physicalai.config import ComponentConfigError
+from physicalai.config import ConfigError
 from physicalai.robot.errors import RobotTransportError
 from physicalai.robot.transport import (
     DEFAULT_RATE_HZ,
@@ -61,7 +61,7 @@ def _build_serve_parser() -> ArgumentParser:
         type=dict,
         required=True,
         help=(
-            "Robot ComponentConfig (class_path + init_args). "
+            "Robot Config (class_path + init_args). "
             'Example: --robot=\'{"class_path":"physicalai.robot.SO101",'
             '"init_args":{"port":"/dev/ttyACM0"}}\'. '
             "Or nested flags: --robot.class_path=physicalai.robot.SO101 "
@@ -163,17 +163,17 @@ def _mapping_from_cfg(value: object) -> dict[str, object]:
 
 
 def _robot_config_from_serve_cfg(cfg: Namespace) -> dict[str, object]:
-    """Require ``--robot`` ComponentConfig for foreground serve.
+    """Require ``--robot`` Config for foreground serve.
 
     Returns:
-        A ComponentConfig mapping for :class:`RobotOwnerConfig`.
+        A Config mapping for :class:`RobotOwnerConfig`.
 
     Raises:
         ValueError: If ``--robot`` is missing.
     """
     robot = getattr(cfg, "robot", None)
     if robot is None:
-        msg = "robot serve requires --robot ComponentConfig (class_path + init_args)"
+        msg = "robot serve requires --robot Config (class_path + init_args)"
         raise ValueError(msg)
     return _mapping_from_cfg(robot)
 
@@ -224,7 +224,7 @@ def serve(cfg: Namespace) -> int:
             rate_hz=cfg.rate_hz,
             idle_timeout=None,
         )
-    except (TypeError, ValueError, ComponentConfigError) as exc:
+    except (TypeError, ValueError, ConfigError) as exc:
         logger.error(f"Invalid robot configuration: {exc}")
         return 1
 

--- a/src/physicalai/cli/run.py
+++ b/src/physicalai/cli/run.py
@@ -50,7 +50,7 @@ def _reshape_config_value(parser: ArgumentParser, value: object) -> object:
     """Return CLI-shaped config content for a bare exported runtime document.
 
     A ``--config`` value that points to a document with a top-level
-    ``class_path`` (as produced by ``to_config(runtime)`` / ``save_yaml``) is
+    ``class_path`` (as produced by ``Config.from_instance(runtime)`` / ``save_yaml``) is
     loaded and unwrapped to the ``runtime:`` mapping the parser expects,
     returned as JSON content (valid YAML that ``ActionConfigFile`` accepts
     inline). Any other value — a non-path, an unreadable file, or a
@@ -70,23 +70,23 @@ def _reshape_config_value(parser: ArgumentParser, value: object) -> object:
     if not isinstance(document, dict) or "class_path" not in document:
         return value
 
-    from physicalai.config import ComponentConfigError  # noqa: PLC0415
+    from physicalai.config import ConfigError  # noqa: PLC0415
     from physicalai.runtime import RobotRuntime  # noqa: PLC0415
     from physicalai.runtime.core import _unwrap_runtime_document  # noqa: PLC0415, PLC2701
 
     try:
         return json.dumps(_unwrap_runtime_document(document, target=RobotRuntime))
-    except ComponentConfigError as exc:
+    except ConfigError as exc:
         parser.error(str(exc))
 
 
 class _RuntimeConfigFile(ActionConfigFile):
     """``--config`` action accepting both the CLI document and a bare export.
 
-    Reshapes a bare exported ``RobotRuntime`` ComponentConfig (a document with a
+    Reshapes a bare exported ``RobotRuntime`` Config (a document with a
     top-level ``class_path``) into the ``runtime:`` document jsonargparse
     expects before applying it; a ``runtime:`` / ``run:`` CLI document is passed
-    through unchanged. This keeps ``to_config(runtime)`` → ``save_yaml`` →
+    through unchanged. This keeps ``Config.from_instance(runtime)`` → ``save_yaml`` →
     ``physicalai run --config`` a single-shape round-trip.
     """
 
@@ -107,7 +107,7 @@ def build_parser() -> ArgumentParser:
     One path: ``RobotRuntime`` constructor arguments (``action_source:``
     always explicit) plus ``run()`` method arguments. ``--config`` accepts
     both the CLI document (``runtime:`` / ``run:``) and a bare exported
-    ComponentConfig produced by ``to_config(runtime)``.
+    Config produced by ``Config.from_instance(runtime)``.
 
     Returns:
         Parser for the ``physicalai run`` subcommand.

--- a/src/physicalai/config/__init__.py
+++ b/src/physicalai/config/__init__.py
@@ -39,7 +39,7 @@ from .importing import import_dotted_path
 from .instantiate import import_class, instantiate_obj
 from .mixin import FromConfig, from_config
 
-instantiate = _strict_instantiate  # noqa: RUF067
+instantiate = _strict_instantiate  # ruff: ignore[RUF067]
 
 __all__ = [
     "Config",

--- a/src/physicalai/config/__init__.py
+++ b/src/physicalai/config/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Captured component configuration: export live components and instantiate configs.
+"""Captured configuration: export live components and instantiate configs.
 
 Trusted local application and parent→child startup configs only. Never pass
 network metadata or untrusted peer payloads to :func:`instantiate`.
@@ -9,52 +9,61 @@ network metadata or untrusted peer payloads to :func:`instantiate`.
 Opt-in path:
 
 - ``@export_config`` / ``@export_config(class_path=...)`` — remember
-  caller-supplied constructor args for :func:`to_config`.
+  caller-supplied constructor args for :meth:`Config.from_instance`.
 - ``@export_config(..., scalar_var_kwargs=True)`` — seal flattened
-  ``**kwargs`` to JSON scalars (non-scalars fail at :func:`to_config`).
+  ``**kwargs`` to JSON scalars (non-scalars fail during export).
 - Domain ctor args may implement :meth:`~ConfigValue.to_config_value` to
   return a JSON-compatible fragment (re-normalized).
 
 Transport and other callers import public names from here (no private
-``physicalai.config._*`` imports). Studio needs only
-:func:`is_config_exportable` and :func:`to_config`, then domain
-``from_config`` helpers (for example ``SharedRobot.from_config``).
+``physicalai.config._*`` imports).
 """
 
 from ._envelope import (
-    normalize_component_config,
+    normalize_config,
     validate_envelope,
 )
-from ._errors import ComponentConfigError, ComponentImportError
+from ._errors import ConfigError, ConfigImportError
 from ._export import (
     export_config,
     is_config_exportable,
     resolve_public_class_path,
     to_config,
 )
-from ._instantiate import instantiate
-from ._normalize import validate_component_config
-from ._types import ComponentConfig, ConfigValue, JsonScalar, JsonValue
+from ._instantiate import instantiate as _instantiate
+from ._normalize import validate_config
+from ._types import ConfigValue, JsonScalar, JsonValue
 from ._yaml import load_yaml, save_yaml, to_yaml
+from .base import Config
 from .importing import import_dotted_path
+from .instantiate import import_class, instantiate_obj
+from .mixin import FromConfig, from_config
+
+# Importing the public ``instantiate`` helper module sets the package attribute
+# to that module; restore the canonical strict function on the package API.
+instantiate = _instantiate
 
 __all__ = [
-    "ComponentConfig",
-    "ComponentConfigError",
-    "ComponentImportError",
+    "Config",
+    "ConfigError",
+    "ConfigImportError",
     "ConfigValue",
+    "FromConfig",
     "JsonScalar",
     "JsonValue",
     "export_config",
+    "from_config",
+    "import_class",
     "import_dotted_path",
     "instantiate",
+    "instantiate_obj",
     "is_config_exportable",
     "load_yaml",
-    "normalize_component_config",
+    "normalize_config",
     "resolve_public_class_path",
     "save_yaml",
     "to_config",
     "to_yaml",
-    "validate_component_config",
+    "validate_config",
     "validate_envelope",
 ]

--- a/src/physicalai/config/__init__.py
+++ b/src/physicalai/config/__init__.py
@@ -30,7 +30,7 @@ from ._export import (
     resolve_public_class_path,
     to_config,
 )
-from ._instantiate import instantiate as _instantiate
+from ._instantiate import instantiate as _strict_instantiate
 from ._normalize import validate_config
 from ._types import ConfigValue, JsonScalar, JsonValue
 from ._yaml import load_yaml, save_yaml, to_yaml
@@ -39,9 +39,7 @@ from .importing import import_dotted_path
 from .instantiate import import_class, instantiate_obj
 from .mixin import FromConfig, from_config
 
-# Importing the public ``instantiate`` helper module sets the package attribute
-# to that module; restore the canonical strict function on the package API.
-instantiate = _instantiate
+instantiate = _strict_instantiate  # noqa: RUF067
 
 __all__ = [
     "Config",

--- a/src/physicalai/config/__init__.py
+++ b/src/physicalai/config/__init__.py
@@ -6,6 +6,13 @@
 Trusted local application and parent→child startup configs only. Never pass
 network metadata or untrusted peer payloads to :func:`instantiate`.
 
+Two instantiation entry points:
+
+- :func:`instantiate` — strict captured ``class_path`` + ``init_args`` recipes
+  (transport, ``@export_config`` components).
+- :func:`instantiate_obj` — generic jsonargparse / Studio loaders; see
+  :mod:`physicalai.config.loading`.
+
 Opt-in path:
 
 - ``@export_config`` / ``@export_config(class_path=...)`` — remember
@@ -36,7 +43,7 @@ from ._types import ConfigValue, JsonScalar, JsonValue
 from ._yaml import load_yaml, save_yaml, to_yaml
 from .base import Config
 from .importing import import_dotted_path
-from .instantiate import import_class, instantiate_obj
+from .loading import import_class, instantiate_obj
 from .mixin import FromConfig, from_config
 
 instantiate = _strict_instantiate  # ruff: ignore[RUF067]

--- a/src/physicalai/config/_envelope.py
+++ b/src/physicalai/config/_envelope.py
@@ -4,7 +4,7 @@
 """Shared validation for transport construction envelopes.
 
 Robot-owner and camera-publisher stdin envelopes carry one nested
-:class:`ComponentConfig` plus transport-only keys. These helpers keep the
+:class:`Config` plus transport-only keys. These helpers keep the
 schema-positive validation in one place; transports supply their key names
 and allowlists.
 
@@ -17,13 +17,11 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from ._errors import ComponentConfigError
-from ._normalize import validate_component_config
-
-if TYPE_CHECKING:
-    from ._types import ComponentConfig
+from ._errors import ConfigError
+from ._normalize import validate_config
+from .base import Config
 
 
 def validate_envelope(
@@ -32,24 +30,24 @@ def validate_envelope(
     component_key: str,
     allowed_keys: frozenset[str],
     envelope_name: str,
-) -> Mapping[str, object]:
+) -> Config:
     """Validate a transport stdin envelope schema-positively.
 
-    Requires *component_key* with a valid ComponentConfig shape and allows
+    Requires *component_key* with a valid Config shape and allows
     only *allowed_keys*. Unknown keys raise a clear schema error before any
     import or hardware access.
 
     Args:
         data: Full stdin envelope dict.
-        component_key: Envelope key holding the nested ComponentConfig
+        component_key: Envelope key holding the nested Config
             (for example ``"robot"`` or ``"camera"``).
         allowed_keys: Complete allowlist of envelope keys.
         envelope_name: Short envelope label for error messages
             (for example ``"owner"`` or ``"publisher"``).
 
     Returns:
-        The validated ComponentConfig mapping (see
-        :func:`normalize_component_config` for the JSON-serializability check).
+        The validated Config mapping (see
+        :func:`normalize_config` for the JSON-serializability check).
 
     Raises:
         TypeError: If *data* or the component value is not a mapping.
@@ -69,7 +67,7 @@ def validate_envelope(
         raise ValueError(msg)
 
     if component_key not in data:
-        msg = f"{envelope_name} config missing required {component_key!r} ComponentConfig"
+        msg = f"{envelope_name} config missing required {component_key!r} Config"
         raise ValueError(msg)
 
     component = data[component_key]
@@ -77,17 +75,17 @@ def validate_envelope(
         msg = f"{envelope_name} {component_key!r} must be a mapping, got {type(component).__name__}"
         raise TypeError(msg)
 
-    return validate_component_config(dict(component), path=component_key)
+    return Config.from_dict(validate_config(dict(component), path=component_key))
 
 
-def normalize_component_config(
-    config: Mapping[str, object],
+def normalize_config(
+    config: Config | Mapping[str, object],
     *,
     component_key: str,
     class_label: str,
     json_hint: str = "",
-) -> ComponentConfig:
-    """Validate a ComponentConfig without importing its ``class_path``.
+) -> Config:
+    """Validate a Config without importing its ``class_path``.
 
     The ``class_path`` is trusted and kept exactly as written: envelopes are
     built in the subscriber process, which must not load the driver package
@@ -105,14 +103,16 @@ def normalize_component_config(
         A validated config whose ``class_path`` is a dotted import path.
 
     Raises:
-        ComponentConfigError: If *config* is not a mapping.
+        ConfigError: If *config* is not a mapping.
         ValueError: If ``class_path`` is not a dotted path or ``init_args`` is
             not JSON-serializable.
     """
+    if type(config) is Config:
+        config = config.to_dict()
     if not isinstance(config, Mapping):
-        msg = f"{component_key} must be a ComponentConfig mapping, got {type(config).__name__}"
-        raise ComponentConfigError(msg)
-    validated = validate_component_config(dict(config), path=component_key)
+        msg = f"{component_key} must be a Config mapping, got {type(config).__name__}"
+        raise ConfigError(msg)
+    validated = validate_config(dict(config), path=component_key)
     class_path = validated["class_path"]
     if not class_path.strip() or "." not in class_path:
         msg = f"{class_label} must be a nonempty dotted path, got {class_path!r}"
@@ -123,4 +123,4 @@ def normalize_component_config(
     except (TypeError, ValueError) as exc:
         msg = f"{component_key}.init_args must be JSON-serializable{json_hint}: {exc}"
         raise ValueError(msg) from exc
-    return {"class_path": class_path, "init_args": dict(init_args)}
+    return Config(class_path, dict(init_args))

--- a/src/physicalai/config/_errors.py
+++ b/src/physicalai/config/_errors.py
@@ -1,18 +1,18 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Errors for component configuration export and instantiation."""
+"""Errors for configuration export and instantiation."""
 
 from __future__ import annotations
 
 
-class ComponentConfigError(Exception):
-    """Raised when a component config cannot be exported, validated, or built.
+class ConfigError(Exception):
+    """Raised when a config cannot be exported, validated, or built.
 
     Callers typically recover by correcting configuration. Subclasses mark
     distinct failure phases when callers need to distinguish them.
     """
 
 
-class ComponentImportError(ComponentConfigError):
+class ConfigImportError(ConfigError):
     """Raised when a ``class_path`` cannot be resolved to an importable class."""

--- a/src/physicalai/config/_export.py
+++ b/src/physicalai/config/_export.py
@@ -9,7 +9,7 @@ import functools
 import inspect
 from typing import TYPE_CHECKING, TypeVar, overload
 
-from ._errors import ComponentConfigError
+from ._errors import ConfigError
 from ._normalize import (
     normalize_value,
     snapshot_captured_value,
@@ -23,13 +23,15 @@ from ._types import (
     _EXPORT_MARKER_ATTR,
     _MAX_CONFIG_DEPTH,
     _NORMALIZE_CAPTURED_INIT_ARGS_ATTR,
-    ComponentConfig,
     JsonValue,
+    _ConfigDict,
 )
 from .importing import import_dotted_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+
+    from .base import Config
 
 _T = TypeVar("_T", bound=type)
 
@@ -78,7 +80,7 @@ def _encode_domain_value(value: object) -> tuple[JsonValue] | None:
 
 
 def is_config_exportable(value: object) -> bool:
-    """Return whether *value* can export a :class:`ComponentConfig`.
+    """Return whether *value* can export a :class:`Config`.
 
     A value is exportable if and only if its most-derived class's effective
     ``__init__`` carries the ``@export_config`` marker.
@@ -88,7 +90,7 @@ def is_config_exportable(value: object) -> bool:
 
 
 def declared_config_args(cls: type) -> frozenset[str]:
-    """Return init-arg names *cls* consumes as ComponentConfig data.
+    """Return init-arg names *cls* consumes as Config data.
 
     Declared via ``@export_config(config_args=...)``. :func:`instantiate`
     passes these arguments through as plain mappings instead of building the
@@ -131,23 +133,23 @@ def resolve_public_class_path(cls: type) -> str:
         The importable public dotted path.
 
     Raises:
-        ComponentConfigError: If *cls* is local, the path is not importable, or
+        ConfigError: If *cls* is local, the path is not importable, or
             the path resolves to a different object.
     """
     path = _class_path_override(cls) or f"{cls.__module__}.{cls.__qualname__}"
 
     if "<locals>" in cls.__qualname__:
         msg = f"local class {path!r} cannot export a stable class_path"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
     try:
         resolved = import_dotted_path(path)
     except (ValueError, ImportError, AttributeError) as exc:
         msg = f"class_path {path!r} for {cls.__qualname__} is not importable: {exc}"
-        raise ComponentConfigError(msg) from exc
+        raise ConfigError(msg) from exc
     if resolved is not cls:
         msg = f"class_path {path!r} resolves to {resolved!r}, expected exactly {cls!r}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     return path
 
 
@@ -162,13 +164,13 @@ def _arg_path(prefix: str, class_path: str, key: str) -> str:
     return f"{class_path}.init_args.{key}"
 
 
-def to_config(
+def _export_instance(
     value: object,
     *,
     _path: str = "",
     _depth: int = 0,
     _seen: set[int] | None = None,
-) -> ComponentConfig:
+) -> _ConfigDict:
     """Export an opted-in live component as JSON-safe ``class_path`` + ``init_args``.
 
     Nested constructor values may be components (``@export_config``) or domain
@@ -179,15 +181,15 @@ def to_config(
         value: An instance whose class uses ``@export_config``.
 
     Returns:
-        A :class:`ComponentConfig` describing the object as constructed.
+        A :class:`Config` describing the object as constructed.
 
     Raises:
-        ComponentConfigError: If *value* is not exportable or captured values
+        ConfigError: If *value* is not exportable or captured values
             cannot be normalized.
     """
     if _depth > _MAX_CONFIG_DEPTH:
         msg = f"{format_path(_path)}: nesting depth exceeds {_MAX_CONFIG_DEPTH}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
     seen = _seen if _seen is not None else set()
 
@@ -196,7 +198,7 @@ def to_config(
             f"{_path or _component_path_prefix(value)}: not config-exportable; "
             "decorate the concrete class with @export_config"
         )
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
     captured = getattr(value, _CAPTURED_INIT_ARGS_ATTR, None)
     if captured is None:
@@ -204,7 +206,7 @@ def to_config(
             f"{_path or _component_path_prefix(value)}: no captured constructor "
             "arguments; the object was not constructed through the decorated __init__"
         )
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
     class_path = resolve_public_class_path(type(value))
     init_args: dict[str, JsonValue] = {}
@@ -214,20 +216,18 @@ def to_config(
             path=_arg_path(_path, class_path, key),
             depth=_depth + 1,
             seen=seen,
-            to_config=to_config,
+            to_config=_export_instance,
             is_exportable=is_config_exportable,
             domain_codec=_encode_domain_value,
         )
     return {"class_path": class_path, "init_args": init_args}
 
 
-def _instance_to_config(self: object) -> ComponentConfig:
-    """Instance-method sugar for :func:`to_config`; prefer the module function.
+def to_config(value: object) -> Config:
+    """Return the canonical recipe for an ``@export_config`` instance."""
+    from .base import Config
 
-    Returns:
-        The component config for *self*.
-    """
-    return to_config(self)
+    return Config.from_instance(value)
 
 
 def _validate_replayable_signature(cls: type, signature: inspect.Signature) -> None:
@@ -388,8 +388,6 @@ def _decorate_export_config(
     if declared:
         setattr(wrapped_init, _CONFIG_ARGS_ATTR, declared)
     cls.__init__ = wrapped_init  # type: ignore[method-assign]
-    # Convenience method; type checkers do not see the injection — prefer module to_config.
-    cls.to_config = _instance_to_config  # type: ignore[attr-defined]
     return cls
 
 
@@ -417,9 +415,7 @@ def export_config(
     """Opt a concrete class into constructor-config export via :func:`to_config`.
 
     Remembers caller-supplied ``__init__`` arguments (not defaults). Rejects
-    constructors that declare positional-only parameters or ``*args``. Injects
-    an instance ``to_config()`` convenience method; library code should still
-    call the module-level :func:`to_config`.
+    constructors that declare positional-only parameters or ``*args``.
 
     Usage::
 
@@ -464,7 +460,7 @@ def export_config(
             export to resolve exactly to the decorated class.
         scalar_var_kwargs: When ``True``, seal flattened ``**kwargs`` to JSON
             scalars so non-scalars fail at :func:`to_config`.
-        config_args: Init-arg names the class consumes as ComponentConfig
+        config_args: Init-arg names the class consumes as Config
             *data*. :func:`instantiate` passes these through as plain mappings
             instead of constructing the nested component — use it for spawn
             recipes that must cross a process boundary (for example

--- a/src/physicalai/config/_export.py
+++ b/src/physicalai/config/_export.py
@@ -24,7 +24,7 @@ from ._types import (
     _MAX_CONFIG_DEPTH,
     _NORMALIZE_CAPTURED_INIT_ARGS_ATTR,
     JsonValue,
-    _ConfigDict,
+    ValidatedConfigDict,
 )
 from .importing import import_dotted_path
 
@@ -170,7 +170,7 @@ def _export_instance(
     _path: str = "",
     _depth: int = 0,
     _seen: set[int] | None = None,
-) -> _ConfigDict:
+) -> ValidatedConfigDict:
     """Export an opted-in live component as JSON-safe ``class_path`` + ``init_args``.
 
     Nested constructor values may be components (``@export_config``) or domain
@@ -225,7 +225,7 @@ def _export_instance(
 
 def to_config(value: object) -> Config:
     """Return the canonical recipe for an ``@export_config`` instance."""
-    from .base import Config
+    from .base import Config  # noqa: PLC0415
 
     return Config.from_instance(value)
 

--- a/src/physicalai/config/_export.py
+++ b/src/physicalai/config/_export.py
@@ -225,7 +225,7 @@ def _export_instance(
 
 def to_config(value: object) -> Config:
     """Return the canonical recipe for an ``@export_config`` instance."""
-    from .base import Config  # noqa: PLC0415
+    from .base import Config  # ruff: ignore[PLC0415]
 
     return Config.from_instance(value)
 

--- a/src/physicalai/config/_instantiate.py
+++ b/src/physicalai/config/_instantiate.py
@@ -285,6 +285,7 @@ def instantiate(config: Config | Mapping[str, JsonValue]) -> object:
     Returns:
         A new instance of the configured class.
     """
-    raw = config.to_dict() if type(config) is Config else config
+    raw: Config | Mapping[str, JsonValue]
+    raw = {"class_path": config.class_path, "init_args": config.init_args} if type(config) is Config else config
     _preflight_config(raw, path="", depth=0, seen=set())
     return _instantiate_impl(raw, path="", depth=0, seen=set())

--- a/src/physicalai/config/_instantiate.py
+++ b/src/physicalai/config/_instantiate.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Instantiate trusted ComponentConfig trees."""
+"""Instantiate trusted Config trees."""
 
 from __future__ import annotations
 
@@ -10,11 +10,12 @@ from collections.abc import Mapping
 from enum import Enum
 from typing import cast
 
-from ._errors import ComponentConfigError, ComponentImportError
+from ._errors import ConfigError, ConfigImportError
 from ._export import declared_config_args
-from ._normalize import validate_component_config
+from ._normalize import validate_config
 from ._path import format_path
-from ._types import _MAX_CONFIG_DEPTH, ComponentConfig, JsonValue
+from ._types import _MAX_CONFIG_DEPTH, JsonValue
+from .base import Config
 from .importing import import_dotted_path
 
 
@@ -25,7 +26,7 @@ def _is_nested_config(value: object) -> bool:
 def _check_preflight_depth(path: str, depth: int) -> None:
     if depth > _MAX_CONFIG_DEPTH:
         msg = f"{format_path(path)}: nesting depth exceeds {_MAX_CONFIG_DEPTH}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
 
 def _preflight_config(
@@ -38,15 +39,15 @@ def _preflight_config(
     """Validate a complete component subtree before any class import.
 
     Raises:
-        ComponentConfigError: If the config tree is malformed.
+        ConfigError: If the config tree is malformed.
     """
     _check_preflight_depth(path, depth)
 
-    validated = validate_component_config(config, path=path)
+    validated = validate_config(config, path=path)
     config_id = id(config)
     if config_id in seen:
-        msg = f"{format_path(path)}: cyclic component config is not instantiable"
-        raise ComponentConfigError(msg)
+        msg = f"{format_path(path)}: cyclic config is not instantiable"
+        raise ConfigError(msg)
     seen.add(config_id)
     try:
         for key, item in validated["init_args"].items():
@@ -70,13 +71,13 @@ def _preflight_mapping(
     value_id = id(value)
     if value_id in seen:
         msg = f"{format_path(path)}: cyclic mapping is not instantiable"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     seen.add(value_id)
     try:
         for key, item in value.items():
             if not isinstance(key, str):
                 msg = f"{format_path(path)}: mapping keys must be strings, got {type(key).__name__}"
-                raise ComponentConfigError(msg)
+                raise ConfigError(msg)
             child_path = f"{path}.{key}" if path else key
             _preflight_value(item, path=child_path, depth=depth + 1, seen=seen)
     finally:
@@ -93,7 +94,7 @@ def _preflight_list(
     value_id = id(value)
     if value_id in seen:
         msg = f"{format_path(path)}: cyclic sequence is not instantiable"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     seen.add(value_id)
     try:
         for index, item in enumerate(value):
@@ -113,13 +114,13 @@ def _preflight_value(
     """Validate one constructor value against the recursive JSON model.
 
     Raises:
-        ComponentConfigError: If the value is outside the JSON model.
+        ConfigError: If the value is outside the JSON model.
     """
     _check_preflight_depth(path, depth)
 
     if isinstance(value, Enum):
-        msg = f"{format_path(path)}: Enum is not a JSON-compatible component config value; pass its value instead"
-        raise ComponentConfigError(msg)
+        msg = f"{format_path(path)}: Enum is not a JSON-compatible config value; pass its value instead"
+        raise ConfigError(msg)
     if value is None or isinstance(value, (bool, str)):
         return
     if isinstance(value, int):
@@ -127,7 +128,7 @@ def _preflight_value(
     if isinstance(value, float):
         if not math.isfinite(value):
             msg = f"{format_path(path)}: non-finite float {value!r} is not JSON-portable"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
         return
 
     if isinstance(value, dict):
@@ -138,8 +139,8 @@ def _preflight_value(
         _preflight_list(value, path=path, depth=depth, seen=seen)
         return
 
-    msg = f"{format_path(path)}: {type(value).__name__} is not a JSON-compatible component config value"
-    raise ComponentConfigError(msg)
+    msg = f"{format_path(path)}: {type(value).__name__} is not a JSON-compatible config value"
+    raise ConfigError(msg)
 
 
 def _decode_value(
@@ -151,11 +152,11 @@ def _decode_value(
 ) -> object:
     if depth > _MAX_CONFIG_DEPTH:
         msg = f"{format_path(path)}: nesting depth exceeds {_MAX_CONFIG_DEPTH}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
     if _is_nested_config(value):
         return _instantiate_impl(
-            cast("ComponentConfig | Mapping[str, JsonValue]", value),
+            cast("Config | Mapping[str, JsonValue]", value),
             path=path,
             depth=depth,
             seen=seen,
@@ -165,14 +166,14 @@ def _decode_value(
         obj_id = id(value)
         if obj_id in seen:
             msg = f"{format_path(path)}: cyclic mapping is not instantiable"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
         seen.add(obj_id)
         try:
             result: dict[str, object] = {}
             for key, item in value.items():
                 if not isinstance(key, str):
                     msg = f"{format_path(path)}: mapping keys must be strings, got {type(key).__name__}"
-                    raise ComponentConfigError(msg)
+                    raise ConfigError(msg)
                 child_path = f"{path}.{key}" if path else key
                 result[key] = _decode_value(item, path=child_path, depth=depth + 1, seen=seen)
             return result
@@ -183,7 +184,7 @@ def _decode_value(
         obj_id = id(value)
         if obj_id in seen:
             msg = f"{format_path(path)}: cyclic sequence is not instantiable"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
         seen.add(obj_id)
         try:
             items: list[object] = []
@@ -200,23 +201,23 @@ def _decode_value(
 def _resolve_class(class_path: str, *, path: str) -> type:
     if "<locals>" in class_path:
         msg = f"{format_path(path)}: local class {class_path!r} cannot be imported"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     try:
         obj = import_dotted_path(class_path)
     except (ValueError, ImportError, AttributeError) as exc:
         msg = f"{format_path(path)}: cannot import class_path {class_path!r}: {exc}"
-        raise ComponentImportError(msg) from exc
+        raise ConfigImportError(msg) from exc
     if not isinstance(obj, type):
         msg = f"{format_path(path)}: {class_path!r} does not resolve to a class (got {type(obj).__name__})"
-        raise ComponentImportError(msg)
+        raise ConfigImportError(msg)
     if "<locals>" in obj.__qualname__:
         msg = f"{format_path(path)}: local class {class_path!r} cannot be instantiated"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     return obj
 
 
 def _instantiate_impl(
-    config: ComponentConfig | Mapping[str, JsonValue],
+    config: Config | Mapping[str, JsonValue],
     *,
     path: str,
     depth: int,
@@ -224,16 +225,16 @@ def _instantiate_impl(
 ) -> object:
     if depth > _MAX_CONFIG_DEPTH:
         msg = f"{format_path(path)}: nesting depth exceeds {_MAX_CONFIG_DEPTH}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
-    validated = validate_component_config(config, path=path)
+    validated = validate_config(config, path=path)
     cls = _resolve_class(validated["class_path"], path=path)
     config_args = declared_config_args(cls)
 
     decoded_args: dict[str, object] = {}
     for key, item in validated["init_args"].items():
         if key in config_args:
-            # Declared ComponentConfig data: hand the recipe over untouched so
+            # Declared Config data: hand the recipe over untouched so
             # nothing nested is constructed in this process.
             decoded_args[key] = item
             continue
@@ -241,18 +242,20 @@ def _instantiate_impl(
         decoded_args[key] = _decode_value(item, path=child_path, depth=depth + 1, seen=seen)
 
     try:
+        if issubclass(cls, Config):
+            return cls.from_dict(decoded_args)
         return cls(**decoded_args)
     except Exception as exc:
         loc = path or validated["class_path"]
-        exc.add_note(f"{format_path(loc)}: constructor failed while instantiating component config")
+        exc.add_note(f"{format_path(loc)}: constructor failed while instantiating config")
         raise
 
 
-def instantiate(config: ComponentConfig | Mapping[str, JsonValue]) -> object:
-    """Build a fresh component from a trusted :class:`ComponentConfig`.
+def instantiate(config: Config | Mapping[str, JsonValue]) -> object:
+    """Build a fresh component from a trusted :class:`Config`.
 
     Validates *config* before importing. Recursively instantiates nested
-    component configs in ``init_args``, then calls the class with keyword
+    configs in ``init_args``, then calls the class with keyword
     arguments. Init args a class declares via
     ``@export_config(config_args=...)`` are passed through as plain mappings
     instead of being constructed. Does not invoke lifecycle methods beyond the
@@ -261,8 +264,8 @@ def instantiate(config: ComponentConfig | Mapping[str, JsonValue]) -> object:
     Trusted local application and parent→child startup configs only. Never
     pass network metadata or untrusted peer payloads.
 
-    Malformed configs raise :class:`ComponentConfigError` (including
-    :class:`ComponentImportError` for unresolved ``class_path``). Constructor
+    Malformed configs raise :class:`ConfigError` (including
+    :class:`ConfigImportError` for unresolved ``class_path``). Constructor
     failures propagate as their original exception type with path context
     attached via :meth:`BaseException.add_note`.
 
@@ -272,5 +275,6 @@ def instantiate(config: ComponentConfig | Mapping[str, JsonValue]) -> object:
     Returns:
         A new instance of the configured class.
     """
-    _preflight_config(config, path="", depth=0, seen=set())
-    return _instantiate_impl(config, path="", depth=0, seen=set())
+    raw = config.to_dict() if type(config) is Config else config
+    _preflight_config(raw, path="", depth=0, seen=set())
+    return _instantiate_impl(raw, path="", depth=0, seen=set())

--- a/src/physicalai/config/_instantiate.py
+++ b/src/physicalai/config/_instantiate.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import math
 from collections.abc import Mapping
 from enum import Enum
@@ -229,6 +230,15 @@ def _instantiate_impl(
 
     validated = validate_config(config, path=path)
     cls = _resolve_class(validated["class_path"], path=path)
+
+    if cls is Config:
+        inner = validated["init_args"]
+        if not isinstance(inner, dict):
+            loc = path or validated["class_path"]
+            msg = f"{format_path(loc)}: Config init_args must be a mapping"
+            raise ConfigError(msg)
+        return cls.from_dict(inner)
+
     config_args = declared_config_args(cls)
 
     decoded_args: dict[str, object] = {}
@@ -242,7 +252,7 @@ def _instantiate_impl(
         decoded_args[key] = _decode_value(item, path=child_path, depth=depth + 1, seen=seen)
 
     try:
-        if issubclass(cls, Config):
+        if dataclasses.is_dataclass(cls) and issubclass(cls, Config):
             return cls.from_dict(decoded_args)
         return cls(**decoded_args)
     except Exception as exc:

--- a/src/physicalai/config/_normalize.py
+++ b/src/physicalai/config/_normalize.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Normalize live values into JSON-safe component configuration fragments."""
+"""Normalize live values into JSON-safe configuration fragments."""
 
 from __future__ import annotations
 
@@ -11,28 +11,28 @@ from enum import Enum
 from pathlib import Path
 from typing import cast
 
-from ._errors import ComponentConfigError
+from ._errors import ConfigError
 from ._path import format_path
 from ._types import (
     _MAX_CONFIG_DEPTH,
     _REPR_LIMIT,
-    ComponentConfig,
     JsonValue,
+    _ConfigDict,
 )
 
-ToConfigFn = Callable[..., ComponentConfig]
+ToConfigFn = Callable[..., Mapping[str, object]]
 IsExportableFn = Callable[[object], bool]
 # Present codec result is a 1-tuple so JSON ``null`` (``None``) is distinct from
 # “no codec” (plain ``None`` return from the codec function).
 DomainCodecFn = Callable[[object], tuple[JsonValue] | None]
 
 
-def _is_component_config_mapping(value: Mapping[object, object]) -> bool:
+def _is_config_mapping(value: Mapping[object, object]) -> bool:
     return "class_path" in value
 
 
-def validate_component_config(config: object, *, path: str = "") -> ComponentConfig:
-    """Validate a mapping as a :class:`ComponentConfig` without importing.
+def validate_config(config: object, *, path: str = "") -> _ConfigDict:
+    """Validate a construction recipe mapping without importing.
 
     Args:
         config: Candidate config mapping.
@@ -42,12 +42,12 @@ def validate_component_config(config: object, *, path: str = "") -> ComponentCon
         The validated config (``init_args`` defaulted to ``{}`` when omitted).
 
     Raises:
-        ComponentConfigError: If the mapping is malformed.
+        ConfigError: If the mapping is malformed.
     """
     loc = format_path(path)
     if not isinstance(config, dict):
-        msg = f"{loc}: component config must be a mapping, got {type(config).__name__}"
-        raise ComponentConfigError(msg)
+        msg = f"{loc}: config must be a mapping, got {type(config).__name__}"
+        raise ConfigError(msg)
 
     keys = set(config)
     allowed = {"class_path", "init_args"}
@@ -55,20 +55,20 @@ def validate_component_config(config: object, *, path: str = "") -> ComponentCon
     if extra:
         extras = ", ".join(sorted(repr(k) for k in extra))
         msg = (
-            f"{loc}: nested component config may only contain 'class_path' and "
+            f"{loc}: nested config may only contain 'class_path' and "
             f"'init_args'; unexpected keys: {extras}. For an ordinary mapping that "
             "needs a 'class_path' data key, encode it via to_config_value() "
-            "(or another domain wrapper) instead of nesting it as a component config"
+            "(or another domain wrapper) instead of nesting it as a config"
         )
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     if "class_path" not in config:
-        msg = f"{loc}: component config missing required 'class_path'"
-        raise ComponentConfigError(msg)
+        msg = f"{loc}: config missing required 'class_path'"
+        raise ConfigError(msg)
 
     class_path = config["class_path"]
     if not isinstance(class_path, str) or not class_path:
         msg = f"{loc}: 'class_path' must be a non-empty string"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
     if "init_args" not in config:
         init_args: object = {}
@@ -76,29 +76,29 @@ def validate_component_config(config: object, *, path: str = "") -> ComponentCon
         init_args = config["init_args"]
         if init_args is None:
             msg = f"{loc}: 'init_args' must be a mapping, got None"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
     if not isinstance(init_args, dict):
         msg = f"{loc}: 'init_args' must be a mapping, got {type(init_args).__name__}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     for key in init_args:
         if not isinstance(key, str):
             msg = f"{loc}.init_args: keys must be strings, got {type(key).__name__}"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
 
-    return {"class_path": class_path, "init_args": dict(init_args)}
+    return {"class_path": class_path, "init_args": cast("dict[str, JsonValue]", dict(init_args))}
 
 
 def _check_depth(path: str, depth: int) -> None:
     if depth > _MAX_CONFIG_DEPTH:
         msg = f"{format_path(path)}: nesting depth exceeds {_MAX_CONFIG_DEPTH}"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
 
 def _try_normalize_scalar(value: object, *, path: str) -> tuple[bool, JsonValue]:
     """Return ``(True, json_value)`` for scalars/Path, else ``(False, None)``.
 
     Raises:
-        ComponentConfigError: If *value* is a non-finite float.
+        ConfigError: If *value* is a non-finite float.
     """
     if value is None or isinstance(value, (bool, str)):
         return True, value
@@ -107,7 +107,7 @@ def _try_normalize_scalar(value: object, *, path: str) -> tuple[bool, JsonValue]
     if isinstance(value, float):
         if not math.isfinite(value):
             msg = f"{format_path(path)}: non-finite float {value!r} is not JSON-portable"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
         return True, value
     if isinstance(value, Path):
         return True, str(value)
@@ -121,10 +121,10 @@ def _normalize_enum(value: Enum, *, path: str) -> JsonValue:
     ):
         if isinstance(enum_value, float) and not math.isfinite(enum_value):
             msg = f"{format_path(path)}: non-finite enum value {enum_value!r}"
-            raise ComponentConfigError(msg)
+            raise ConfigError(msg)
         return enum_value  # type: ignore[return-value]
     msg = f"{format_path(path)}: enum {type(value).__name__} value {type(enum_value).__name__} is not JSON-safe"
-    raise ComponentConfigError(msg)
+    raise ConfigError(msg)
 
 
 def _normalize_exportable(
@@ -135,7 +135,7 @@ def _normalize_exportable(
     seen: set[int],
     to_config: ToConfigFn,
 ) -> JsonValue:
-    # Match instantiate: a nested component config found at *depth* is itself at
+    # Match instantiate: a nested config found at *depth* is itself at
     # *depth* (its init_args then advance to depth + 1 inside to_config).
     nested = to_config(value, _path=path, _depth=depth, _seen=seen)
     return cast("JsonValue", dict(nested))
@@ -155,10 +155,10 @@ def _normalize_mapping(
     obj_id = id(value)
     if obj_id in seen:
         msg = f"{format_path(path)}: cyclic mapping is not serializable"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
 
-    if _is_component_config_mapping(value):
-        validated = validate_component_config(value, path=path)
+    if _is_config_mapping(value):
+        validated = validate_config(value, path=path)
         nested_args: dict[str, JsonValue] = {}
         seen.add(obj_id)
         try:
@@ -184,7 +184,7 @@ def _normalize_mapping(
         for key, item in value.items():
             if not isinstance(key, str):
                 msg = f"{format_path(path)}: mapping keys must be strings, got {type(key).__name__}"
-                raise ComponentConfigError(msg)
+                raise ConfigError(msg)
             child_path = f"{path}.{key}" if path else key
             result[key] = normalize_value(
                 item,
@@ -215,7 +215,7 @@ def _normalize_sequence(
     obj_id = id(value)
     if obj_id in seen:
         msg = f"{format_path(path)}: cyclic sequence is not serializable"
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     seen.add(obj_id)
     try:
         items: list[JsonValue] = []
@@ -276,7 +276,7 @@ def normalize_value(
         A JSON-safe value.
 
     Raises:
-        ComponentConfigError: On unsupported values, cycles, depth overflow,
+        ConfigError: On unsupported values, cycles, depth overflow,
             or a domain codec that returns the same object identity.
     """
     _check_depth(path, depth)
@@ -292,6 +292,20 @@ def normalize_value(
     if isinstance(value, Enum):
         return _normalize_enum(value, path=path)
 
+    from .base import Config
+
+    if isinstance(value, Config):
+        return normalize_value(
+            value.to_jsonargparse(),
+            path=path,
+            depth=depth,
+            seen=seen,
+            codec_seen=codec_seen,
+            to_config=to_config,
+            is_exportable=is_exportable,
+            domain_codec=domain_codec,
+        )
+
     if is_exportable is not None and to_config is not None and is_exportable(value):
         return _normalize_exportable(value, path=path, depth=depth, seen=seen, to_config=to_config)
 
@@ -301,7 +315,7 @@ def normalize_value(
             obj_id = id(value)
             if obj_id in codec_seen:
                 msg = f"{format_path(path)}: cyclic to_config_value() encoding is not serializable"
-                raise ComponentConfigError(msg)
+                raise ConfigError(msg)
             (encoded,) = encoded_result
             # Identity guard: a method that returns self would recurse forever.
             if encoded is value:
@@ -310,7 +324,7 @@ def normalize_value(
                     "JSON-compatible value, not the same object "
                     "(absence of the method means no codec)"
                 )
-                raise ComponentConfigError(msg)
+                raise ConfigError(msg)
             codec_seen.add(obj_id)
             try:
                 return normalize_value(
@@ -351,7 +365,36 @@ def normalize_value(
         )
 
     msg = _unsupported_message(value, path=path)
-    raise ComponentConfigError(msg)
+    raise ConfigError(msg)
+
+
+def normalize_config(config: object, *, path: str = "") -> _ConfigDict:
+    """Normalize a recipe and its constructor values to the strict JSON model.
+
+    Returns:
+        A JSON-safe direct recipe mapping.
+    """
+    from ._export import (
+        _encode_domain_value,
+        _export_instance,
+        is_config_exportable,
+    )
+    from .base import Config
+
+    raw = config.to_dict() if type(config) is Config else config
+    validated = validate_config(raw, path=path)
+    normalized: dict[str, JsonValue] = {}
+    for key, value in validated["init_args"].items():
+        child_path = f"{path}.init_args.{key}" if path else f"{validated['class_path']}.init_args.{key}"
+        normalized[key] = normalize_value(
+            value,
+            path=child_path,
+            depth=1,
+            to_config=_export_instance,
+            is_exportable=is_config_exportable,
+            domain_codec=_encode_domain_value,
+        )
+    return {"class_path": validated["class_path"], "init_args": normalized}
 
 
 def snapshot_captured_value(
@@ -364,7 +407,7 @@ def snapshot_captured_value(
     Non-container values — including nested exportable components and domain
     values — are retained by identity so their own conversion remains
     authoritative. Cyclic containers are preserved via *memo* so
-    :func:`~physicalai.config.to_config` can reject them during normalization.
+            :meth:`~physicalai.config.Config.from_instance` can reject them during normalization.
 
     Returns:
         A snapshot of *value* suitable for later normalization.

--- a/src/physicalai/config/_normalize.py
+++ b/src/physicalai/config/_normalize.py
@@ -17,7 +17,7 @@ from ._types import (
     _MAX_CONFIG_DEPTH,
     _REPR_LIMIT,
     JsonValue,
-    _ConfigDict,
+    ValidatedConfigDict,
 )
 
 ToConfigFn = Callable[..., Mapping[str, object]]
@@ -31,7 +31,7 @@ def _is_config_mapping(value: Mapping[object, object]) -> bool:
     return "class_path" in value
 
 
-def validate_config(config: object, *, path: str = "") -> _ConfigDict:
+def validate_config(config: object, *, path: str = "") -> ValidatedConfigDict:
     """Validate a construction recipe mapping without importing.
 
     Args:
@@ -246,7 +246,7 @@ def _unsupported_message(value: object, *, path: str) -> str:
     return f"{format_path(path)}: cannot encode {type_name} {repr_value}; omit it or use a supported component value"
 
 
-def normalize_value(
+def normalize_value(  # noqa: PLR0911, PLR0912
     value: object,
     *,
     path: str = "",
@@ -292,7 +292,7 @@ def normalize_value(
     if isinstance(value, Enum):
         return _normalize_enum(value, path=path)
 
-    from .base import Config
+    from .base import Config  # noqa: PLC0415
 
     if isinstance(value, Config):
         return normalize_value(
@@ -368,18 +368,18 @@ def normalize_value(
     raise ConfigError(msg)
 
 
-def normalize_config(config: object, *, path: str = "") -> _ConfigDict:
+def normalize_config(config: object, *, path: str = "") -> ValidatedConfigDict:
     """Normalize a recipe and its constructor values to the strict JSON model.
 
     Returns:
         A JSON-safe direct recipe mapping.
     """
-    from ._export import (
+    from ._export import (  # noqa: PLC0415
         _encode_domain_value,
         _export_instance,
         is_config_exportable,
     )
-    from .base import Config
+    from .base import Config  # noqa: PLC0415
 
     raw = config.to_dict() if type(config) is Config else config
     validated = validate_config(raw, path=path)

--- a/src/physicalai/config/_normalize.py
+++ b/src/physicalai/config/_normalize.py
@@ -246,7 +246,7 @@ def _unsupported_message(value: object, *, path: str) -> str:
     return f"{format_path(path)}: cannot encode {type_name} {repr_value}; omit it or use a supported component value"
 
 
-def normalize_value(  # noqa: PLR0911, PLR0912
+def normalize_value(  # ruff: ignore[PLR0911, PLR0912]
     value: object,
     *,
     path: str = "",
@@ -292,7 +292,7 @@ def normalize_value(  # noqa: PLR0911, PLR0912
     if isinstance(value, Enum):
         return _normalize_enum(value, path=path)
 
-    from .base import Config  # noqa: PLC0415
+    from .base import Config  # ruff: ignore[PLC0415]
 
     if isinstance(value, Config):
         return normalize_value(
@@ -374,12 +374,8 @@ def normalize_config(config: object, *, path: str = "") -> ValidatedConfigDict:
     Returns:
         A JSON-safe direct recipe mapping.
     """
-    from ._export import (  # noqa: PLC0415
-        _encode_domain_value,
-        _export_instance,
-        is_config_exportable,
-    )
-    from .base import Config  # noqa: PLC0415
+    from ._export import _encode_domain_value, _export_instance, is_config_exportable  # ruff: ignore[PLC0415]
+    from .base import Config  # ruff: ignore[PLC0415]
 
     raw = config.to_dict() if type(config) is Config else config
     validated = validate_config(raw, path=path)

--- a/src/physicalai/config/_path.py
+++ b/src/physicalai/config/_path.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared argument-path formatting for component-config errors."""
+"""Shared argument-path formatting for config errors."""
 
 from __future__ import annotations
 

--- a/src/physicalai/config/_types.py
+++ b/src/physicalai/config/_types.py
@@ -16,6 +16,11 @@ class ValidatedConfigDict(TypedDict):
     init_args: dict[str, JsonValue]
 
 
+class JsonArgparseEnvelope(TypedDict):
+    class_path: str
+    init_args: dict[str, JsonValue]
+
+
 @runtime_checkable
 class ConfigValue(Protocol):
     """Domain value that encodes to constructor-compatible JSON for export."""

--- a/src/physicalai/config/_types.py
+++ b/src/physicalai/config/_types.py
@@ -11,7 +11,7 @@ JsonScalar = None | bool | int | float | str
 JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 
 
-class _ConfigDict(TypedDict):
+class ValidatedConfigDict(TypedDict):
     class_path: str
     init_args: dict[str, JsonValue]
 

--- a/src/physicalai/config/_types.py
+++ b/src/physicalai/config/_types.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Types for JSON-safe component configuration."""
+"""Types for JSON-safe configuration."""
 
 from __future__ import annotations
 
@@ -11,9 +11,7 @@ JsonScalar = None | bool | int | float | str
 JsonValue = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 
 
-class ComponentConfig(TypedDict):
-    """Wire shape shared with jsonargparse: ``class_path`` + ``init_args``."""
-
+class _ConfigDict(TypedDict):
     class_path: str
     init_args: dict[str, JsonValue]
 
@@ -23,12 +21,12 @@ class ConfigValue(Protocol):
     """Domain value that encodes to constructor-compatible JSON for export."""
 
     def to_config_value(self) -> JsonValue:
-        """Return ctor-compatible JSON for component-config export."""
+        """Return ctor-compatible JSON for config export."""
         ...
 
 
 # Maximum nesting depth for recursive normalization and instantiation.
-# Counts traversal through lists and mappings as well as nested component configs.
+# Counts traversal through lists and mappings as well as nested configs.
 _MAX_CONFIG_DEPTH = 10
 
 # Private attribute names used by @export_config.
@@ -38,7 +36,7 @@ _EXPORT_MARKER_ATTR = "_physicalai_export_config"
 _NORMALIZE_CAPTURED_INIT_ARGS_ATTR = "_physicalai_normalize_captured_init_args"
 # Optional public class_path override stored on the decorated __init__ wrapper.
 _CONFIG_CLASS_PATH_ATTR = "_physicalai_config_class_path"
-# Init-arg names the component consumes as ComponentConfig *data* rather than as
+# Init-arg names the component consumes as Config *data* rather than as
 # a constructed object. instantiate() passes these through undecoded.
 _CONFIG_ARGS_ATTR = "_physicalai_config_args"
 

--- a/src/physicalai/config/_yaml.py
+++ b/src/physicalai/config/_yaml.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""YAML round-trip helpers for component configs.
+"""YAML round-trip helpers for configs.
 
 ``to_yaml`` / ``save_yaml`` serialize a live ``@export_config`` component (or
 an existing ``class_path`` + ``init_args`` mapping) to a YAML document that
@@ -17,16 +17,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import yaml
 
-from ._errors import ComponentConfigError
+from ._errors import ConfigError
 from ._export import to_config
-from ._normalize import validate_component_config
-
-if TYPE_CHECKING:
-    from ._types import ComponentConfig, JsonValue
+from ._normalize import normalize_config
+from .base import Config
 
 
 def to_yaml(component: object) -> str:
@@ -34,14 +31,18 @@ def to_yaml(component: object) -> str:
 
     Args:
         component: A live ``@export_config`` instance, or an existing
-            :class:`ComponentConfig` mapping (validated, not re-exported).
+            :class:`Config` mapping (validated, not re-exported).
 
     Returns:
-        YAML text of the validated :class:`ComponentConfig`.
+        YAML text of the validated :class:`Config`.
     """
-    config: ComponentConfig
-    config = validate_component_config(dict(component)) if isinstance(component, Mapping) else to_config(component)
-    return yaml.safe_dump(dict(config), sort_keys=False, default_flow_style=False)
+    if type(component) is Config:
+        config = component
+    elif isinstance(component, Mapping):
+        config = Config.from_dict(component)
+    else:
+        config = to_config(component)
+    return yaml.safe_dump(config.to_dict(), sort_keys=False, default_flow_style=False)
 
 
 def save_yaml(component: object, path: str | Path) -> None:
@@ -49,13 +50,13 @@ def save_yaml(component: object, path: str | Path) -> None:
 
     Args:
         component: A live ``@export_config`` instance or a
-            :class:`ComponentConfig` mapping.
+            :class:`Config` mapping.
         path: Destination file path.
     """
     Path(path).write_text(to_yaml(component), encoding="utf-8")
 
 
-def load_yaml(path: str | Path) -> dict[str, JsonValue]:
+def load_yaml(path: str | Path) -> Config:
     """Load a YAML document as a mapping, ready for :func:`~physicalai.config.instantiate`.
 
     The document is parsed with ``yaml.safe_load`` and only shape-checked to
@@ -70,10 +71,10 @@ def load_yaml(path: str | Path) -> dict[str, JsonValue]:
         The loaded top-level mapping.
 
     Raises:
-        ComponentConfigError: If the document is not a mapping.
+        ConfigError: If the document is not a mapping.
     """
     loaded = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
     if not isinstance(loaded, dict):
         msg = f"{str(path)!r}: YAML config must be a mapping, got {type(loaded).__name__}"
-        raise ComponentConfigError(msg)
-    return loaded
+        raise ConfigError(msg)
+    return Config.from_dict(normalize_config(loaded))

--- a/src/physicalai/config/_yaml.py
+++ b/src/physicalai/config/_yaml.py
@@ -74,6 +74,8 @@ def load_yaml(path: str | Path) -> Config:
         ConfigError: If the document is not a mapping.
     """
     loaded = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if loaded is None:
+        loaded = {}
     if not isinstance(loaded, dict):
         msg = f"{str(path)!r}: YAML config must be a mapping, got {type(loaded).__name__}"
         raise ConfigError(msg)

--- a/src/physicalai/config/base.py
+++ b/src/physicalai/config/base.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception]
+
+"""Unified construction-recipe and typed-dataclass configuration class."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal, Self
+
+import yaml
+
+from .serializable import dataclass_to_dict, dict_to_dataclass
+
+__all__ = ["Config"]
+
+
+class Config:
+    """A construction recipe, or the base for a typed dataclass config."""
+
+    __hash__ = None
+
+    def __init__(self, class_path: str, init_args: Mapping[str, object] | None = None) -> None:
+        """Create a direct construction recipe."""
+        if type(self) is not Config:
+            msg = "Config subclasses must be dataclasses"
+            raise TypeError(msg)
+        from ._normalize import normalize_config  # ruff: ignore[import-outside-top-level]
+
+        validated = normalize_config({"class_path": class_path, "init_args": dict(init_args or {})})
+        self.class_path = validated["class_path"]
+        self.init_args = validated["init_args"]
+
+    @classmethod
+    def from_instance(cls, instance: object) -> Config:
+        """Capture an ``@export_config`` instance as a construction recipe."""
+        if cls is not Config:
+            msg = "from_instance() constructs the direct Config recipe type"
+            raise TypeError(msg)
+        from ._export import _export_instance  # ruff: ignore[import-outside-top-level]
+
+        recipe = _export_instance(instance)
+        return cls(recipe["class_path"], recipe["init_args"])
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert this config to its plain serialization form."""
+        if dataclasses.is_dataclass(self):
+            result = dataclass_to_dict(self)
+            if not isinstance(result, dict):
+                msg = f"Expected dict from dataclass_to_dict, got {type(result)}"
+                raise TypeError(msg)
+            return result
+        if type(self) is not Config:
+            msg = f"{type(self).__name__} must be a dataclass to use Config"
+            raise TypeError(msg)
+        return {"class_path": self.class_path, "init_args": dataclass_to_dict(self.init_args)}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> Self:
+        """Parse a direct recipe or reconstruct a typed dataclass config."""
+        if cls is Config:
+            from ._normalize import normalize_config  # ruff: ignore[import-outside-top-level]
+
+            validated = normalize_config(data)
+            return cls(validated["class_path"], validated["init_args"])
+        if not dataclasses.is_dataclass(cls):
+            msg = f"{cls.__name__} must be a dataclass to use Config"
+            raise TypeError(msg)
+        return dict_to_dataclass(cls, data)
+
+    def instantiate(self) -> object:
+        """Instantiate this direct construction recipe through the strict core."""
+        if type(self) is not Config:
+            msg = "instantiate() is only available on a direct Config recipe"
+            raise TypeError(msg)
+        from ._instantiate import instantiate  # ruff: ignore[import-outside-top-level]
+
+        return instantiate(self)
+
+    def to_jsonargparse(self) -> dict[str, Any]:
+        """Convert this config to a ``class_path``/``init_args`` envelope."""
+        if type(self) is Config:
+            return self.to_dict()
+        return {
+            "class_path": f"{type(self).__module__}.{type(self).__qualname__}",
+            "init_args": self.to_dict(),
+        }
+
+    def save(
+        self,
+        path: str | Path,
+        *,
+        format: Literal["jsonargparse", "dict"] = "jsonargparse",  # ruff: ignore[builtin-argument-shadowing]
+    ) -> None:
+        """Save this config to YAML."""
+        target = Path(path)
+        if target.suffix not in {".yaml", ".yml"}:
+            msg = f"Unsupported file extension: {target.suffix}. Use .yaml or .yml"
+            raise ValueError(msg)
+        data = self.to_dict() if format == "dict" else self.to_jsonargparse()
+        target.write_text(yaml.safe_dump(data, default_flow_style=False, sort_keys=False), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        """Load a direct recipe or typed config from YAML."""
+        source = Path(path)
+        if source.suffix not in {".yaml", ".yml"}:
+            msg = f"Unsupported file extension: {source.suffix}. Use .yaml or .yml"
+            raise ValueError(msg)
+        data = yaml.safe_load(source.read_text(encoding="utf-8"))
+        if data is None:
+            data = {}
+        if not isinstance(data, Mapping):
+            msg = f"Expected YAML root to be a mapping, got {type(data).__name__}"
+            raise TypeError(msg)
+        if cls is not Config and "init_args" in data:
+            data = data["init_args"]
+            if data is None:
+                data = {}
+            if not isinstance(data, Mapping):
+                msg = f"Expected 'init_args' to be a mapping, got {type(data).__name__}"
+                raise TypeError(msg)
+        return cls.from_dict(data)
+
+    def __getitem__(self, key: str) -> Any:
+        """Expose direct recipe keys for gradual internal migration."""
+        return self.to_dict()[key]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Return a direct recipe value, or *default* when absent."""
+        return self.to_dict().get(key, default)
+
+    def __eq__(self, other: object) -> bool:
+        """Compare configs by their plain serialization form."""
+        if isinstance(other, Config):
+            return self.to_dict() == other.to_dict()
+        if isinstance(other, Mapping):
+            return self.to_dict() == dict(other)
+        return NotImplemented
+
+    def __repr__(self) -> str:
+        """Return a direct recipe representation."""
+        if type(self) is Config:
+            return f"Config(class_path={self.class_path!r}, init_args={self.init_args!r})"
+        return object.__repr__(self)

--- a/src/physicalai/config/base.py
+++ b/src/physicalai/config/base.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception]
 
 """Unified construction-recipe and typed-dataclass configuration class."""
 
@@ -28,7 +27,7 @@ class Config:
         if type(self) is not Config:
             msg = "Config subclasses must be dataclasses"
             raise TypeError(msg)
-        from ._normalize import normalize_config  # ruff: ignore[import-outside-top-level]
+        from ._normalize import normalize_config
 
         validated = normalize_config({"class_path": class_path, "init_args": dict(init_args or {})})
         self.class_path = validated["class_path"]
@@ -40,7 +39,7 @@ class Config:
         if cls is not Config:
             msg = "from_instance() constructs the direct Config recipe type"
             raise TypeError(msg)
-        from ._export import _export_instance  # ruff: ignore[import-outside-top-level]
+        from ._export import _export_instance
 
         recipe = _export_instance(instance)
         return cls(recipe["class_path"], recipe["init_args"])
@@ -62,7 +61,7 @@ class Config:
     def from_dict(cls, data: Mapping[str, Any]) -> Self:
         """Parse a direct recipe or reconstruct a typed dataclass config."""
         if cls is Config:
-            from ._normalize import normalize_config  # ruff: ignore[import-outside-top-level]
+            from ._normalize import normalize_config
 
             validated = normalize_config(data)
             return cls(validated["class_path"], validated["init_args"])
@@ -76,7 +75,7 @@ class Config:
         if type(self) is not Config:
             msg = "instantiate() is only available on a direct Config recipe"
             raise TypeError(msg)
-        from ._instantiate import instantiate  # ruff: ignore[import-outside-top-level]
+        from ._instantiate import instantiate
 
         return instantiate(self)
 
@@ -93,7 +92,7 @@ class Config:
         self,
         path: str | Path,
         *,
-        format: Literal["jsonargparse", "dict"] = "jsonargparse",  # ruff: ignore[builtin-argument-shadowing]
+        format: Literal["jsonargparse", "dict"] = "jsonargparse",
     ) -> None:
         """Save this config to YAML."""
         target = Path(path)

--- a/src/physicalai/config/base.py
+++ b/src/physicalai/config/base.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Literal, Self
 
 import yaml
 
@@ -23,11 +23,15 @@ class Config:
     __hash__ = None
 
     def __init__(self, class_path: str, init_args: Mapping[str, object] | None = None) -> None:
-        """Create a direct construction recipe."""
+        """Create a direct construction recipe.
+
+        Raises:
+            TypeError: If called on a dataclass ``Config`` subclass.
+        """
         if type(self) is not Config:
             msg = "Config subclasses must be dataclasses"
             raise TypeError(msg)
-        from ._normalize import normalize_config
+        from ._normalize import normalize_config  # ruff: ignore[PLC0415]
 
         validated = normalize_config({"class_path": class_path, "init_args": dict(init_args or {})})
         self.class_path = validated["class_path"]
@@ -35,17 +39,31 @@ class Config:
 
     @classmethod
     def from_instance(cls, instance: object) -> Config:
-        """Capture an ``@export_config`` instance as a construction recipe."""
+        """Capture an ``@export_config`` instance as a construction recipe.
+
+        Returns:
+            A direct :class:`Config` recipe.
+
+        Raises:
+            TypeError: If called on a dataclass ``Config`` subclass.
+        """
         if cls is not Config:
             msg = "from_instance() constructs the direct Config recipe type"
             raise TypeError(msg)
-        from ._export import _export_instance
+        from ._export import _export_instance  # ruff: ignore[PLC0415]
 
         recipe = _export_instance(instance)
         return cls(recipe["class_path"], recipe["init_args"])
 
-    def to_dict(self) -> dict[str, Any]:
-        """Convert this config to its plain serialization form."""
+    def to_dict(self) -> dict[str, object]:
+        """Convert this config to its plain serialization form.
+
+        Returns:
+            A mapping safe for checkpoints and YAML export.
+
+        Raises:
+            TypeError: If this instance is not a dataclass subclass or direct recipe.
+        """
         if dataclasses.is_dataclass(self):
             result = dataclass_to_dict(self)
             if not isinstance(result, dict):
@@ -58,10 +76,17 @@ class Config:
         return {"class_path": self.class_path, "init_args": dataclass_to_dict(self.init_args)}
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> Self:
-        """Parse a direct recipe or reconstruct a typed dataclass config."""
+    def from_dict(cls, data: Mapping[str, object]) -> Self:
+        """Parse a direct recipe or reconstruct a typed dataclass config.
+
+        Returns:
+            A :class:`Config` recipe or dataclass instance.
+
+        Raises:
+            TypeError: If ``cls`` is not a dataclass when reconstructing nested fields.
+        """
         if cls is Config:
-            from ._normalize import normalize_config
+            from ._normalize import normalize_config  # ruff: ignore[PLC0415]
 
             validated = normalize_config(data)
             return cls(validated["class_path"], validated["init_args"])
@@ -71,16 +96,27 @@ class Config:
         return dict_to_dataclass(cls, data)
 
     def instantiate(self) -> object:
-        """Instantiate this direct construction recipe through the strict core."""
+        """Instantiate this direct construction recipe through the strict core.
+
+        Returns:
+            The constructed object.
+
+        Raises:
+            TypeError: If called on a dataclass ``Config`` subclass.
+        """
         if type(self) is not Config:
             msg = "instantiate() is only available on a direct Config recipe"
             raise TypeError(msg)
-        from ._instantiate import instantiate
+        from ._instantiate import instantiate  # ruff: ignore[PLC0415]
 
         return instantiate(self)
 
-    def to_jsonargparse(self) -> dict[str, Any]:
-        """Convert this config to a ``class_path``/``init_args`` envelope."""
+    def to_jsonargparse(self) -> dict[str, object]:
+        """Convert this config to a ``class_path``/``init_args`` envelope.
+
+        Returns:
+            A jsonargparse-compatible mapping.
+        """
         if type(self) is Config:
             return self.to_dict()
         return {
@@ -92,9 +128,13 @@ class Config:
         self,
         path: str | Path,
         *,
-        format: Literal["jsonargparse", "dict"] = "jsonargparse",
+        format: Literal["jsonargparse", "dict"] = "jsonargparse",  # ruff: ignore[A002]
     ) -> None:
-        """Save this config to YAML."""
+        """Save this config to YAML.
+
+        Raises:
+            ValueError: If the path extension is not ``.yaml`` or ``.yml``.
+        """
         target = Path(path)
         if target.suffix not in {".yaml", ".yml"}:
             msg = f"Unsupported file extension: {target.suffix}. Use .yaml or .yml"
@@ -104,7 +144,15 @@ class Config:
 
     @classmethod
     def load(cls, path: str | Path) -> Self:
-        """Load a direct recipe or typed config from YAML."""
+        """Load a direct recipe or typed config from YAML.
+
+        Returns:
+            A reconstructed config instance.
+
+        Raises:
+            ValueError: If the path extension is not ``.yaml`` or ``.yml``.
+            TypeError: If the YAML root or ``init_args`` is not a mapping.
+        """
         source = Path(path)
         if source.suffix not in {".yaml", ".yml"}:
             msg = f"Unsupported file extension: {source.suffix}. Use .yaml or .yml"
@@ -124,16 +172,28 @@ class Config:
                 raise TypeError(msg)
         return cls.from_dict(data)
 
-    def __getitem__(self, key: str) -> Any:
-        """Expose direct recipe keys for gradual internal migration."""
+    def __getitem__(self, key: str) -> object:
+        """Expose direct recipe keys for gradual internal migration.
+
+        Returns:
+            The value for ``key`` in :meth:`to_dict`.
+        """
         return self.to_dict()[key]
 
-    def get(self, key: str, default: Any = None) -> Any:
-        """Return a direct recipe value, or *default* when absent."""
+    def get(self, key: str, default: object | None = None) -> object | None:
+        """Return a direct recipe value, or *default* when absent.
+
+        Returns:
+            The value for ``key``, or *default* if missing.
+        """
         return self.to_dict().get(key, default)
 
     def __eq__(self, other: object) -> bool:
-        """Compare configs by their plain serialization form."""
+        """Compare configs by their plain serialization form.
+
+        Returns:
+            ``NotImplemented`` for unsupported comparison types, otherwise equality.
+        """
         if isinstance(other, Config):
             return self.to_dict() == other.to_dict()
         if isinstance(other, Mapping):

--- a/src/physicalai/config/base.py
+++ b/src/physicalai/config/base.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Literal, Self
+from typing import TYPE_CHECKING, Literal, Self, cast, overload
 
 import yaml
 
 from .serializable import dataclass_to_dict, dict_to_dataclass
+
+if TYPE_CHECKING:
+    from ._types import JsonArgparseEnvelope, JsonValue
 
 __all__ = ["Config"]
 
@@ -34,8 +37,8 @@ class Config:
         from ._normalize import normalize_config  # ruff: ignore[PLC0415]
 
         validated = normalize_config({"class_path": class_path, "init_args": dict(init_args or {})})
-        self.class_path = validated["class_path"]
-        self.init_args = validated["init_args"]
+        self.class_path: str = validated["class_path"]
+        self.init_args: dict[str, JsonValue] = validated["init_args"]
 
     @classmethod
     def from_instance(cls, instance: object) -> Config:
@@ -111,17 +114,20 @@ class Config:
 
         return instantiate(self)
 
-    def to_jsonargparse(self) -> dict[str, object]:
+    def to_jsonargparse(self) -> JsonArgparseEnvelope:
         """Convert this config to a ``class_path``/``init_args`` envelope.
 
         Returns:
             A jsonargparse-compatible mapping.
         """
         if type(self) is Config:
-            return self.to_dict()
+            return {
+                "class_path": self.class_path,
+                "init_args": self.init_args,
+            }
         return {
             "class_path": f"{type(self).__module__}.{type(self).__qualname__}",
-            "init_args": self.to_dict(),
+            "init_args": cast("dict[str, JsonValue]", dataclass_to_dict(self)),
         }
 
     def save(
@@ -172,13 +178,22 @@ class Config:
                 raise TypeError(msg)
         return cls.from_dict(data)
 
-    def __getitem__(self, key: str) -> object:
+    @overload
+    def __getitem__(self, key: Literal["class_path"]) -> str: ...
+
+    @overload
+    def __getitem__(self, key: Literal["init_args"]) -> dict[str, JsonValue]: ...
+
+    @overload
+    def __getitem__(self, key: str) -> JsonValue: ...
+
+    def __getitem__(self, key: str) -> JsonValue:
         """Expose direct recipe keys for gradual internal migration.
 
         Returns:
             The value for ``key`` in :meth:`to_dict`.
         """
-        return self.to_dict()[key]
+        return cast("JsonValue", self.to_dict()[key])
 
     def get(self, key: str, default: object | None = None) -> object | None:
         """Return a direct recipe value, or *default* when absent.

--- a/src/physicalai/config/base.py
+++ b/src/physicalai/config/base.py
@@ -79,8 +79,12 @@ class Config:
         return {"class_path": self.class_path, "init_args": dataclass_to_dict(self.init_args)}
 
     @classmethod
-    def from_dict(cls, data: Mapping[str, object]) -> Self:
+    def from_dict(cls, data: Mapping[str, object], *, strict: bool = True) -> Self:
         """Parse a direct recipe or reconstruct a typed dataclass config.
+
+        Args:
+            data: Recipe envelope or dataclass field mapping.
+            strict: When reconstructing a typed dataclass, reject unknown keys.
 
         Returns:
             A :class:`Config` recipe or dataclass instance.
@@ -96,7 +100,7 @@ class Config:
         if not dataclasses.is_dataclass(cls):
             msg = f"{cls.__name__} must be a dataclass to use Config"
             raise TypeError(msg)
-        return dict_to_dataclass(cls, data)
+        return dict_to_dataclass(cls, data, strict=strict)
 
     def instantiate(self) -> object:
         """Instantiate this direct construction recipe through the strict core.

--- a/src/physicalai/config/importing.py
+++ b/src/physicalai/config/importing.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-"""Dotted-path imports for trusted component configuration."""
+"""Dotted-path imports for trusted configuration."""
 
 from __future__ import annotations
 

--- a/src/physicalai/config/importing.py
+++ b/src/physicalai/config/importing.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import importlib
 
+__all__ = ["import_dotted_path"]
+
 
 def import_dotted_path(path: str) -> object:
     """Resolve a fully-qualified path, including nested attributes.

--- a/src/physicalai/config/instantiate.py
+++ b/src/physicalai/config/instantiate.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception, type-check-without-type-error]
 
 """General configuration instantiation helpers."""
 
@@ -43,7 +42,7 @@ def import_class(class_path: str) -> type:
     return value
 
 
-def _instantiate_recursive(value: Any) -> Any:  # ruff: ignore[any-type]
+def _instantiate_recursive(value: Any) -> Any:
     if isinstance(value, dict):
         if "class_path" in value:
             return Config.from_dict(value).instantiate()

--- a/src/physicalai/config/instantiate.py
+++ b/src/physicalai/config/instantiate.py
@@ -1,0 +1,147 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception, type-check-without-type-error]
+
+"""General configuration instantiation helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel
+
+from ._instantiate import instantiate
+from .base import Config
+from .importing import import_dotted_path
+
+ConfigMapping = Mapping[str, Any]
+
+__all__ = [
+    "import_class",
+    "instantiate_obj",
+    "instantiate_obj_from_dataclass",
+    "instantiate_obj_from_dict",
+    "instantiate_obj_from_file",
+    "instantiate_obj_from_pydantic",
+]
+
+
+def import_class(class_path: str) -> type:
+    """Import and validate a class from a dotted path."""
+    try:
+        value = import_dotted_path(class_path)
+    except (ValueError, ImportError, AttributeError) as exc:
+        msg = f"Cannot import {class_path!r}: {exc}"
+        raise ImportError(msg) from exc
+    if not isinstance(value, type):
+        msg = f"{class_path!r} does not resolve to a class"
+        raise ImportError(msg)
+    return value
+
+
+def _instantiate_recursive(value: Any) -> Any:  # ruff: ignore[any-type]
+    if isinstance(value, dict):
+        if "class_path" in value:
+            return Config.from_dict(value).instantiate()
+        return {key: _instantiate_recursive(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_instantiate_recursive(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_instantiate_recursive(item) for item in value)
+    return value
+
+
+def instantiate_obj_from_dict(
+    config: ConfigMapping,
+    *,
+    key: str | None = None,
+    target_cls: type | None = None,
+) -> object:
+    """Instantiate an object from a configuration mapping."""
+    selected: object = config
+    if key is not None:
+        if key not in config:
+            msg = f"Configuration must contain {key!r} key. Got keys: {list(config.keys())}"
+            raise ValueError(msg)
+        selected = config[key]
+        if not isinstance(selected, Mapping):
+            msg = f"Configuration at key {key!r} must be a mapping, got {type(selected).__name__}"
+            raise TypeError(msg)
+    if not isinstance(selected, Mapping):
+        msg = f"Configuration must be a mapping, got {type(selected).__name__}"
+        raise TypeError(msg)
+    if "class_path" in selected:
+        return instantiate(Config.from_dict(selected))
+    if target_cls is None:
+        msg = (
+            "Configuration must contain 'class_path' for instantiation, "
+            f"or pass target_cls explicitly. Got keys: {list(selected.keys())}"
+        )
+        raise ValueError(msg)
+    init_args = {name: _instantiate_recursive(value) for name, value in selected.items()}
+    args = init_args.pop("args", ())
+    return target_cls(*args, **init_args)
+
+
+def instantiate_obj_from_pydantic(
+    config: BaseModel,
+    *,
+    key: str | None = None,
+    target_cls: type | None = None,
+) -> object:
+    """Instantiate from a Pydantic model."""
+    return instantiate_obj_from_dict(config.model_dump(), key=key, target_cls=target_cls)
+
+
+def instantiate_obj_from_dataclass(
+    config: object,
+    *,
+    key: str | None = None,
+    target_cls: type | None = None,
+) -> object:
+    """Instantiate from a dataclass instance."""
+    if not dataclasses.is_dataclass(config) or isinstance(config, type):
+        msg = f"Expected dataclass instance, got {type(config)}"
+        raise TypeError(msg)
+    return instantiate_obj_from_dict(dataclasses.asdict(config), key=key, target_cls=target_cls)
+
+
+def instantiate_obj_from_file(
+    file_path: str | Path,
+    *,
+    key: str | None = None,
+    target_cls: type | None = None,
+) -> object:
+    """Instantiate from a YAML or JSON file."""
+    config = yaml.safe_load(Path(file_path).read_text(encoding="utf-8"))
+    if config is None:
+        config = {}
+    if not isinstance(config, Mapping):
+        msg = f"Expected YAML root to be a mapping, got {type(config).__name__}"
+        raise TypeError(msg)
+    return instantiate_obj_from_dict(config, key=key, target_cls=target_cls)
+
+
+def instantiate_obj(
+    config: ConfigMapping | Config | BaseModel | object | str | Path,
+    *,
+    key: str | None = None,
+    target_cls: type | None = None,
+) -> object:
+    """Instantiate from a recipe, mapping, model, dataclass, or file."""
+    if type(config) is Config:
+        return config.instantiate()
+    if isinstance(config, (str, Path)):
+        return instantiate_obj_from_file(config, key=key, target_cls=target_cls)
+    if isinstance(config, BaseModel):
+        return instantiate_obj_from_pydantic(config, key=key, target_cls=target_cls)
+    if dataclasses.is_dataclass(config) and not isinstance(config, type):
+        return instantiate_obj_from_dataclass(config, key=key, target_cls=target_cls)
+    if isinstance(config, Mapping):
+        return instantiate_obj_from_dict(config, key=key, target_cls=target_cls)
+    msg = f"Unsupported configuration type: {type(config)}. Expected dict, file path, Pydantic model, or dataclass."
+    raise TypeError(msg)

--- a/src/physicalai/config/instantiate.py
+++ b/src/physicalai/config/instantiate.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import dataclasses
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
 
 import yaml
 from pydantic import BaseModel
@@ -17,7 +16,7 @@ from ._instantiate import instantiate
 from .base import Config
 from .importing import import_dotted_path
 
-ConfigMapping = Mapping[str, Any]
+ConfigMapping = Mapping[str, object]
 
 __all__ = [
     "import_class",
@@ -30,7 +29,15 @@ __all__ = [
 
 
 def import_class(class_path: str) -> type:
-    """Import and validate a class from a dotted path."""
+    """Import and validate a class from a dotted path.
+
+    Returns:
+        The imported class.
+
+    Raises:
+        ImportError: If the module or attribute cannot be imported.
+        TypeError: If the path resolves to a non-class object.
+    """
     try:
         value = import_dotted_path(class_path)
     except (ValueError, ImportError, AttributeError) as exc:
@@ -38,11 +45,11 @@ def import_class(class_path: str) -> type:
         raise ImportError(msg) from exc
     if not isinstance(value, type):
         msg = f"{class_path!r} does not resolve to a class"
-        raise ImportError(msg)
+        raise TypeError(msg)
     return value
 
 
-def _instantiate_recursive(value: Any) -> Any:
+def _instantiate_recursive(value: object) -> object:
     if isinstance(value, dict):
         if "class_path" in value:
             return Config.from_dict(value).instantiate()
@@ -60,7 +67,15 @@ def instantiate_obj_from_dict(
     key: str | None = None,
     target_cls: type | None = None,
 ) -> object:
-    """Instantiate an object from a configuration mapping."""
+    """Instantiate an object from a configuration mapping.
+
+    Returns:
+        The constructed object.
+
+    Raises:
+        ValueError: If ``key`` is missing or no ``class_path``/``target_cls`` is available.
+        TypeError: If a selected sub-config is not a mapping.
+    """
     selected: object = config
     if key is not None:
         if key not in config:
@@ -92,7 +107,11 @@ def instantiate_obj_from_pydantic(
     key: str | None = None,
     target_cls: type | None = None,
 ) -> object:
-    """Instantiate from a Pydantic model."""
+    """Instantiate from a Pydantic model.
+
+    Returns:
+        The constructed object.
+    """
     return instantiate_obj_from_dict(config.model_dump(), key=key, target_cls=target_cls)
 
 
@@ -102,7 +121,14 @@ def instantiate_obj_from_dataclass(
     key: str | None = None,
     target_cls: type | None = None,
 ) -> object:
-    """Instantiate from a dataclass instance."""
+    """Instantiate from a dataclass instance.
+
+    Returns:
+        The constructed object.
+
+    Raises:
+        TypeError: If ``config`` is not a dataclass instance.
+    """
     if not dataclasses.is_dataclass(config) or isinstance(config, type):
         msg = f"Expected dataclass instance, got {type(config)}"
         raise TypeError(msg)
@@ -115,7 +141,14 @@ def instantiate_obj_from_file(
     key: str | None = None,
     target_cls: type | None = None,
 ) -> object:
-    """Instantiate from a YAML or JSON file."""
+    """Instantiate from a YAML or JSON file.
+
+    Returns:
+        The constructed object.
+
+    Raises:
+        TypeError: If the file root is not a mapping.
+    """
     config = yaml.safe_load(Path(file_path).read_text(encoding="utf-8"))
     if config is None:
         config = {}
@@ -131,7 +164,14 @@ def instantiate_obj(
     key: str | None = None,
     target_cls: type | None = None,
 ) -> object:
-    """Instantiate from a recipe, mapping, model, dataclass, or file."""
+    """Instantiate from a recipe, mapping, model, dataclass, or file.
+
+    Returns:
+        The constructed object.
+
+    Raises:
+        TypeError: If ``config`` has an unsupported type.
+    """
     if type(config) is Config:
         return config.instantiate()
     if isinstance(config, (str, Path)):

--- a/src/physicalai/config/loading.py
+++ b/src/physicalai/config/loading.py
@@ -12,7 +12,9 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel
 
+from ._errors import ConfigError
 from ._instantiate import instantiate
+from ._types import _MAX_CONFIG_DEPTH
 from .base import Config
 from .importing import import_dotted_path
 
@@ -49,15 +51,18 @@ def import_class(class_path: str) -> type:
     return value
 
 
-def _instantiate_recursive(value: object) -> object:
+def _instantiate_recursive(value: object, *, depth: int = 0) -> object:
+    if depth > _MAX_CONFIG_DEPTH:
+        msg = f"Configuration nesting depth exceeds {_MAX_CONFIG_DEPTH}"
+        raise ConfigError(msg)
     if isinstance(value, dict):
         if "class_path" in value:
             return Config.from_dict(value).instantiate()
-        return {key: _instantiate_recursive(item) for key, item in value.items()}
+        return {key: _instantiate_recursive(item, depth=depth + 1) for key, item in value.items()}
     if isinstance(value, list):
-        return [_instantiate_recursive(item) for item in value]
+        return [_instantiate_recursive(item, depth=depth + 1) for item in value]
     if isinstance(value, tuple):
-        return tuple(_instantiate_recursive(item) for item in value)
+        return tuple(_instantiate_recursive(item, depth=depth + 1) for item in value)
     return value
 
 
@@ -68,6 +73,11 @@ def instantiate_obj_from_dict(
     target_cls: type | None = None,
 ) -> object:
     """Instantiate an object from a configuration mapping.
+
+    When ``target_cls`` is set and the selected mapping has no ``class_path``,
+    entries are passed as keyword arguments after recursive instantiation.
+    The reserved key ``args`` supplies positional constructor arguments (a
+    sequence); it is removed from ``init_args`` before ``target_cls`` is called.
 
     Returns:
         The constructed object.

--- a/src/physicalai/config/mixin.py
+++ b/src/physicalai/config/mixin.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception]
 
 """Mixins for configuration-based construction."""
 

--- a/src/physicalai/config/mixin.py
+++ b/src/physicalai/config/mixin.py
@@ -25,17 +25,29 @@ class FromConfig:
 
     @classmethod
     def from_yaml(cls, file_path: str | Path, *, key: str | None = None) -> Self:
-        """Load configuration from YAML and instantiate the class."""
+        """Load configuration from YAML and instantiate the class.
+
+        Returns:
+            An instance of ``cls``.
+        """
         return cast("Self", instantiate_obj_from_file(file_path, key=key, target_cls=cls))
 
     @classmethod
     def from_dict(cls, config: Mapping[str, Any], *, key: str | None = None) -> Self:
-        """Instantiate the class from a mapping."""
+        """Instantiate the class from a mapping.
+
+        Returns:
+            An instance of ``cls``.
+        """
         return cast("Self", instantiate_obj_from_dict(config, key=key, target_cls=cls))
 
     @classmethod
     def from_pydantic(cls, config: BaseModel, *, key: str | None = None, recursive: bool = False) -> Self:
-        """Instantiate the class from a Pydantic model."""
+        """Instantiate the class from a Pydantic model.
+
+        Returns:
+            An instance of ``cls``.
+        """
         values = (
             config.model_dump()
             if recursive
@@ -45,7 +57,14 @@ class FromConfig:
 
     @classmethod
     def from_dataclass(cls, config: object, *, key: str | None = None, recursive: bool = False) -> Self:
-        """Instantiate the class from a dataclass instance."""
+        """Instantiate the class from a dataclass instance.
+
+        Returns:
+            An instance of ``cls``.
+
+        Raises:
+            TypeError: If ``config`` is not a dataclass instance.
+        """
         if not dataclasses.is_dataclass(config) or isinstance(config, type):
             msg = f"Expected dataclass instance, got {type(config)}"
             raise TypeError(msg)
@@ -60,7 +79,14 @@ class FromConfig:
         key: str | None = None,
         recursive: bool = False,
     ) -> Self:
-        """Dispatch to the matching configuration constructor."""
+        """Dispatch to the matching configuration constructor.
+
+        Returns:
+            An instance of ``cls``.
+
+        Raises:
+            TypeError: If ``config`` has an unsupported type.
+        """
         if isinstance(config, (str, Path)):
             return cls.from_yaml(config, key=key)
         if isinstance(config, BaseModel):
@@ -74,7 +100,11 @@ class FromConfig:
 
 
 def from_config(cls: _T) -> _T:
-    """Decorate a class with the constructors provided by :class:`FromConfig`."""
+    """Decorate a class with the constructors provided by :class:`FromConfig`.
+
+    Returns:
+        The same class with ``from_*`` constructors attached.
+    """
     for name in ("from_yaml", "from_dict", "from_pydantic", "from_dataclass", "from_config"):
         setattr(cls, name, FromConfig.__dict__[name])
     return cls

--- a/src/physicalai/config/mixin.py
+++ b/src/physicalai/config/mixin.py
@@ -12,7 +12,7 @@ from typing import Any, Self, TypeVar, cast
 
 from pydantic import BaseModel
 
-from .instantiate import instantiate_obj_from_dict, instantiate_obj_from_file
+from .loading import instantiate_obj_from_dict, instantiate_obj_from_file
 from .serializable import dataclass_to_dict
 
 __all__ = ["FromConfig", "from_config"]

--- a/src/physicalai/config/mixin.py
+++ b/src/physicalai/config/mixin.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception]
+
+"""Mixins for configuration-based construction."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Self, TypeVar, cast
+
+from pydantic import BaseModel
+
+from .instantiate import instantiate_obj_from_dict, instantiate_obj_from_file
+from .serializable import dataclass_to_dict
+
+__all__ = ["FromConfig", "from_config"]
+
+_T = TypeVar("_T", bound=type)
+
+
+class FromConfig:
+    """Mixin adding constructors for mapping, YAML, Pydantic, and dataclass configs."""
+
+    @classmethod
+    def from_yaml(cls, file_path: str | Path, *, key: str | None = None) -> Self:
+        """Load configuration from YAML and instantiate the class."""
+        return cast("Self", instantiate_obj_from_file(file_path, key=key, target_cls=cls))
+
+    @classmethod
+    def from_dict(cls, config: Mapping[str, Any], *, key: str | None = None) -> Self:
+        """Instantiate the class from a mapping."""
+        return cast("Self", instantiate_obj_from_dict(config, key=key, target_cls=cls))
+
+    @classmethod
+    def from_pydantic(cls, config: BaseModel, *, key: str | None = None, recursive: bool = False) -> Self:
+        """Instantiate the class from a Pydantic model."""
+        values = (
+            config.model_dump()
+            if recursive
+            else {name: getattr(config, name) for name in config.__class__.model_fields}
+        )
+        return cls.from_dict(values, key=key)
+
+    @classmethod
+    def from_dataclass(cls, config: object, *, key: str | None = None, recursive: bool = False) -> Self:
+        """Instantiate the class from a dataclass instance."""
+        if not dataclasses.is_dataclass(config) or isinstance(config, type):
+            msg = f"Expected dataclass instance, got {type(config)}"
+            raise TypeError(msg)
+        values = cast("dict[str, Any]", dataclass_to_dict(config, recursive=recursive))
+        return cls.from_dict(values, key=key)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Mapping[str, Any] | BaseModel | object | str | Path,
+        *,
+        key: str | None = None,
+        recursive: bool = False,
+    ) -> Self:
+        """Dispatch to the matching configuration constructor."""
+        if isinstance(config, (str, Path)):
+            return cls.from_yaml(config, key=key)
+        if isinstance(config, BaseModel):
+            return cls.from_pydantic(config, key=key, recursive=recursive)
+        if dataclasses.is_dataclass(config) and not isinstance(config, type):
+            return cls.from_dataclass(config, key=key, recursive=recursive)
+        if isinstance(config, Mapping):
+            return cls.from_dict(config, key=key)
+        msg = f"Unsupported configuration type: {type(config)}. Expected dict, file path, Pydantic model, or dataclass."
+        raise TypeError(msg)
+
+
+def from_config(cls: _T) -> _T:
+    """Decorate a class with the constructors provided by :class:`FromConfig`."""
+    for name in ("from_yaml", "from_dict", "from_pydantic", "from_dataclass", "from_config"):
+        setattr(cls, name, FromConfig.__dict__[name])
+    return cls

--- a/src/physicalai/config/serializable.py
+++ b/src/physicalai/config/serializable.py
@@ -11,6 +11,7 @@ import types
 from enum import Enum
 from functools import reduce
 from itertools import starmap
+from pathlib import PurePath
 from typing import TYPE_CHECKING, TypeVar, Union, get_args, get_origin, get_type_hints
 
 if TYPE_CHECKING:
@@ -41,23 +42,36 @@ def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:  # ruff
         return [dataclass_to_dict(item) for item in obj]
     if isinstance(obj, Enum):
         return obj.value
+    if isinstance(obj, PurePath):
+        return str(obj)
     if hasattr(obj, "tolist") and hasattr(obj, "ndim"):
         return obj.tolist()  # type: ignore[union-attr]
     return obj
 
 
-def dict_to_dataclass(cls: type[_T], data: Mapping[str, object]) -> _T:
+def dict_to_dataclass(cls: type[_T], data: Mapping[str, object], *, strict: bool = True) -> _T:
     """Reconstruct a dataclass from a mapping using its type hints.
+
+    Args:
+        cls: Dataclass type to construct.
+        data: Field values (typically from YAML or a checkpoint).
+        strict: When ``True``, reject keys that are not dataclass fields.
 
     Returns:
         An instance of ``cls``.
 
     Raises:
-        TypeError: If ``cls`` is not a dataclass.
+        TypeError: If ``cls`` is not a dataclass or ``strict`` rejects extra keys.
     """
     if not dataclasses.is_dataclass(cls):
         msg = f"Expected dataclass, got {cls}"
         raise TypeError(msg)
+    if strict:
+        field_names = {field.name for field in dataclasses.fields(cls)}
+        extras = set(data.keys()) - field_names
+        if extras:
+            msg = f"Unexpected keys for {cls.__name__}: {sorted(extras)}"
+            raise TypeError(msg)
     try:
         hints = get_type_hints(cls)
     except (NameError, TypeError, AttributeError, KeyError):
@@ -91,6 +105,8 @@ def _reconstruct_value(value: object, field_type: object) -> object:  # ruff: ig
     actual_type = origin or field_type
     if isinstance(actual_type, type) and dataclasses.is_dataclass(actual_type) and isinstance(value, dict):
         return dict_to_dataclass(actual_type, value)
+    if isinstance(actual_type, type) and issubclass(actual_type, PurePath) and isinstance(value, str):
+        return actual_type(value)
     if isinstance(actual_type, type) and issubclass(actual_type, Enum) and not isinstance(value, Enum):
         return actual_type(value)
     return value

--- a/src/physicalai/config/serializable.py
+++ b/src/physicalai/config/serializable.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception]
 
 """Serialization utilities for typed dataclass configs."""
 
@@ -24,7 +23,7 @@ _T = TypeVar("_T")
 __all__ = ["dataclass_to_dict", "dict_to_dataclass"]
 
 
-def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:  # ruff: ignore[too-many-return-statements]
+def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:
     """Convert a dataclass or nested structure to plain Python data."""
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
         if not recursive:
@@ -50,7 +49,7 @@ def dict_to_dataclass(cls: type[_T], data: Mapping[str, object]) -> _T:
         raise TypeError(msg)
     try:
         hints = get_type_hints(cls)
-    except Exception:  # ruff: ignore[blind-except]
+    except Exception:
         hints = {}
     kwargs = {}
     for field in dataclasses.fields(cls):
@@ -59,7 +58,7 @@ def dict_to_dataclass(cls: type[_T], data: Mapping[str, object]) -> _T:
     return cls(**kwargs)  # type: ignore[return-value]
 
 
-def _reconstruct_value(value: object, field_type: object) -> object:  # ruff: ignore[too-many-return-statements]
+def _reconstruct_value(value: object, field_type: object) -> object:
     if value is None:
         return None
     origin = get_origin(field_type)

--- a/src/physicalai/config/serializable.py
+++ b/src/physicalai/config/serializable.py
@@ -23,8 +23,12 @@ _T = TypeVar("_T")
 __all__ = ["dataclass_to_dict", "dict_to_dataclass"]
 
 
-def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:
-    """Convert a dataclass or nested structure to plain Python data."""
+def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:  # ruff: ignore[PLR0911]
+    """Convert a dataclass or nested structure to plain Python data.
+
+    Returns:
+        Plain dicts, lists, and scalars suitable for ``torch.save(weights_only=True)``.
+    """
     if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
         if not recursive:
             return {field.name: getattr(obj, field.name) for field in dataclasses.fields(obj)}
@@ -43,13 +47,20 @@ def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:
 
 
 def dict_to_dataclass(cls: type[_T], data: Mapping[str, object]) -> _T:
-    """Reconstruct a dataclass from a mapping using its type hints."""
+    """Reconstruct a dataclass from a mapping using its type hints.
+
+    Returns:
+        An instance of ``cls``.
+
+    Raises:
+        TypeError: If ``cls`` is not a dataclass.
+    """
     if not dataclasses.is_dataclass(cls):
         msg = f"Expected dataclass, got {cls}"
         raise TypeError(msg)
     try:
         hints = get_type_hints(cls)
-    except Exception:
+    except (NameError, TypeError, AttributeError, KeyError):
         hints = {}
     kwargs = {}
     for field in dataclasses.fields(cls):
@@ -58,7 +69,7 @@ def dict_to_dataclass(cls: type[_T], data: Mapping[str, object]) -> _T:
     return cls(**kwargs)  # type: ignore[return-value]
 
 
-def _reconstruct_value(value: object, field_type: object) -> object:
+def _reconstruct_value(value: object, field_type: object) -> object:  # ruff: ignore[PLR0911]
     if value is None:
         return None
     origin = get_origin(field_type)

--- a/src/physicalai/config/serializable.py
+++ b/src/physicalai/config/serializable.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# ruff: file-ignore[docstring-missing-returns, docstring-missing-exception]
+
+"""Serialization utilities for typed dataclass configs."""
+
+from __future__ import annotations
+
+import dataclasses
+import operator
+import types
+from enum import Enum
+from functools import reduce
+from itertools import starmap
+from typing import TYPE_CHECKING, TypeVar, Union, get_args, get_origin, get_type_hints
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_MIN_DICT_TYPE_ARGS = 2
+_VAR_TUPLE_ARG_COUNT = 2
+_T = TypeVar("_T")
+
+__all__ = ["dataclass_to_dict", "dict_to_dataclass"]
+
+
+def dataclass_to_dict(obj: object, *, recursive: bool = True) -> object:  # ruff: ignore[too-many-return-statements]
+    """Convert a dataclass or nested structure to plain Python data."""
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        if not recursive:
+            return {field.name: getattr(obj, field.name) for field in dataclasses.fields(obj)}
+        return {field.name: dataclass_to_dict(getattr(obj, field.name)) for field in dataclasses.fields(obj)}
+    if not recursive:
+        return obj
+    if isinstance(obj, dict):
+        return {(key.value if isinstance(key, Enum) else key): dataclass_to_dict(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [dataclass_to_dict(item) for item in obj]
+    if isinstance(obj, Enum):
+        return obj.value
+    if hasattr(obj, "tolist") and hasattr(obj, "ndim"):
+        return obj.tolist()  # type: ignore[union-attr]
+    return obj
+
+
+def dict_to_dataclass(cls: type[_T], data: Mapping[str, object]) -> _T:
+    """Reconstruct a dataclass from a mapping using its type hints."""
+    if not dataclasses.is_dataclass(cls):
+        msg = f"Expected dataclass, got {cls}"
+        raise TypeError(msg)
+    try:
+        hints = get_type_hints(cls)
+    except Exception:  # ruff: ignore[blind-except]
+        hints = {}
+    kwargs = {}
+    for field in dataclasses.fields(cls):
+        if field.name in data:
+            kwargs[field.name] = _reconstruct_value(data[field.name], hints.get(field.name, field.type))
+    return cls(**kwargs)  # type: ignore[return-value]
+
+
+def _reconstruct_value(value: object, field_type: object) -> object:  # ruff: ignore[too-many-return-statements]
+    if value is None:
+        return None
+    origin = get_origin(field_type)
+    args = get_args(field_type)
+    if _is_optional_type(field_type):
+        return _reconstruct_value(value, _get_optional_inner_type(field_type))
+    if origin is dict and isinstance(value, dict):
+        if len(args) >= _MIN_DICT_TYPE_ARGS:
+            return {key: _reconstruct_value(item, args[1]) for key, item in value.items()}
+        return value
+    if origin is list and isinstance(value, list):
+        return [_reconstruct_value(item, args[0]) for item in value] if args else value
+    if origin is tuple and isinstance(value, list):
+        if not args:
+            return tuple(value)
+        if len(args) == _VAR_TUPLE_ARG_COUNT and args[1] is ...:
+            return tuple(_reconstruct_value(item, args[0]) for item in value)
+        return tuple(starmap(_reconstruct_value, zip(value, args, strict=False)))
+    actual_type = origin or field_type
+    if isinstance(actual_type, type) and dataclasses.is_dataclass(actual_type) and isinstance(value, dict):
+        return dict_to_dataclass(actual_type, value)
+    if isinstance(actual_type, type) and issubclass(actual_type, Enum) and not isinstance(value, Enum):
+        return actual_type(value)
+    return value
+
+
+def _is_optional_type(field_type: object) -> bool:
+    origin = get_origin(field_type)
+    return origin in {types.UnionType, Union} and type(None) in get_args(field_type)
+
+
+def _get_optional_inner_type(field_type: object) -> object:
+    non_none_args = [arg for arg in get_args(field_type) if arg is not type(None)]
+    if len(non_none_args) == 1:
+        return non_none_args[0]
+    return reduce(operator.or_, non_none_args)

--- a/src/physicalai/robot/transport/_owner_config.py
+++ b/src/physicalai/robot/transport/_owner_config.py
@@ -30,18 +30,18 @@ import.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from physicalai.config import (
     Config,
+    is_config_exportable,
     normalize_config,
     validate_envelope,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from physicalai.robot.interface import Robot
 
 DEFAULT_RATE_HZ = 100.0
@@ -93,6 +93,26 @@ def normalize_robot_config(robot: Config | Mapping[str, object]) -> Config:
         class_label="robot_class",
         json_hint=" (e.g. paths as str, not objects)",
     )
+
+
+def coerce_robot_config_input(robot: Config | Mapping[str, object] | object) -> Config | Mapping[str, object]:
+    """Accept a recipe, mapping, or live ``@export_config`` driver instance.
+
+    Returns:
+        A value suitable for :func:`normalize_robot_config`.
+
+    Raises:
+        TypeError: If ``robot`` is not a supported config shape.
+    """
+    if type(robot) is Config or isinstance(robot, Mapping):
+        return robot
+    if is_config_exportable(robot):
+        return Config.from_instance(robot)
+    msg = (
+        "robot config must be physicalai.config.Config, a class_path mapping, "
+        f"or an @export_config instance; got {type(robot).__name__}"
+    )
+    raise TypeError(msg)
 
 
 @dataclass(frozen=True)
@@ -200,10 +220,14 @@ class RobotOwnerConfig:
             raise TypeError(msg)
 
         robot = validate_owner_config(data)
+        allow_remote = data.get("allow_remote", False)
+        if not isinstance(allow_remote, bool):
+            msg = f"owner config 'allow_remote' must be a bool, got {type(allow_remote).__name__}"
+            raise TypeError(msg)
         return cls(
             name=data["name"],
             robot=robot,
-            allow_remote=data.get("allow_remote", False),
+            allow_remote=allow_remote,
             rate_hz=data.get("rate_hz", DEFAULT_RATE_HZ),
             idle_timeout=data.get("idle_timeout", 10.0),
         )

--- a/src/physicalai/robot/transport/_owner_config.py
+++ b/src/physicalai/robot/transport/_owner_config.py
@@ -10,11 +10,11 @@ subprocess stdin handshake.
 
 The owner must construct the robot driver itself: a live serial/socket
 handle cannot cross a process boundary (D15). Only a local
-:class:`~physicalai.config.ComponentConfig` (``class_path`` + ``init_args``)
+:class:`~physicalai.config.Config` (``class_path`` + ``init_args``)
 survives that boundary — arbitrary robot types, including third-party
 plugins, work without any registry lookup here.
 
-Private stdin is ``robot: ComponentConfig`` only. The owner envelope is
+Private stdin is ``robot: Config`` only. The owner envelope is
 validated schema-positively: required ``robot``, known transport keys, and
 rejection of unknown keys before import or hardware access. Public
 ``SharedRobot`` and ``physicalai robot serve`` use the same
@@ -34,9 +34,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from physicalai.config import (
-    ComponentConfig,
-    instantiate,
-    normalize_component_config,
+    Config,
+    normalize_config,
     validate_envelope,
 )
 
@@ -67,11 +66,11 @@ _OWNER_ENVELOPE_KEYS = frozenset({
 })
 
 
-def validate_owner_config(data: Mapping[str, Any]) -> Mapping[str, object]:
+def validate_owner_config(data: Mapping[str, Any]) -> Config:
     """Validate an owner stdin payload schema-positively.
 
     Returns:
-        The validated ``robot`` ComponentConfig mapping (see
+        The validated ``robot`` Config mapping (see
         :func:`normalize_robot_config` for the JSON-serializability check).
     """
     return validate_envelope(
@@ -82,13 +81,13 @@ def validate_owner_config(data: Mapping[str, Any]) -> Mapping[str, object]:
     )
 
 
-def normalize_robot_config(robot: Mapping[str, object]) -> ComponentConfig:
-    """Validate a robot ComponentConfig without importing its ``class_path``.
+def normalize_robot_config(robot: Config | Mapping[str, object]) -> Config:
+    """Validate a robot Config without importing its ``class_path``.
 
     Returns:
         A validated config whose ``class_path`` is a dotted import path.
     """
-    return normalize_component_config(
+    return normalize_config(
         robot,
         component_key="robot",
         class_label="robot_class",
@@ -119,17 +118,17 @@ class RobotOwnerConfig:
     """
 
     name: str
-    robot: Mapping[str, object]
+    robot: Config | Mapping[str, object]
     allow_remote: bool = False
     rate_hz: float = DEFAULT_RATE_HZ
     idle_timeout: float | None = 10.0
 
     def __post_init__(self) -> None:
-        """Validate transport fields and normalize ``robot`` to a public ComponentConfig.
+        """Validate transport fields and normalize ``robot`` to a public Config.
 
         Raises:
             ValueError: If ``rate_hz`` / ``idle_timeout`` are invalid, or
-                ``robot`` is not a JSON-serializable ComponentConfig.
+                ``robot`` is not a JSON-serializable Config.
         """
         if (
             isinstance(self.rate_hz, bool)
@@ -147,7 +146,7 @@ class RobotOwnerConfig:
         ):
             msg = f"idle_timeout must be finite and greater than zero, got {self.idle_timeout!r}"
             raise ValueError(msg)
-        from ._ids import validate_name  # noqa: PLC0415
+        from ._ids import validate_name
 
         validate_name(self.name)
         object.__setattr__(self, "robot", normalize_robot_config(self.robot))
@@ -163,19 +162,10 @@ class RobotOwnerConfig:
         Returns:
             Dictionary with every dataclass field (new ``robot:`` shape only).
 
-        Raises:
-            TypeError: If ``robot.init_args`` is not a mapping.
         """
-        init_args = self.robot["init_args"]
-        if not isinstance(init_args, dict):
-            msg = f"robot.init_args must be a mapping, got {type(init_args).__name__}"
-            raise TypeError(msg)
         return {
             "name": self.name,
-            "robot": {
-                "class_path": self.robot["class_path"],
-                "init_args": dict(init_args),
-            },
+            "robot": normalize_robot_config(self.robot).to_dict(),
             "allow_remote": self.allow_remote,
             "rate_hz": self.rate_hz,
             "idle_timeout": self.idle_timeout,
@@ -223,7 +213,7 @@ class RobotOwnerConfig:
 
         Owner stdin is a parent→child local handshake only — never pass
         network metadata to this path. Uses :func:`physicalai.config.instantiate`
-        on the ``robot`` ComponentConfig, then verifies the
+        on the ``robot`` Config, then verifies the
         :class:`~physicalai.robot.Robot` protocol.
 
         Returns:
@@ -232,9 +222,9 @@ class RobotOwnerConfig:
         Raises:
             TypeError: If the instantiated object does not satisfy ``Robot``.
         """
-        from physicalai.robot.interface import Robot  # noqa: PLC0415
+        from physicalai.robot.interface import Robot
 
-        driver = instantiate(self.robot)  # type: ignore[arg-type]
+        driver = normalize_robot_config(self.robot).instantiate()
         if not isinstance(driver, Robot):
             msg = f"{self.robot_class!r} does not satisfy the Robot protocol (got {type(driver).__name__})"
             raise TypeError(msg)

--- a/src/physicalai/robot/transport/_owner_config.py
+++ b/src/physicalai/robot/transport/_owner_config.py
@@ -146,7 +146,7 @@ class RobotOwnerConfig:
         ):
             msg = f"idle_timeout must be finite and greater than zero, got {self.idle_timeout!r}"
             raise ValueError(msg)
-        from ._ids import validate_name
+        from ._ids import validate_name  # noqa: PLC0415
 
         validate_name(self.name)
         object.__setattr__(self, "robot", normalize_robot_config(self.robot))
@@ -222,7 +222,7 @@ class RobotOwnerConfig:
         Raises:
             TypeError: If the instantiated object does not satisfy ``Robot``.
         """
-        from physicalai.robot.interface import Robot
+        from physicalai.robot.interface import Robot  # noqa: PLC0415
 
         driver = normalize_robot_config(self.robot).instantiate()
         if not isinstance(driver, Robot):

--- a/src/physicalai/robot/transport/_owner_worker.py
+++ b/src/physicalai/robot/transport/_owner_worker.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from physicalai.config import ComponentConfigError
+from physicalai.config import ConfigError
 from physicalai.robot.errors import RobotTransportError
 from physicalai.robot.interface import Robot
 from physicalai.robot.transport._codec import (  # noqa: PLC2701
@@ -185,7 +185,7 @@ def _build_metadata(
         "protocol_version": ROBOT_TRANSPORT_PROTOCOL_VERSION,
         "name": config.name,
         # Network key stays ``robot_class`` (protocol version unchanged); value is
-        # the normalized public ComponentConfig class_path.
+        # the normalized public Config class_path.
         "robot_class": config.robot["class_path"],
         "host": default_host(),
         "joint_names": joint_names,
@@ -562,7 +562,7 @@ def main() -> int:
     sys.stdin.close()
     try:
         config = RobotOwnerConfig.from_json_dict(json.loads(raw))
-    except (json.JSONDecodeError, ValueError, KeyError, TypeError, ComponentConfigError) as exc:
+    except (json.JSONDecodeError, ValueError, KeyError, TypeError, ConfigError) as exc:
         signal_error(f"invalid worker config: {exc}", phase="invalid_config")
         return 1
 

--- a/src/physicalai/robot/transport/_shared_robot.py
+++ b/src/physicalai/robot/transport/_shared_robot.py
@@ -49,7 +49,7 @@ from physicalai.robot.errors import (
 from ._codec import ROBOT_TRANSPORT_PROTOCOL_VERSION, TransportObservation, decode_metadata, decode_state, encode_action
 from ._ids import KEY_PREFIX, METADATA_WILDCARD, action_key, metadata_key, state_key, validate_name
 from ._lock import active_owner_device_ids, registered_owner_names
-from ._owner_config import DEFAULT_RATE_HZ, normalize_robot_config
+from ._owner_config import DEFAULT_RATE_HZ, coerce_robot_config_input, normalize_robot_config
 from ._session import open_session
 
 if TYPE_CHECKING:
@@ -222,7 +222,7 @@ class SharedRobot:
         self,
         name: str,
         *,
-        robot: Config | Mapping[str, object] | None = None,
+        robot: Config | Mapping[str, Any] | None = None,
         allow_remote: bool = False,
         rate_hz: float = DEFAULT_RATE_HZ,
         idle_timeout: float | None = 10.0,
@@ -249,13 +249,15 @@ class SharedRobot:
     @classmethod
     def _physicalai_normalize_captured_init_args(cls, supplied: dict[str, object]) -> None:
         robot = supplied.get("robot")
+        if robot is None:
+            return
         if isinstance(robot, Mapping) or type(robot) is Config:
             supplied["robot"] = normalize_robot_config(robot).to_dict()
 
     @classmethod
     def from_config(
         cls,
-        robot_config: Config | Mapping[str, object],
+        robot_config: Config | Mapping[str, Any] | object,
         *,
         name: str,
         allow_remote: bool = False,
@@ -267,7 +269,9 @@ class SharedRobot:
         """Primary API: spawn/attach from a local robot Config.
 
         Args:
-            robot_config: Local ``class_path`` + ``init_args`` for the driver.
+            robot_config: Local ``class_path`` + ``init_args``, a mapping, or a
+                live ``@export_config`` driver (exported via
+                :meth:`~physicalai.config.Config.from_instance`).
             name: Logical owner name (Zenoh topic key).
             allow_remote: Whether this session / spawned owner may leave localhost.
             rate_hz: Owner loop rate when this instance spawns the owner.
@@ -280,6 +284,7 @@ class SharedRobot:
             writes only the new owner stdin shape on spawn.
         """
         # Omit default None so @export_config does not capture "_session": null.
+        robot_config = coerce_robot_config_input(robot_config)
         if _session is None:
             return cls(
                 name,

--- a/src/physicalai/robot/transport/_shared_robot.py
+++ b/src/physicalai/robot/transport/_shared_robot.py
@@ -9,7 +9,7 @@ actions fire-and-forget. The first instance constructed for a given *name*
 that finds no existing owner spawns one; later instances (for the same
 *name*, anywhere reachable) attach.
 
-Construction is :class:`~physicalai.config.ComponentConfig`-only via
+Construction is :class:`~physicalai.config.Config`-only via
 ``robot=`` or :meth:`from_config`. ``robot`` is declared as an
 ``@export_config(config_args=...)`` argument, so a nested
 :func:`~physicalai.config.instantiate` hands over the recipe instead of
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
-from physicalai.config import export_config
+from physicalai.config import Config, export_config
 from physicalai.robot.errors import (
     RobotDeviceAlreadyOwned,
     RobotNameConflict,
@@ -55,7 +55,6 @@ from ._session import open_session
 if TYPE_CHECKING:
     import numpy as np
 
-    from physicalai.config import ComponentConfig
     from physicalai.robot import RobotObservation
 
 
@@ -188,11 +187,11 @@ class SharedRobot:
     is a drop-in replacement for a direct driver.
 
     Prefer :meth:`from_config`. The constructor takes
-    ``robot: ComponentConfig`` to spawn, or ``robot=None`` (attach-only;
+    ``robot: Config`` to spawn, or ``robot=None`` (attach-only;
     :meth:`attach` is the explicit form).
 
     Opted into :func:`~physicalai.config.export_config` as a **construction
-    recipe** only (name, nested ``robot`` ComponentConfig, transport knobs).
+    recipe** only (name, nested ``robot`` Config, transport knobs).
     Connection / Zenoh session / publisher state is never part of
     :func:`~physicalai.config.to_config`.
 
@@ -200,7 +199,7 @@ class SharedRobot:
         name: Required logical name — keys the Zenoh topics directly. Two
             instances constructed with the same *name* (anywhere reachable
             under the chosen transport scope) share one owner.
-        robot: Driver :class:`~physicalai.config.ComponentConfig` from local
+        robot: Driver :class:`~physicalai.config.Config` from local
             config input (same boundary as CLI/app args), used
             to spawn if no owner exists yet for *name*. ``None`` means
             attach-only — use :meth:`attach` for that case. Declared as an
@@ -223,7 +222,7 @@ class SharedRobot:
         self,
         name: str,
         *,
-        robot: ComponentConfig | Mapping[str, object] | None = None,
+        robot: Config | Mapping[str, object] | None = None,
         allow_remote: bool = False,
         rate_hz: float = DEFAULT_RATE_HZ,
         idle_timeout: float | None = 10.0,
@@ -250,13 +249,13 @@ class SharedRobot:
     @classmethod
     def _physicalai_normalize_captured_init_args(cls, supplied: dict[str, object]) -> None:
         robot = supplied.get("robot")
-        if isinstance(robot, Mapping):
-            supplied["robot"] = normalize_robot_config(robot)
+        if isinstance(robot, Mapping) or type(robot) is Config:
+            supplied["robot"] = normalize_robot_config(robot).to_dict()
 
     @classmethod
     def from_config(
         cls,
-        robot_config: ComponentConfig | Mapping[str, object],
+        robot_config: Config | Mapping[str, object],
         *,
         name: str,
         allow_remote: bool = False,
@@ -265,7 +264,7 @@ class SharedRobot:
         connect_timeout: float = 10.0,
         _session: object | None = None,
     ) -> SharedRobot:
-        """Primary API: spawn/attach from a local robot ComponentConfig.
+        """Primary API: spawn/attach from a local robot Config.
 
         Args:
             robot_config: Local ``class_path`` + ``init_args`` for the driver.
@@ -277,7 +276,7 @@ class SharedRobot:
             connect_timeout: Overall budget for :meth:`connect`.
 
         Returns:
-            A ``SharedRobot`` that stores the normalized ComponentConfig and
+            A ``SharedRobot`` that stores the normalized Config and
             writes only the new owner stdin shape on spawn.
         """
         # Omit default None so @export_config does not capture "_session": null.

--- a/src/physicalai/runtime/core.py
+++ b/src/physicalai/runtime/core.py
@@ -8,17 +8,17 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, Self
 
 from physicalai.capture.errors import CaptureError
 from physicalai.config import export_config
-from physicalai.runtime._callback_bus import _CallbackBus  # noqa: PLC2701
+from physicalai.runtime._callback_bus import _CallbackBus
 from physicalai.runtime.events import LifecycleEvent, TickEvent
 from physicalai.runtime.execution.base import WorkerDiedError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-    from pathlib import Path
     from typing import Any
 
     import numpy as np
@@ -38,38 +38,38 @@ _GOAL_TIME_TICKS = 3
 
 
 def _unwrap_runtime_document(document: dict[str, Any], *, target: type) -> dict[str, Any]:
-    """Rewrite a bare exported ComponentConfig document to the CLI ``runtime:`` shape.
+    """Rewrite a bare exported Config document to the CLI ``runtime:`` shape.
 
     A document without a top-level ``class_path`` is returned unchanged (it is
     already a CLI document). Otherwise it must be a valid
-    :class:`~physicalai.config.ComponentConfig` whose ``class_path`` resolves
+    :class:`~physicalai.config.Config` whose ``class_path`` resolves
     to *target* (or a subclass), and its ``init_args`` become the ``runtime:``
-    section — making ``to_config(runtime)`` → YAML → CLI round-trip.
+    section — making ``Config.from_instance(runtime)`` → YAML → CLI round-trip.
 
     Returns:
         A CLI-shaped document with constructor args under ``runtime:``.
 
     Raises:
-        ComponentConfigError: If ``class_path`` does not resolve to *target*.
+        ConfigError: If ``class_path`` does not resolve to *target*.
     """
     if "class_path" not in document:
         return document
 
-    from physicalai.config import (  # noqa: PLC0415
-        ComponentConfigError,
+    from physicalai.config import (
+        ConfigError,
         import_dotted_path,
-        validate_component_config,
+        validate_config,
     )
 
-    config = validate_component_config(document)
+    config = validate_config(document)
     resolved = import_dotted_path(config["class_path"])
     if not (isinstance(resolved, type) and issubclass(resolved, target)):
         msg = (
             f"config class_path {config['class_path']!r} does not resolve to "
             f"{target.__module__}.{target.__qualname__} (or a subclass); "
-            "expected a runtime config exported via to_config(runtime)"
+            "expected a runtime config exported via Config.from_instance(runtime)"
         )
-        raise ComponentConfigError(msg)
+        raise ConfigError(msg)
     return {"runtime": dict(config["init_args"])}
 
 
@@ -105,7 +105,7 @@ class RuntimeCallback(Protocol):
 class RobotRuntime:
     """Generic robot runtime loop with a required, pluggable action source."""
 
-    def __init__(  # noqa: D107
+    def __init__(
         self,
         robot: Robot,
         action_source: ActionSource,
@@ -204,11 +204,11 @@ class RobotRuntime:
 
         self._connected = False
 
-    def __enter__(self) -> Self:  # noqa: D105
+    def __enter__(self) -> Self:
         self.connect()
         return self
 
-    def __exit__(self, *exc_info: object) -> None:  # noqa: D105
+    def __exit__(self, *exc_info: object) -> None:
         self.disconnect()
 
     @classmethod
@@ -217,7 +217,7 @@ class RobotRuntime:
 
         Accepts two document shapes: the CLI document (constructor args under
         ``runtime:``, optional ``run:``) and a bare exported
-        :class:`~physicalai.config.ComponentConfig` as produced by
+        :class:`~physicalai.config.Config` as produced by
         :func:`~physicalai.config.to_config` / :func:`~physicalai.config.save_yaml`
         (top-level ``class_path`` resolving to this class).
         ``action_source:`` is always required and explicit — one schema, no
@@ -226,11 +226,14 @@ class RobotRuntime:
         Returns:
             Instantiated runtime object.
         """
-        from jsonargparse import ArgumentParser  # noqa: PLC0415
+        import yaml
+        from jsonargparse import ArgumentParser
 
-        from physicalai.config import load_yaml  # noqa: PLC0415
-
-        document = _unwrap_runtime_document(load_yaml(config), target=cls)
+        document = yaml.safe_load(Path(config).read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            msg = f"runtime config must be a mapping, got {type(document).__name__}"
+            raise TypeError(msg)
+        document = _unwrap_runtime_document(document, target=cls)
         parser = ArgumentParser()
         parser.add_class_arguments(cls, "runtime")
         parser.add_method_arguments(cls, "run", "run")

--- a/src/physicalai/runtime/core.py
+++ b/src/physicalai/runtime/core.py
@@ -233,6 +233,8 @@ class RobotRuntime:
         from jsonargparse import ArgumentParser  # noqa: PLC0415
 
         document = yaml.safe_load(Path(config).read_text(encoding="utf-8"))
+        if document is None:
+            document = {}
         if not isinstance(document, dict):
             msg = f"runtime config must be a mapping, got {type(document).__name__}"
             raise TypeError(msg)

--- a/src/physicalai/runtime/core.py
+++ b/src/physicalai/runtime/core.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Protocol, Self
 
 from physicalai.capture.errors import CaptureError
 from physicalai.config import export_config
-from physicalai.runtime._callback_bus import _CallbackBus
+from physicalai.runtime._callback_bus import _CallbackBus  # noqa: PLC2701
 from physicalai.runtime.events import LifecycleEvent, TickEvent
 from physicalai.runtime.execution.base import WorkerDiedError
 
@@ -55,7 +55,7 @@ def _unwrap_runtime_document(document: dict[str, Any], *, target: type) -> dict[
     if "class_path" not in document:
         return document
 
-    from physicalai.config import (
+    from physicalai.config import (  # noqa: PLC0415
         ConfigError,
         import_dotted_path,
         validate_config,
@@ -105,7 +105,7 @@ class RuntimeCallback(Protocol):
 class RobotRuntime:
     """Generic robot runtime loop with a required, pluggable action source."""
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         robot: Robot,
         action_source: ActionSource,
@@ -204,11 +204,11 @@ class RobotRuntime:
 
         self._connected = False
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> Self:  # noqa: D105
         self.connect()
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(self, *exc_info: object) -> None:  # noqa: D105
         self.disconnect()
 
     @classmethod
@@ -225,9 +225,12 @@ class RobotRuntime:
 
         Returns:
             Instantiated runtime object.
+
+        Raises:
+            TypeError: If the file root is not a mapping.
         """
-        import yaml
-        from jsonargparse import ArgumentParser
+        import yaml  # noqa: PLC0415
+        from jsonargparse import ArgumentParser  # noqa: PLC0415
 
         document = yaml.safe_load(Path(config).read_text(encoding="utf-8"))
         if not isinstance(document, dict):

--- a/tests/unit/capture/test_camera_config.py
+++ b/tests/unit/capture/test_camera_config.py
@@ -164,17 +164,17 @@ class TestSharedCameraConfig:
     def test_nested_recipe_is_not_instantiated(self) -> None:
         from physicalai.capture import SharedCamera
 
-        config: Config = {
-            "class_path": "physicalai.capture.SharedCamera",
-            "init_args": {
+        config = Config(
+            "physicalai.capture.SharedCamera",
+            {
                 "camera": {
                     "class_path": "physicalai.capture.UVCCamera",
                     "init_args": {"device": 0, "backend": "v4l2"},
                 },
                 "service_name": "physicalai/camera/UVCCamera/0/frame",
             },
-        }
+        )
         restored = instantiate(config)
         assert isinstance(restored, SharedCamera)
         # The declared config arg stays a mapping — no UVCCamera is built here.
-        assert restored._camera == config["init_args"]["camera"]
+        assert restored._camera == config.init_args["camera"]

--- a/tests/unit/capture/test_camera_config.py
+++ b/tests/unit/capture/test_camera_config.py
@@ -15,14 +15,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from physicalai.capture.camera import Camera, ColorMode
-from physicalai.config import ComponentConfig, instantiate, is_config_exportable, to_config
+from physicalai.config import Config, instantiate, is_config_exportable, to_config
 
 
 def _assert_construction_round_trip(camera: object) -> dict[str, Any]:
     assert is_config_exportable(camera)
     assert isinstance(camera, Camera)
     config = to_config(camera)
-    wire: dict[str, Any] = json.loads(json.dumps(config))
+    wire: dict[str, Any] = json.loads(json.dumps(config.to_dict()))
     restored = instantiate(wire)
     assert type(restored) is type(camera)
     assert to_config(restored) == wire
@@ -30,7 +30,7 @@ def _assert_construction_round_trip(camera: object) -> dict[str, Any]:
     return wire
 
 
-class TestUVCCameraComponentConfig:
+class TestUVCCameraConfig:
     def test_v4l2_backend_round_trip(self) -> None:
         from physicalai.capture import UVCCamera
 
@@ -59,7 +59,7 @@ def mock_pyrealsense2() -> Generator[MagicMock, None, None]:
         yield mock_rs
 
 
-class TestRealSenseCameraComponentConfig:
+class TestRealSenseCameraConfig:
     def test_round_trip(self, mock_pyrealsense2: MagicMock) -> None:
         from physicalai.capture.cameras.realsense import RealSenseCamera
 
@@ -87,7 +87,7 @@ def mock_pypylon() -> Generator[None, None, None]:
         yield
 
 
-class TestBaslerCameraComponentConfig:
+class TestBaslerCameraConfig:
     def test_round_trip(self, mock_pypylon: None) -> None:
         from physicalai.capture.cameras.basler import BaslerCamera
 
@@ -105,7 +105,7 @@ class TestBaslerCameraComponentConfig:
 # ---------------------------------------------------------------------------
 
 
-class TestSharedCameraComponentConfig:
+class TestSharedCameraConfig:
     def test_spawn_recipe_round_trip(self) -> None:
         from physicalai.capture import SharedCamera
 
@@ -164,7 +164,7 @@ class TestSharedCameraComponentConfig:
     def test_nested_recipe_is_not_instantiated(self) -> None:
         from physicalai.capture import SharedCamera
 
-        config: ComponentConfig = {
+        config: Config = {
             "class_path": "physicalai.capture.SharedCamera",
             "init_args": {
                 "camera": {

--- a/tests/unit/capture/test_transport.py
+++ b/tests/unit/capture/test_transport.py
@@ -34,7 +34,7 @@ from physicalai.capture.transport._spec import (
     derive_service_name,
     validate_reconfigure_request,
 )
-from physicalai.config import ConfigError
+from physicalai.config import Config, ConfigError
 
 from .conftest import FAKE_CAMERA_CLASS
 
@@ -1207,10 +1207,10 @@ class TestReconfigureIntegration:
             assert frame.data.shape == (240, 320, 3)
 
             camera._overwrite_settings = True
-            camera._camera = {
-                "class_path": FAKE_CAMERA_CLASS,
-                "init_args": {"width": 640, "height": 480},
-            }
+            camera._camera = Config(
+                FAKE_CAMERA_CLASS,
+                {"width": 640, "height": 480},
+            )
 
             result = camera._request_reconfigure(timeout=5.0)
             assert result["ok"] is True

--- a/tests/unit/capture/test_transport.py
+++ b/tests/unit/capture/test_transport.py
@@ -34,7 +34,7 @@ from physicalai.capture.transport._spec import (
     derive_service_name,
     validate_reconfigure_request,
 )
-from physicalai.config import ComponentConfigError
+from physicalai.config import ConfigError
 
 from .conftest import FAKE_CAMERA_CLASS
 
@@ -453,11 +453,11 @@ class TestSharedCameraConstruction:
         assert "service_name" not in cam._camera["init_args"]
         assert derive_service_name(cam._camera) == cam._service_name
 
-    def test_constructor_requires_component_config_mapping(self) -> None:
+    def test_constructor_requires_config_mapping(self) -> None:
         from tests.unit.capture.fake import FakeCamera
 
         driver = FakeCamera(width=32, height=32, device_name="d1")
-        with pytest.raises(ComponentConfigError, match="camera must be a ComponentConfig mapping"):
+        with pytest.raises(ConfigError, match="camera must be a Config mapping"):
             SharedCamera(camera=driver, service_name="physicalai/test/x/frame")  # type: ignore[arg-type]
 
     def test_subscriber_never_imports_the_vendor_driver(self) -> None:
@@ -1238,7 +1238,7 @@ class TestReconfigureIntegration:
 
     def test_attach_only_reconfigure_requires_camera_config(self) -> None:
         camera = SharedCamera.from_publisher(f"physicalai/test/{uuid4().hex[:8]}/frame")
-        with pytest.raises(CaptureError, match="requires a camera ComponentConfig"):
+        with pytest.raises(CaptureError, match="requires a camera Config"):
             camera._request_reconfigure(timeout=1.0)
 
     def test_end_to_end_overwrite_on_connect(self) -> None:

--- a/tests/unit/cli/test_robot_cli.py
+++ b/tests/unit/cli/test_robot_cli.py
@@ -77,7 +77,7 @@ def test_serve_runs_owner_in_foreground_with_persistent_timeout(capsys: object) 
     assert "[local-only]" in stderr
 
 
-def test_serve_requires_robot_component_config(capsys: object) -> None:
+def test_serve_requires_robot_config(capsys: object) -> None:
     with patch.object(robot_module, "run_owner") as run:
         assert robot_module.serve(_serve_cfg(robot=None)) == 1
     run.assert_not_called()
@@ -240,7 +240,7 @@ def test_parser_does_not_expose_idle_timeout() -> None:
     assert not hasattr(cfg.serve, "robot_kwargs")
 
 
-def test_parser_accepts_robot_component_config() -> None:
+def test_parser_accepts_robot_config() -> None:
     parser = robot_module.build_parser()
     cfg = parser.parse_args(
         [

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# ruff:file-ignore[undocumented-public-module, undocumented-public-class, undocumented-public-function, undocumented-public-init, magic-value-comparison, assert]
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+from physicalai.config import Config, FromConfig, export_config, instantiate_obj
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class Mode(Enum):
+    FAST = "fast"
+
+
+@dataclass
+class Nested:
+    value: int
+
+
+@dataclass
+class TypedConfig(Config):
+    nested: Nested
+    mode: Mode
+    shape: tuple[int, int]
+
+
+class Target(FromConfig):
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+@export_config
+class ConfigTarget:
+    def __init__(self, config: TypedConfig) -> None:
+        self.config = config
+
+
+def test_direct_recipe_round_trip(tmp_path: Path) -> None:
+    config = Config(f"{__name__}.Target", {"value": 7})
+    path = tmp_path / "recipe.yaml"
+
+    config.save(path)
+    restored = Config.load(path)
+
+    assert restored.to_dict() == config.to_dict()
+    assert isinstance(restored.instantiate(), Target)
+
+
+def test_typed_dataclass_semantics(tmp_path: Path) -> None:
+    config = TypedConfig(Nested(3), Mode.FAST, (2, 4))
+    path = tmp_path / "typed.yaml"
+    config.save(path)
+
+    restored = TypedConfig.load(path)
+
+    assert restored == config
+    assert config.to_dict() == {"nested": {"value": 3}, "mode": "fast", "shape": [2, 4]}
+    assert config.to_jsonargparse()["init_args"] == config.to_dict()
+
+
+def test_typed_dataclass_dynamic_instantiation() -> None:
+    config = TypedConfig(Nested(3), Mode.FAST, (2, 4))
+
+    restored = instantiate_obj(config.to_jsonargparse())
+
+    assert restored == config
+
+
+def test_typed_dataclass_nested_in_exported_instance() -> None:
+    instance = ConfigTarget(TypedConfig(Nested(3), Mode.FAST, (2, 4)))
+
+    restored = Config.from_instance(instance).instantiate()
+
+    assert isinstance(restored, ConfigTarget)
+    assert restored.config == instance.config
+
+
+def test_general_instantiation_delegates_recipe_to_strict_config() -> None:
+    target = instantiate_obj({"class_path": f"{__name__}.Target", "init_args": {"value": 9}})
+    assert isinstance(target, Target)
+    assert target.value == 9

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -6,12 +6,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING
+from pathlib import Path
 
-from physicalai.config import Config, FromConfig, export_config, instantiate_obj
-
-if TYPE_CHECKING:
-    from pathlib import Path
+import pytest
+from physicalai.config import Config, ConfigError, FromConfig, export_config, instantiate_obj
 
 
 class Mode(Enum):
@@ -114,3 +112,37 @@ def test_instantiate_config_class_path_requires_inner_recipe() -> None:
 
     with pytest.raises(ConfigError, match="class_path"):
         instantiate({"class_path": "physicalai.config.Config", "init_args": {}})
+
+
+@dataclass
+class PathConfig(Config):
+    root: Path
+
+
+def test_typed_dataclass_strict_rejects_extra_keys() -> None:
+    with pytest.raises(TypeError, match="Unexpected keys"):
+        TypedConfig.from_dict(
+            {"nested": {"value": 1}, "mode": "fast", "shape": [1, 1], "epochs": 1},
+            strict=True,
+        )
+
+
+def test_typed_dataclass_path_round_trip() -> None:
+    cfg = PathConfig(Path("/tmp/data"))
+    restored = PathConfig.from_dict(cfg.to_dict())
+    assert restored.root == Path("/tmp/data")
+
+
+def test_instantiate_recursive_depth_limit() -> None:
+    nested: dict[str, object] = {"value": 1}
+    current = nested
+    for _ in range(12):
+        current["child"] = {"value": 1}
+        current = current["child"]  # type: ignore[assignment]
+
+    class Leaf:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+    with pytest.raises(ConfigError, match="nesting depth exceeds"):
+        instantiate_obj({"nested": nested}, target_cls=Leaf)

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -85,3 +85,32 @@ def test_general_instantiation_delegates_recipe_to_strict_config() -> None:
     target = instantiate_obj({"class_path": f"{__name__}.Target", "init_args": {"value": 9}})
     assert isinstance(target, Target)
     assert target.value == 9
+
+
+def test_instantiate_config_class_path_builds_nested_recipe() -> None:
+    from physicalai.config import instantiate
+
+    cfg = instantiate(
+        {
+            "class_path": "physicalai.config.Config",
+            "init_args": {
+                "class_path": "builtins.dict",
+                "init_args": {"k": {"class_path": "builtins.int", "init_args": {}}},
+            },
+        },
+    )
+
+    assert isinstance(cfg, Config)
+    assert cfg.class_path == "builtins.dict"
+    nested = cfg.init_args["k"]
+    assert isinstance(nested, dict)
+    assert nested["class_path"] == "builtins.int"
+
+
+def test_instantiate_config_class_path_requires_inner_recipe() -> None:
+    import pytest
+
+    from physicalai.config import ConfigError, instantiate
+
+    with pytest.raises(ConfigError, match="class_path"):
+        instantiate({"class_path": "physicalai.config.Config", "init_args": {}})

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -135,10 +135,11 @@ def test_typed_dataclass_path_round_trip() -> None:
 
 def test_instantiate_recursive_depth_limit() -> None:
     nested: dict[str, object] = {"value": 1}
-    current = nested
+    current: dict[str, object] = nested
     for _ in range(12):
-        current["child"] = {"value": 1}
-        current = current["child"]  # type: ignore[assignment]
+        child: dict[str, object] = {"value": 1}
+        current["child"] = child
+        current = child
 
     class Leaf:
         def __init__(self, **kwargs: object) -> None:

--- a/tests/unit/config/test_export_config.py
+++ b/tests/unit/config/test_export_config.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# ruff:file-ignore[undocumented-public-module, undocumented-public-class, undocumented-public-method, undocumented-public-init, undocumented-magic-method, bad-dunder-method-name, magic-value-comparison, no-self-use, assert, unused-method-argument, too-many-public-methods]
+# ruff:file-ignore[undocumented-public-module, undocumented-public-class, undocumented-public-method, undocumented-public-init, magic-value-comparison, no-self-use, assert, unused-method-argument, too-many-public-methods]
 
 from __future__ import annotations
 
@@ -8,24 +8,26 @@ import inspect
 import json
 import math
 import sys
-from collections.abc import Mapping
 from enum import Enum
 from pathlib import Path
-from typing import Protocol, cast, runtime_checkable
-from unittest.mock import MagicMock, patch
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 import pytest
 
 from physicalai.config import (
-    ComponentConfig,
-    ComponentConfigError,
-    ComponentImportError,
+    Config,
+    ConfigError,
+    ConfigImportError,
     JsonValue,
     export_config,
     import_dotted_path,
     instantiate,
     is_config_exportable,
-    normalize_component_config,
+    normalize_config,
     to_config,
 )
 
@@ -131,7 +133,7 @@ class Leaf:
 
 @export_config(config_args=("recipe",))
 class Holder:
-    def __init__(self, recipe: ComponentConfig, eager: object) -> None:
+    def __init__(self, recipe: Config, eager: object) -> None:
         self.recipe = recipe
         self.eager = eager
 
@@ -235,7 +237,7 @@ class DomainHolder:
         self.payload = payload
 
 
-@export_config(class_path="tests.unit.config.test_component_config.ExportAlias")
+@export_config(class_path="tests.unit.config.test_export_config.ExportAlias")
 class _HiddenExport:
     """Defining-module class with a public re-export alias (see ExportAlias)."""
 
@@ -252,7 +254,7 @@ class InheritsAliasedExport(_HiddenExport):
 
 class TestImportDottedPath:
     def test_resolves_nested_class(self) -> None:
-        assert import_dotted_path("tests.unit.config.test_component_config.Point") is Point
+        assert import_dotted_path("tests.unit.config.test_export_config.Point") is Point
 
     def test_real_import_failures_are_not_masked(self, tmp_path: Path) -> None:
         pkg = tmp_path / "mask_pkg"
@@ -283,10 +285,10 @@ class TestImportDottedPath:
             import_dotted_path("totally.unknown.module.Cls")
 
 
-class TestNormalizeComponentConfig:
+class TestNormalizeConfig:
     def test_rejects_nan(self) -> None:
         with pytest.raises(ValueError, match="JSON-serializable"):
-            normalize_component_config(
+            normalize_config(
                 {"class_path": f"{__name__}.Point", "init_args": {"x": math.nan}},
                 component_key="robot",
                 class_label="robot_class",
@@ -294,7 +296,7 @@ class TestNormalizeComponentConfig:
 
     def test_rejects_infinity(self) -> None:
         with pytest.raises(ValueError, match="JSON-serializable"):
-            normalize_component_config(
+            normalize_config(
                 {"class_path": f"{__name__}.Point", "init_args": {"x": float("inf")}},
                 component_key="camera",
                 class_label="camera_class",
@@ -302,7 +304,7 @@ class TestNormalizeComponentConfig:
 
     def test_rejects_non_serializable_object(self) -> None:
         with pytest.raises(ValueError, match="JSON-serializable"):
-            normalize_component_config(
+            normalize_config(
                 {"class_path": f"{__name__}.Point", "init_args": {"x": object()}},
                 component_key="robot",
                 class_label="robot_class",
@@ -313,7 +315,7 @@ class TestNormalizeAndInstantiate:
     def test_primitives_round_trip(self) -> None:
         point = Point(1, y=2)
         config = to_config(point)
-        wire = json.loads(json.dumps(config))
+        wire = json.loads(json.dumps(config.to_dict()))
         restored = instantiate(wire)
         assert isinstance(restored, Point)
         assert restored.x == 1
@@ -324,14 +326,14 @@ class TestNormalizeAndInstantiate:
         point = Point(3)
         config = to_config(point)
         assert config["init_args"] == {"x": 3}
-        restored = cast(Point, instantiate(config))
+        restored = cast("Point", instantiate(config))
         assert restored.y == 0
 
     def test_explicit_none_is_preserved(self) -> None:
         obj = OptionalName(None)
         config = to_config(obj)
         assert config["init_args"] == {"name": None}
-        restored = cast(OptionalName, instantiate(config))
+        restored = cast("OptionalName", instantiate(config))
         assert restored.name is None
 
     def test_path_as_given(self) -> None:
@@ -346,23 +348,23 @@ class TestNormalizeAndInstantiate:
         holder = EnumHolder(Color.RED)
         config = to_config(holder)
         assert config["init_args"]["color"] == "red"
-        restored = cast(EnumHolder, instantiate(config))
+        restored = cast("EnumHolder", instantiate(config))
         assert restored.color is Color.RED
 
     def test_non_finite_float_rejected(self) -> None:
         holder = MappingHolder({"x": math.nan})
-        with pytest.raises(ComponentConfigError, match="non-finite"):
+        with pytest.raises(ConfigError, match="non-finite"):
             to_config(holder)
 
     def test_nested_component(self) -> None:
         box = Box(Point(1, 2), label="b")
         config = to_config(box)
         origin = _as_mapping(config["init_args"]["origin"])
-        assert cast(str, origin["class_path"]).endswith(".Point")
+        assert cast("str", origin["class_path"]).endswith(".Point")
         assert origin["init_args"] == {"x": 1, "y": 2}
-        restored = cast(Box, instantiate(json.loads(json.dumps(config))))
+        restored = cast("Box", instantiate(json.loads(json.dumps(config.to_dict()))))
         assert restored.origin.x == 1
-        assert to_config(restored) == json.loads(json.dumps(config))
+        assert to_config(restored) == json.loads(json.dumps(config.to_dict()))
 
     def test_list_and_mapping(self) -> None:
         holder = ListHolder([Point(1), {"a": 1}])
@@ -371,7 +373,7 @@ class TestNormalizeAndInstantiate:
         first = _as_mapping(items[0])
         assert _as_mapping(first["init_args"])["x"] == 1
         assert items[1] == {"a": 1}
-        restored = cast(ListHolder, instantiate(config))
+        restored = cast("ListHolder", instantiate(config))
         assert isinstance(restored.items[0], Point)
 
     def test_mutable_container_snapshot(self) -> None:
@@ -384,7 +386,7 @@ class TestNormalizeAndInstantiate:
         data: dict[str, object] = {}
         data["self"] = data
         holder = MappingHolder(data)
-        with pytest.raises(ComponentConfigError, match="cyclic"):
+        with pytest.raises(ConfigError, match="cyclic"):
             to_config(holder)
 
     def test_depth_limit_on_mappings(self) -> None:
@@ -392,7 +394,7 @@ class TestNormalizeAndInstantiate:
         for _ in range(_MAX_CONFIG_DEPTH + 2):
             nested = {"child": nested}
         holder = MappingHolder(nested)
-        with pytest.raises(ComponentConfigError, match="nesting depth"):
+        with pytest.raises(ConfigError, match="nesting depth"):
             to_config(holder)
 
     def test_nested_component_depth_symmetric(self) -> None:
@@ -417,56 +419,55 @@ class TestNormalizeAndInstantiate:
         assert to_config(restored) == config
 
         too_deep = nest_chain(_MAX_CONFIG_DEPTH + 1)
-        with pytest.raises(ComponentConfigError, match="nesting depth"):
+        with pytest.raises(ConfigError, match="nesting depth"):
             to_config(too_deep)
 
-        deeper: ComponentConfig = {
-            "class_path": "tests.unit.config.test_component_config.Nest",
-            "init_args": cast("dict[str, JsonValue]", {"child": config}),
-        }
-        with pytest.raises(ComponentConfigError, match="nesting depth"):
-            instantiate(deeper)
+        with pytest.raises(ConfigError, match="nesting depth"):
+            Config(
+                "tests.unit.config.test_export_config.Nest",
+                cast("dict[str, JsonValue]", {"child": config}),
+            )
 
     def test_nested_error_path_includes_parent(self) -> None:
         outer = Outer(BadInner(lambda: None))
-        with pytest.raises(ComponentConfigError, match=r"Outer\.init_args\.child\.init_args\.fn"):
+        with pytest.raises(ConfigError, match=r"Outer\.init_args\.child\.init_args\.fn"):
             to_config(outer)
 
     def test_malformed_nested_config_before_import(self) -> None:
-        with pytest.raises(ComponentConfigError, match="unexpected keys"):
+        with pytest.raises(ConfigError, match="unexpected keys"):
             instantiate({
-                "class_path": "tests.unit.config.test_component_config.Point",
+                "class_path": "tests.unit.config.test_export_config.Point",
                 "init_args": {},
                 "extra": 1,
             })
 
     def test_null_init_args_rejected(self) -> None:
-        with pytest.raises(ComponentConfigError, match="init_args"):
+        with pytest.raises(ConfigError, match="init_args"):
             instantiate({
-                "class_path": "tests.unit.config.test_component_config.Point",
+                "class_path": "tests.unit.config.test_export_config.Point",
                 "init_args": None,
             })
 
     def test_missing_class_path_rejected(self) -> None:
-        with pytest.raises(ComponentConfigError, match="missing required"):
+        with pytest.raises(ConfigError, match="missing required"):
             instantiate({"init_args": {}})  # type: ignore[arg-type]
 
     def test_non_class_import_target(self) -> None:
-        with pytest.raises(ComponentImportError, match="does not resolve to a class"):
+        with pytest.raises(ConfigImportError, match="does not resolve to a class"):
             instantiate({"class_path": "os.path.join", "init_args": {}})
 
     def test_unimportable_class_path(self) -> None:
-        with pytest.raises(ComponentImportError, match="cannot import"):
+        with pytest.raises(ConfigImportError, match="cannot import"):
             instantiate({"class_path": "totally.unknown.module.Cls", "init_args": {}})
 
     def test_dict_with_class_path_is_reserved(self) -> None:
         holder = MappingHolder({"class_path": "not.a.component", "other": 1})
-        with pytest.raises(ComponentConfigError, match="to_config_value"):
+        with pytest.raises(ConfigError, match="to_config_value"):
             to_config(holder)
 
     def test_unsupported_object_reports_path(self) -> None:
         holder = MappingHolder({"fn": lambda: None})
-        with pytest.raises(ComponentConfigError, match=r"init_args\.data\.fn"):
+        with pytest.raises(ConfigError, match=r"init_args\.data\.fn"):
             to_config(holder)
 
     def test_local_class_export_fails(self) -> None:
@@ -476,20 +477,20 @@ class TestNormalizeAndInstantiate:
                 self.x = x
 
         obj = LocalPoint(1)
-        with pytest.raises(ComponentConfigError, match="<locals>"):
+        with pytest.raises(ConfigError, match="<locals>"):
             to_config(obj)
 
     def test_local_class_instantiate_fails(self) -> None:
-        with pytest.raises(ComponentConfigError, match="<locals>"):
+        with pytest.raises(ConfigError, match="<locals>"):
             instantiate({
-                "class_path": "tests.unit.config.test_component_config.Local.<locals>.X",
+                "class_path": "tests.unit.config.test_export_config.Local.<locals>.X",
                 "init_args": {},
             })
 
     def test_constructor_failure_propagates_with_note(self) -> None:
         with pytest.raises(ValueError, match="boom") as info:
             instantiate({
-                "class_path": "tests.unit.config.test_component_config.CtorBoom",
+                "class_path": "tests.unit.config.test_export_config.CtorBoom",
                 "init_args": {"x": 1},
             })
         notes = getattr(info.value, "__notes__", [])
@@ -497,17 +498,17 @@ class TestNormalizeAndInstantiate:
 
     def test_malformed_nested_config_rejected_before_any_import(self) -> None:
         config = {
-            "class_path": "tests.unit.config.test_component_config.Point",
+            "class_path": "tests.unit.config.test_export_config.Point",
             "init_args": {
                 "x": {
-                    "class_path": "tests.unit.config.test_component_config.Point",
+                    "class_path": "tests.unit.config.test_export_config.Point",
                     "init_args": None,
                 },
             },
         }
         with (
             patch("physicalai.config._instantiate.import_dotted_path") as import_path,
-            pytest.raises(ComponentConfigError, match="init_args"),
+            pytest.raises(ConfigError, match="init_args"),
         ):
             instantiate(config)  # type: ignore[arg-type]
         import_path.assert_not_called()
@@ -515,47 +516,47 @@ class TestNormalizeAndInstantiate:
     @pytest.mark.parametrize("value", [math.nan, math.inf, (1, 2), Path("config.json"), Color.RED, object()])
     def test_non_json_value_rejected_before_any_import(self, value: object) -> None:
         config = {
-            "class_path": "tests.unit.config.test_component_config.DomainHolder",
+            "class_path": "tests.unit.config.test_export_config.DomainHolder",
             "init_args": {"payload": value},
         }
         with (
             patch("physicalai.config._instantiate.import_dotted_path") as import_path,
-            pytest.raises(ComponentConfigError),
+            pytest.raises(ConfigError),
         ):
             instantiate(config)  # type: ignore[arg-type]
         import_path.assert_not_called()
 
     def test_non_string_plain_mapping_key_rejected_before_any_import(self) -> None:
         config = {
-            "class_path": "tests.unit.config.test_component_config.MappingHolder",
+            "class_path": "tests.unit.config.test_export_config.MappingHolder",
             "init_args": {"data": {1: "value"}},
         }
         with (
             patch("physicalai.config._instantiate.import_dotted_path") as import_path,
-            pytest.raises(ComponentConfigError, match="mapping keys must be strings"),
+            pytest.raises(ConfigError, match="mapping keys must be strings"),
         ):
             instantiate(config)  # type: ignore[arg-type]
         import_path.assert_not_called()
 
-    def test_cyclic_component_config_rejected_before_any_import(self) -> None:
+    def test_cyclic_config_rejected_before_any_import(self) -> None:
         config: dict[str, object] = {
-            "class_path": "tests.unit.config.test_component_config.Nest",
+            "class_path": "tests.unit.config.test_export_config.Nest",
             "init_args": {},
         }
         cast("dict[str, object]", config["init_args"])["child"] = config
         with (
             patch("physicalai.config._instantiate.import_dotted_path") as import_path,
-            pytest.raises(ComponentConfigError, match="cyclic component config"),
+            pytest.raises(ConfigError, match="cyclic config"),
         ):
             instantiate(config)  # type: ignore[arg-type]
         import_path.assert_not_called()
 
     def test_plain_nested_mapping_remains_valid(self) -> None:
-        config = cast("ComponentConfig", {
-            "class_path": "tests.unit.config.test_component_config.MappingHolder",
-            "init_args": {"data": {"nested": {"value": 1}}},
-        })
-        restored = cast(MappingHolder, instantiate(config))
+        config = Config(
+            "tests.unit.config.test_export_config.MappingHolder",
+            {"data": {"nested": {"value": 1}}},
+        )
+        restored = cast("MappingHolder", instantiate(config))
         assert restored.data == {"nested": {"value": 1}}
 
 
@@ -600,7 +601,7 @@ class TestExportConfig:
     def test_undecorated_override_fails(self) -> None:
         obj = UndecoratedOverride("n", 1)
         assert not is_config_exportable(obj)
-        with pytest.raises(ComponentConfigError, match="not config-exportable"):
+        with pytest.raises(ConfigError, match="not config-exportable"):
             to_config(obj)
 
     def test_inherited_decorated_constructor(self) -> None:
@@ -618,7 +619,7 @@ class TestExportConfig:
         obj = _HiddenExport(3)
         assert is_config_exportable(obj)
         config = to_config(obj)
-        assert config["class_path"] == "tests.unit.config.test_component_config.ExportAlias"
+        assert config["class_path"] == "tests.unit.config.test_export_config.ExportAlias"
         assert config["init_args"] == {"x": 3}
         restored = instantiate(config)
         assert type(restored) is _HiddenExport
@@ -628,9 +629,7 @@ class TestExportConfig:
         obj = InheritsAliasedExport(9)
         assert is_config_exportable(obj)
         config = to_config(obj)
-        assert config["class_path"] == (
-            "tests.unit.config.test_component_config.InheritsAliasedExport"
-        )
+        assert config["class_path"] == ("tests.unit.config.test_export_config.InheritsAliasedExport")
         assert config["init_args"] == {"x": 9}
         restored = instantiate(config)
         assert type(restored) is InheritsAliasedExport
@@ -639,8 +638,8 @@ class TestExportConfig:
         holder = DomainHolder(DomainPayload(42))
         config = to_config(holder)
         assert config["init_args"]["payload"] == {"amount": 42}
-        wire = json.loads(json.dumps(config))
-        restored = cast(DomainHolder, instantiate(wire))
+        wire = json.loads(json.dumps(config.to_dict()))
+        restored = cast("DomainHolder", instantiate(wire))
         assert restored.payload == {"amount": 42}
         assert to_config(restored) == wire
 
@@ -648,8 +647,8 @@ class TestExportConfig:
         holder = DomainHolder(NullDomain())
         config = to_config(holder)
         assert config["init_args"]["payload"] is None
-        wire = json.loads(json.dumps(config))
-        restored = cast(DomainHolder, instantiate(wire))
+        wire = json.loads(json.dumps(config.to_dict()))
+        restored = cast("DomainHolder", instantiate(wire))
         assert restored.payload is None
 
     def test_domain_value_codec_cycle_raises(self) -> None:
@@ -658,27 +657,27 @@ class TestExportConfig:
         left.other = right
         right.other = left
         holder = DomainHolder(left)
-        with pytest.raises(ComponentConfigError, match="cyclic to_config_value"):
+        with pytest.raises(ConfigError, match="cyclic to_config_value"):
             to_config(holder)
 
     def test_domain_value_hook_output_is_renormalized(self) -> None:
         holder = DomainHolder(BadNanDomain())
-        with pytest.raises(ComponentConfigError, match="non-finite"):
+        with pytest.raises(ConfigError, match="non-finite"):
             to_config(holder)
 
     def test_domain_value_hook_reserved_class_path_validated(self) -> None:
         holder = DomainHolder(BadReservedDomain())
-        with pytest.raises(ComponentConfigError, match="to_config_value"):
+        with pytest.raises(ConfigError, match="to_config_value"):
             to_config(holder)
 
-    def test_instance_to_config_sugar(self) -> None:
+    def test_export_config_does_not_inject_to_config(self) -> None:
         point = Point(1, 2)
-        assert point.to_config() == to_config(point)  # type: ignore[attr-defined]
+        assert not hasattr(point, "to_config")
 
-    def test_injected_to_config_does_not_break_protocol(self) -> None:
+    def test_export_config_does_not_break_protocol(self) -> None:
         widget = BaseWidget("ok")
         assert isinstance(widget, Named)
-        assert widget.to_config()["init_args"] == {"name": "ok"}  # type: ignore[attr-defined]
+        assert Config.from_instance(widget)["init_args"] == {"name": "ok"}
 
     def test_signature_preserved(self) -> None:
         sig = inspect.signature(Point.__init__)
@@ -709,18 +708,18 @@ class TestScalarVarKwargs:
             "label": "x",
             "missing": None,
         }
-        restored = cast(ScalarVarKwargs, instantiate(json.loads(json.dumps(config))))
+        restored = cast("ScalarVarKwargs", instantiate(json.loads(json.dumps(config.to_dict()))))
         assert restored.base == 1
         assert restored.kwargs == {"count": 2, "flag": True, "label": "x", "missing": None}
 
     def test_non_scalar_dict_var_kwarg_fails(self) -> None:
         obj = ScalarVarKwargs(1, config_blob={"a": 1})
-        with pytest.raises(ComponentConfigError, match=r"init_args\.config_blob"):
+        with pytest.raises(ConfigError, match=r"init_args\.config_blob"):
             to_config(obj)
 
     def test_non_scalar_list_var_kwarg_fails(self) -> None:
         obj = ScalarVarKwargs(1, tags=["x", "y"])
-        with pytest.raises(ComponentConfigError, match=r"init_args\.tags"):
+        with pytest.raises(ConfigError, match=r"init_args\.tags"):
             to_config(obj)
 
     def test_named_mapping_still_exports_without_scalar_flag(self) -> None:
@@ -739,27 +738,24 @@ class TestScalarVarKwargs:
 
 class TestConfigArgs:
     def test_declared_config_arg_is_not_instantiated(self) -> None:
-        config: ComponentConfig = {
-            "class_path": f"{__name__}.Holder",
-            "init_args": {
+        config = Config(
+            f"{__name__}.Holder",
+            {
                 "recipe": {"class_path": f"{__name__}.Leaf", "init_args": {"value": 3}},
                 "eager": {"class_path": f"{__name__}.Leaf", "init_args": {"value": 3}},
             },
-        }
-        holder = cast(Holder, instantiate(config))
+        )
+        holder = cast("Holder", instantiate(config))
         assert holder.recipe == config["init_args"]["recipe"]
         assert isinstance(holder.eager, Leaf)
 
     def test_declared_config_arg_round_trips(self) -> None:
-        recipe: ComponentConfig = {
-            "class_path": f"{__name__}.Leaf",
-            "init_args": {"value": 3},
-        }
+        recipe = Config(f"{__name__}.Leaf", {"value": 3})
         holder = Holder(recipe=recipe, eager=Leaf(value=3))
         config = to_config(holder)
-        assert config["init_args"]["recipe"] == recipe
-        wire = json.loads(json.dumps(config))
-        restored = cast(Holder, instantiate(wire))
+        assert config["init_args"]["recipe"] == recipe.to_dict()
+        wire = json.loads(json.dumps(config.to_dict()))
+        restored = cast("Holder", instantiate(wire))
         assert to_config(restored) == wire
 
     def test_unknown_config_arg_name_rejected(self) -> None:

--- a/tests/unit/config/test_from_config_and_instantiate.py
+++ b/tests/unit/config/test_from_config_and_instantiate.py
@@ -1,0 +1,274 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# ruff:file-ignore[missing-type-function-argument, missing-return-type-undocumented-public-function, class-as-data-structure, undocumented-public-init, magic-value-comparison, no-self-use, float-equality-comparison, assert]
+
+"""Tests for FromConfig, instantiate_obj, and typed dataclass Config."""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, cast
+
+import numpy as np
+import pytest
+from pydantic import BaseModel
+
+from physicalai.config import Config, from_config
+from physicalai.config.instantiate import import_class, instantiate_obj
+from physicalai.config.mixin import FromConfig
+
+
+class SampleModel(FromConfig):
+    def __init__(self, hidden_size: int, num_layers: int = 3, **kwargs: object) -> None:
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+        self.kwargs = kwargs
+
+
+class SampleModelConfig(BaseModel):
+    hidden_size: int = 128
+    num_layers: int = 3
+
+
+@dataclass
+class SampleModelDataclassConfig(Config):
+    hidden_size: int = 128
+    num_layers: int = 3
+
+
+class NestedComponent:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+
+class ParentModel(FromConfig):
+    def __init__(self, component: NestedComponent, components: list[NestedComponent] | None = None) -> None:
+        self.component = component
+        self.components = components or []
+
+
+@from_config
+class DecoratedModel:
+    def __init__(self, hidden_size: int, num_layers: int = 3) -> None:
+        self.hidden_size = hidden_size
+        self.num_layers = num_layers
+
+
+@dataclasses.dataclass
+class SampleModelDataclass:
+    hidden_size: int = 128
+    num_layers: int = 3
+
+
+class ActivationType(StrEnum):
+    RELU = "relu"
+    GELU = "gelu"
+
+
+@dataclass
+class SimpleConfig(Config):
+    hidden_size: int = 128
+    num_layers: int = 3
+
+
+@dataclass
+class NestedConfig(Config):
+    model: SimpleConfig = field(default_factory=SimpleConfig)
+    learning_rate: float = 0.001
+
+
+@dataclass
+class ComplexConfig(Config):
+    activation: ActivationType = ActivationType.RELU
+    layers: tuple = (64, 128)
+    weights: np.ndarray = field(default_factory=lambda: np.array([1.0, 2.0]))
+
+
+class TestInstantiateObj:
+    def test_from_dict(self) -> None:
+        result = instantiate_obj({"class_path": "builtins.dict", "init_args": {"key": "value"}})
+        assert result == {"key": "value"}
+
+    def test_from_dict_with_key(self) -> None:
+        config = {"model": {"class_path": "builtins.dict", "init_args": {"size": 128}}}
+        assert instantiate_obj(config, key="model") == {"size": 128}
+
+    def test_nested_instantiation(self) -> None:
+        config = {
+            "class_path": "builtins.dict",
+            "init_args": {"nested": {"class_path": "builtins.dict", "init_args": {"k": "v"}}},
+        }
+        assert instantiate_obj(config)["nested"] == {"k": "v"}
+
+    def test_from_file(self, tmp_path) -> None:
+        (tmp_path / "config.yaml").write_text("class_path: builtins.dict\ninit_args:\n  key: value")
+        assert instantiate_obj(tmp_path / "config.yaml") == {"key": "value"}
+
+    def test_missing_class_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="class_path"):
+            instantiate_obj({"init_args": {}})
+
+    def test_invalid_import_raises(self) -> None:
+        with pytest.raises(ImportError):
+            import_class("nonexistent.module.Class")
+
+    def test_import_class_imports_symbol(self) -> None:
+        assert import_class("builtins.dict") is dict
+
+
+class TestFromConfigMixin:
+    def test_from_dict(self) -> None:
+        model = SampleModel.from_dict({"hidden_size": 256, "num_layers": 4})
+        assert model.hidden_size == 256
+        assert model.num_layers == 4
+
+    def test_from_dict_with_key(self) -> None:
+        model = SampleModel.from_dict({"model": {"hidden_size": 512, "num_layers": 6}}, key="model")
+        assert model.hidden_size == 512
+
+    def test_from_pydantic(self) -> None:
+        model = SampleModel.from_pydantic(SampleModelConfig(hidden_size=256))
+        assert model.hidden_size == 256
+
+    def test_from_dataclass(self) -> None:
+        model = SampleModel.from_dataclass(SampleModelDataclass(hidden_size=512))
+        assert model.hidden_size == 512
+
+    def test_from_yaml(self, tmp_path) -> None:
+        (tmp_path / "config.yaml").write_text("hidden_size: 1024\nnum_layers: 8")
+        model = SampleModel.from_yaml(tmp_path / "config.yaml")
+        assert model.hidden_size == 1024
+
+    def test_from_config_unified(self) -> None:
+        assert SampleModel.from_config({"hidden_size": 128, "num_layers": 3}).hidden_size == 128
+        assert SampleModel.from_config(SampleModelConfig()).hidden_size == 128
+        assert SampleModel.from_config(SampleModelDataclass()).hidden_size == 128
+
+    def test_concrete_class_accepts_jsonargparse_config(self) -> None:
+        config = {
+            "class_path": f"{SampleModel.__module__}.SampleModel",
+            "init_args": {"hidden_size": 256, "num_layers": 4},
+        }
+        model = SampleModel.from_config(config)
+        assert model.hidden_size == 256
+        assert model.num_layers == 4
+
+    def test_concrete_class_accepts_config_dataclass(self) -> None:
+        model = SampleModel.from_config(SampleModelDataclassConfig(hidden_size=384, num_layers=5))
+        assert model.hidden_size == 384
+        assert model.num_layers == 5
+
+    def test_nested_class_path_values_in_direct_args(self) -> None:
+        model = ParentModel.from_config(
+            {
+                "component": {
+                    "class_path": f"{NestedComponent.__module__}.NestedComponent",
+                    "init_args": {"value": 10},
+                },
+                "components": [
+                    {
+                        "class_path": f"{NestedComponent.__module__}.NestedComponent",
+                        "init_args": {"value": 20},
+                    },
+                ],
+            },
+        )
+        assert isinstance(model.component, NestedComponent)
+        assert model.component.value == 10
+        assert isinstance(model.components[0], NestedComponent)
+        assert model.components[0].value == 20
+
+    def test_from_config_decorator(self) -> None:
+        decorated_model_cls = cast("Any", DecoratedModel)
+        model = decorated_model_cls.from_config({"hidden_size": 512, "num_layers": 6})
+        assert model.hidden_size == 512
+        assert model.num_layers == 6
+
+    def test_from_config_decorator_with_yaml(self, tmp_path) -> None:
+        decorated_model_cls = cast("Any", DecoratedModel)
+        path = tmp_path / "decorated.yaml"
+        path.write_text("hidden_size: 640\nnum_layers: 7")
+        model = decorated_model_cls.from_config(path)
+        assert model.hidden_size == 640
+        assert model.num_layers == 7
+
+    def test_recursive_parameter(self) -> None:
+        @dataclass
+        class Nested:
+            size: int = 64
+
+        @dataclass
+        class Parent:
+            hidden_size: int = 128
+            nested: Nested = field(default_factory=Nested)
+
+        class Model(FromConfig):
+            def __init__(self, hidden_size: int, nested: Nested | None = None) -> None:
+                self.hidden_size = hidden_size
+                self.nested = nested
+
+        parent = Parent()
+        assert isinstance(Model.from_dataclass(parent, recursive=False).nested, Nested)
+        assert isinstance(Model.from_dataclass(parent, recursive=True).nested, dict)
+
+
+class TestConfigSerialization:
+    def test_to_jsonargparse(self) -> None:
+        result = SimpleConfig(hidden_size=256).to_jsonargparse()
+        assert "class_path" in result
+        assert result["init_args"]["hidden_size"] == 256
+
+    def test_to_dict(self) -> None:
+        result = SimpleConfig(hidden_size=256).to_dict()
+        assert "class_path" not in result
+        assert result["hidden_size"] == 256
+
+    def test_from_dict(self) -> None:
+        config = SimpleConfig.from_dict({"hidden_size": 512, "num_layers": 8})
+        assert config.hidden_size == 512
+
+    def test_from_dict_nested(self) -> None:
+        config = NestedConfig.from_dict({"model": {"hidden_size": 256, "num_layers": 4}, "learning_rate": 0.01})
+        assert isinstance(config.model, SimpleConfig)
+        assert config.model.hidden_size == 256
+
+    def test_round_trip(self) -> None:
+        original = NestedConfig(model=SimpleConfig(hidden_size=512), learning_rate=0.005)
+        restored = NestedConfig.from_dict(original.to_dict())
+        assert restored.model.hidden_size == 512
+        assert restored.learning_rate == 0.005
+
+    def test_type_conversions(self) -> None:
+        result = ComplexConfig(
+            activation=ActivationType.GELU,
+            layers=(32, 64),
+            weights=np.array([[1.0, 2.0]]),
+        ).to_jsonargparse()
+        assert result["init_args"]["activation"] == "gelu"
+        assert result["init_args"]["layers"] == [32, 64]
+        assert result["init_args"]["weights"] == [[1.0, 2.0]]
+
+
+class TestConfigSaveLoad:
+    def test_save_load_jsonargparse(self, tmp_path) -> None:
+        path = tmp_path / "config.yaml"
+        SimpleConfig(hidden_size=256).save(path)
+        assert SimpleConfig.load(path).hidden_size == 256
+
+    def test_save_load_dict_format(self, tmp_path) -> None:
+        path = tmp_path / "config.yaml"
+        SimpleConfig(hidden_size=512).save(path, format="dict")
+        assert SimpleConfig.load(path).hidden_size == 512
+
+    def test_invalid_extension_raises(self, tmp_path) -> None:
+        with pytest.raises(ValueError, match="Unsupported file extension"):
+            SimpleConfig().save(tmp_path / "config.json")
+
+    def test_not_dataclass_raises(self) -> None:
+        class NotDataclass(Config):
+            pass
+
+        with pytest.raises(TypeError, match="Config subclasses must be dataclasses"):
+            NotDataclass("builtins.dict")

--- a/tests/unit/config/test_from_config_and_instantiate.py
+++ b/tests/unit/config/test_from_config_and_instantiate.py
@@ -100,7 +100,9 @@ class TestInstantiateObj:
             "class_path": "builtins.dict",
             "init_args": {"nested": {"class_path": "builtins.dict", "init_args": {"k": "v"}}},
         }
-        assert instantiate_obj(config)["nested"] == {"k": "v"}
+        result = instantiate_obj(config)
+        assert isinstance(result, dict)
+        assert result["nested"] == {"k": "v"}
 
     def test_from_file(self, tmp_path) -> None:
         (tmp_path / "config.yaml").write_text("class_path: builtins.dict\ninit_args:\n  key: value")

--- a/tests/unit/config/test_from_config_and_instantiate.py
+++ b/tests/unit/config/test_from_config_and_instantiate.py
@@ -16,7 +16,7 @@ import pytest
 from pydantic import BaseModel
 
 from physicalai.config import Config, from_config
-from physicalai.config.instantiate import import_class, instantiate_obj
+from physicalai.config.loading import import_class, instantiate_obj
 from physicalai.config.mixin import FromConfig
 
 

--- a/tests/unit/config/test_yaml.py
+++ b/tests/unit/config/test_yaml.py
@@ -84,3 +84,10 @@ class TestSaveLoadYaml:
 
         with pytest.raises(ConfigError, match="must be a mapping"):
             load_yaml(target)
+
+    def test_load_empty_file_as_empty_mapping(self, tmp_path: Path) -> None:
+        target = tmp_path / "empty.yaml"
+        target.write_text("", encoding="utf-8")
+
+        with pytest.raises(ConfigError, match="class_path"):
+            load_yaml(target)

--- a/tests/unit/config/test_yaml.py
+++ b/tests/unit/config/test_yaml.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# ruff:file-ignore[undocumented-public-module, undocumented-public-class, undocumented-public-method, undocumented-public-init, undocumented-magic-method, magic-value-comparison, no-self-use, assert]
+# ruff:file-ignore[undocumented-public-module, undocumented-public-class, undocumented-public-method, undocumented-public-init, magic-value-comparison, no-self-use, assert]
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import pytest
 import yaml
 
 from physicalai.config import (
-    ComponentConfigError,
+    ConfigError,
     export_config,
     instantiate,
     load_yaml,
@@ -49,7 +49,7 @@ class TestToYaml:
         assert rebuilt.gadget.size == 3
         assert rebuilt.gadget.label == "inner"
 
-    def test_accepts_existing_component_config_mapping(self) -> None:
+    def test_accepts_existing_config_mapping(self) -> None:
         config = to_config(Gadget(7))
 
         text = to_yaml(config)
@@ -58,11 +58,11 @@ class TestToYaml:
         assert loaded == {"class_path": f"{__name__}.Gadget", "init_args": {"size": 7}}
 
     def test_rejects_malformed_mapping(self) -> None:
-        with pytest.raises(ComponentConfigError, match="class_path"):
+        with pytest.raises(ConfigError, match="class_path"):
             to_yaml({"init_args": {"size": 1}})
 
     def test_rejects_non_exportable_object(self) -> None:
-        with pytest.raises(ComponentConfigError):
+        with pytest.raises(ConfigError):
             to_yaml(object())
 
 
@@ -82,5 +82,5 @@ class TestSaveLoadYaml:
         target = tmp_path / "list.yaml"
         target.write_text("- 1\n- 2\n", encoding="utf-8")
 
-        with pytest.raises(ComponentConfigError, match="must be a mapping"):
+        with pytest.raises(ConfigError, match="must be a mapping"):
             load_yaml(target)

--- a/tests/unit/inference/test_inference_model_config.py
+++ b/tests/unit/inference/test_inference_model_config.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from physicalai.config import ComponentConfigError, instantiate, is_config_exportable, to_config
+from physicalai.config import ConfigError, instantiate, is_config_exportable, to_config
 
 
 def _make_export_dir(tmp_path: Path, *, backend: str = "openvino") -> Path:
@@ -44,7 +44,7 @@ def _make_export_dir(tmp_path: Path, *, backend: str = "openvino") -> Path:
 def _assert_construction_round_trip(model: object) -> dict[str, Any]:
     assert is_config_exportable(model)
     config = to_config(model)
-    wire: dict[str, Any] = json.loads(json.dumps(config))
+    wire: dict[str, Any] = json.loads(json.dumps(config.to_dict()))
     restored = instantiate(wire)
     assert type(restored) is type(model)
     assert to_config(restored) == wire
@@ -66,7 +66,7 @@ def _patch_adapter(mock_adapter: MagicMock) -> Generator[MagicMock, None, None]:
         yield mock_adapter
 
 
-class TestInferenceModelComponentConfig:
+class TestInferenceModelConfig:
     def test_path_rooted_round_trip(self, tmp_path: Path, _patch_adapter: MagicMock) -> None:
         from physicalai.inference import InferenceModel
 
@@ -129,7 +129,7 @@ class TestInferenceModelComponentConfig:
             device="cpu",
             runner=SinglePass(),
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.runner"):
+        with pytest.raises(ConfigError, match=r"init_args\.runner"):
             to_config(model)
 
     def test_live_preprocessors_fail(self, tmp_path: Path, _patch_adapter: MagicMock) -> None:
@@ -141,7 +141,7 @@ class TestInferenceModelComponentConfig:
             device="cpu",
             preprocessors=[MagicMock()],
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.preprocessors"):
+        with pytest.raises(ConfigError, match=r"init_args\.preprocessors"):
             to_config(model)
 
     def test_live_postprocessors_fail(self, tmp_path: Path, _patch_adapter: MagicMock) -> None:
@@ -153,7 +153,7 @@ class TestInferenceModelComponentConfig:
             device="cpu",
             postprocessors=[MagicMock()],
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.postprocessors"):
+        with pytest.raises(ConfigError, match=r"init_args\.postprocessors"):
             to_config(model)
 
     def test_live_callbacks_fail(self, tmp_path: Path, _patch_adapter: MagicMock) -> None:
@@ -165,7 +165,7 @@ class TestInferenceModelComponentConfig:
             device="cpu",
             callbacks=[MagicMock()],
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.callbacks"):
+        with pytest.raises(ConfigError, match=r"init_args\.callbacks"):
             to_config(model)
 
     def test_non_scalar_dict_adapter_kwarg_fails(self, tmp_path: Path, _patch_adapter: MagicMock) -> None:
@@ -177,7 +177,7 @@ class TestInferenceModelComponentConfig:
             device="cpu",
             config_blob={"a": 1},
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.config_blob"):
+        with pytest.raises(ConfigError, match=r"init_args\.config_blob"):
             to_config(model)
 
     def test_non_scalar_list_adapter_kwarg_fails(self, tmp_path: Path, _patch_adapter: MagicMock) -> None:
@@ -189,5 +189,5 @@ class TestInferenceModelComponentConfig:
             device="cpu",
             tags=["x", "y"],
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.tags"):
+        with pytest.raises(ConfigError, match=r"init_args\.tags"):
             to_config(model)

--- a/tests/unit/robot/test_robot_config.py
+++ b/tests/unit/robot/test_robot_config.py
@@ -358,17 +358,17 @@ class TestSharedRobotConfig:
         from physicalai.config import instantiate
         from physicalai.robot import SharedRobot
 
-        config: Config = {
-            "class_path": "physicalai.robot.SharedRobot",
-            "init_args": {
+        config = Config(
+            "physicalai.robot.SharedRobot",
+            {
                 "name": "nested-arm",
                 "robot": {
                     "class_path": "tests.unit.robot.transport.fake.FakeRobot",
                     "init_args": {"port": "/dev/fake-nested", "device_ids": ["fake:follower"]},
                 },
             },
-        }
+        )
         restored = instantiate(config)
         assert isinstance(restored, SharedRobot)
         # The declared config arg stays a mapping — no driver is built here.
-        assert restored._robot == config["init_args"]["robot"]
+        assert restored._robot == config.init_args["robot"]

--- a/tests/unit/robot/test_robot_config.py
+++ b/tests/unit/robot/test_robot_config.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from physicalai.config import ComponentConfig, instantiate, is_config_exportable, to_config
+from physicalai.config import Config, instantiate, is_config_exportable, to_config
 from physicalai.robot import Robot
 
 # SO101 imports scservo_sdk at module load; keep unit tests hardware-free.
@@ -35,7 +35,7 @@ def _assert_construction_round_trip(robot: object) -> dict[str, Any]:
     assert is_config_exportable(robot)
     assert isinstance(robot, Robot)
     config = to_config(robot)
-    wire: dict[str, Any] = json.loads(json.dumps(config))
+    wire: dict[str, Any] = json.loads(json.dumps(config.to_dict()))
     restored = instantiate(wire)
     assert type(restored) is type(robot)
     assert to_config(restored) == wire
@@ -56,7 +56,7 @@ def mock_scservo_sdk() -> Generator[MagicMock, None, None]:
         yield sdk
 
 
-class TestSO101ComponentConfig:
+class TestSO101Config:
     def test_dict_calibration_round_trip(self, mock_scservo_sdk: MagicMock) -> None:
         from physicalai.robot import SO101
 
@@ -141,7 +141,7 @@ class TestSO101ComponentConfig:
 
         robot = SO101(port="/dev/ttyUSB0", calibration=SAMPLE_CALIBRATION)
         assert isinstance(robot, Robot)
-        assert robot.to_config() == to_config(robot)  # type: ignore[attr-defined]
+        assert Config.from_instance(robot) == to_config(robot)
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +177,7 @@ def mock_trossen_arm() -> Generator[MagicMock, None, None]:
         yield mock_module
 
 
-class TestWidowXAIComponentConfig:
+class TestWidowXAIConfig:
     def test_default_role_omitted(self, mock_trossen_arm: MagicMock) -> None:
         from physicalai.robot import WidowXAI
 
@@ -198,10 +198,10 @@ class TestWidowXAIComponentConfig:
 
         robot = WidowXAI(ip="192.168.1.2")
         assert isinstance(robot, Robot)
-        assert robot.to_config() == to_config(robot)  # type: ignore[attr-defined]
+        assert Config.from_instance(robot) == to_config(robot)
 
 
-class TestBimanualWidowXAIComponentConfig:
+class TestBimanualWidowXAIConfig:
     def test_nested_arms_round_trip(self, mock_trossen_arm: MagicMock) -> None:
         from physicalai.robot import BimanualWidowXAI, WidowXAI
 
@@ -225,7 +225,7 @@ class TestBimanualWidowXAIComponentConfig:
 # ---------------------------------------------------------------------------
 
 
-class TestSharedRobotComponentConfig:
+class TestSharedRobotConfig:
     def test_spawn_recipe_round_trip(self) -> None:
         from physicalai.robot import SharedRobot
 
@@ -295,11 +295,11 @@ class TestSharedRobotComponentConfig:
         assert wire["init_args"]["robot"] is None
 
     def test_live_session_arg_fails_at_to_config(self) -> None:
-        from physicalai.config import ComponentConfigError
+        from physicalai.config import ConfigError
         from physicalai.robot import SharedRobot
 
         robot = SharedRobot("sess", _session=object())
-        with pytest.raises(ComponentConfigError, match=r"init_args\._session"):
+        with pytest.raises(ConfigError, match=r"init_args\._session"):
             to_config(robot)
 
     def test_from_config_omits_null_session(self) -> None:
@@ -336,7 +336,7 @@ class TestSharedRobotComponentConfig:
         assert "_session" not in wire["init_args"]
 
     def test_classmethod_live_session_still_fails_at_to_config(self) -> None:
-        from physicalai.config import ComponentConfigError
+        from physicalai.config import ConfigError
         from physicalai.robot import SharedRobot
 
         session = object()
@@ -351,14 +351,14 @@ class TestSharedRobotComponentConfig:
             ),
             SharedRobot.attach("live-attach", _session=session),
         ):
-            with pytest.raises(ComponentConfigError, match=r"init_args\._session"):
+            with pytest.raises(ConfigError, match=r"init_args\._session"):
                 to_config(robot)
 
     def test_nested_recipe_is_not_instantiated(self) -> None:
         from physicalai.config import instantiate
         from physicalai.robot import SharedRobot
 
-        config: ComponentConfig = {
+        config: Config = {
             "class_path": "physicalai.robot.SharedRobot",
             "init_args": {
                 "name": "nested-arm",

--- a/tests/unit/robot/transport/test_owner_config.py
+++ b/tests/unit/robot/transport/test_owner_config.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from physicalai.config import ComponentConfigError, ComponentImportError
+from physicalai.config import ConfigError, ConfigImportError
 from physicalai.robot.transport._owner import RobotOwner
 from physicalai.robot.transport._owner_config import (
     RobotOwnerConfig,
@@ -48,7 +48,7 @@ class TestNormalizeRobotConfigClassPath:
             normalize_robot_config({"class_path": class_path})
 
     def test_empty_path_raises(self) -> None:
-        with pytest.raises(ComponentConfigError, match="must be a non-empty string"):
+        with pytest.raises(ConfigError, match="must be a non-empty string"):
             normalize_robot_config({"class_path": ""})
 
 
@@ -123,7 +123,7 @@ class TestRobotOwnerConfig:
             name="left-arm",
             robot={"class_path": "physicalai.robot.transport._ids.KEY_PREFIX", "init_args": {}},
         )
-        with pytest.raises(ComponentImportError, match="does not resolve to a class"):
+        with pytest.raises(ConfigImportError, match="does not resolve to a class"):
             config.build()
 
     def test_build_unknown_path_raises(self) -> None:
@@ -131,7 +131,7 @@ class TestRobotOwnerConfig:
             name="left-arm",
             robot={"class_path": "totally.unknown.module.Cls", "init_args": {}},
         )
-        with pytest.raises(ComponentImportError, match="cannot import class_path"):
+        with pytest.raises(ConfigImportError, match="cannot import class_path"):
             config.build()
 
     def test_flat_stdin_rejected_before_import(self) -> None:
@@ -195,7 +195,7 @@ class TestRobotOwnerConfig:
         assert init_args["port"] == "/dev/ttyUSB0"
 
     def test_malformed_robot_rejected_before_import(self) -> None:
-        with pytest.raises(ComponentConfigError):
+        with pytest.raises(ConfigError):
             RobotOwnerConfig.from_json_dict(
                 {
                     "name": "left-arm",
@@ -268,5 +268,5 @@ class TestRobotOwnerConfig:
 
 class TestNormalizeRobotConfig:
     def test_normalize_robot_config_rejects_malformed(self) -> None:
-        with pytest.raises(ComponentConfigError):
+        with pytest.raises(ConfigError):
             normalize_robot_config({"class_path": FAKE_ROBOT_CLASS, "extra": True})

--- a/tests/unit/robot/transport/test_owner_config.py
+++ b/tests/unit/robot/transport/test_owner_config.py
@@ -179,6 +179,12 @@ class TestRobotOwnerConfig:
         with pytest.raises(TypeError, match="owner config 'name' must be a string"):
             RobotOwnerConfig.from_json_dict({"name": bad_name, "robot": _fake_robot()})
 
+    def test_non_bool_allow_remote_rejected(self) -> None:
+        with pytest.raises(TypeError, match="allow_remote' must be a bool"):
+            RobotOwnerConfig.from_json_dict(
+                {"name": "left-arm", "robot": _fake_robot(), "allow_remote": "no"},
+            )
+
     def test_validate_owner_config_shared_helper(self) -> None:
         robot = validate_owner_config(
             {

--- a/tests/unit/robot/transport/test_shared_robot.py
+++ b/tests/unit/robot/transport/test_shared_robot.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
-from physicalai.config import ComponentConfigError
+from physicalai.config import ConfigError
 from physicalai.robot.errors import (
     RobotNameConflict,
     RobotNotConnectedError,
@@ -90,7 +90,7 @@ class TestConstruction:
         assert robot._robot is None
         assert robot.device_ids == ()
 
-    def test_robot_component_config_normalized(self) -> None:
+    def test_robot_config_normalized(self) -> None:
         robot = SharedRobot(
             "left-arm",
             robot={"class_path": FAKE_ROBOT_CLASS, "init_args": {"port": "/dev/ttyUSB0"}},
@@ -100,16 +100,16 @@ class TestConstruction:
             "init_args": {"port": "/dev/ttyUSB0"},
         }
 
-    def test_from_config_stores_component_config(self) -> None:
+    def test_from_config_stores_config(self) -> None:
         robot = SharedRobot.from_config(
             {"class_path": FAKE_ROBOT_CLASS, "init_args": {"port": "/dev/fake0"}},
             name="left-arm",
         )
         assert robot._robot == {"class_path": FAKE_ROBOT_CLASS, "init_args": {"port": "/dev/fake0"}}
 
-    def test_constructor_requires_component_config_mapping(self) -> None:
+    def test_constructor_requires_config_mapping(self) -> None:
         driver = FakeRobot(port="/dev/fake0", device_ids=("fake:/dev/fake0",))
-        with pytest.raises(ComponentConfigError, match="robot must be a ComponentConfig mapping"):
+        with pytest.raises(ConfigError, match="robot must be a Config mapping"):
             SharedRobot("left-arm", robot=driver)  # type: ignore[arg-type]
 
     def test_satisfies_robot_protocol(self) -> None:

--- a/tests/unit/robot/transport/test_shared_robot.py
+++ b/tests/unit/robot/transport/test_shared_robot.py
@@ -107,10 +107,15 @@ class TestConstruction:
         )
         assert robot._robot == {"class_path": FAKE_ROBOT_CLASS, "init_args": {"port": "/dev/fake0"}}
 
-    def test_constructor_requires_config_mapping(self) -> None:
+    def test_constructor_accepts_exportable_driver(self) -> None:
         driver = FakeRobot(port="/dev/fake0", device_ids=("fake:/dev/fake0",))
+        robot = SharedRobot.from_config(driver, name="left-arm")
+        assert robot._robot is not None
+        assert robot._robot.init_args["port"] == "/dev/fake0"
+
+    def test_constructor_rejects_non_config_object(self) -> None:
         with pytest.raises(ConfigError, match="robot must be a Config mapping"):
-            SharedRobot("left-arm", robot=driver)  # type: ignore[arg-type]
+            SharedRobot("left-arm", robot=object())  # type: ignore[arg-type]
 
     def test_satisfies_robot_protocol(self) -> None:
         from physicalai.robot import Robot

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -500,6 +500,13 @@ class TestFromConfig:
         with pytest.raises(SystemExit):
             RobotRuntime.from_config(cfg_path)
 
+    def test_empty_yaml_fails_via_parser_not_type_error(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text("", encoding="utf-8")
+
+        with pytest.raises(SystemExit):
+            RobotRuntime.from_config(cfg_path)
+
     def test_returns_disconnected_runtime(self, tmp_path: Path) -> None:
         cfg_path = tmp_path / "runtime.yaml"
         cfg_path.write_text(_minimal_yaml())

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from physicalai.config import ComponentConfigError, instantiate, is_config_exportable, to_config
+from physicalai.config import ConfigError, instantiate, is_config_exportable, to_config
 
 # SO101 imports scservo_sdk at module load; keep unit tests hardware-free.
 # Use setdefault — not patch.dict(sys.modules) — because patch.dict restores by
@@ -27,7 +27,7 @@ sys.modules.setdefault("scservo_sdk", MagicMock())
 def _assert_construction_round_trip(value: object) -> dict[str, Any]:
     assert is_config_exportable(value)
     config = to_config(value)
-    wire: dict[str, Any] = json.loads(json.dumps(config))
+    wire: dict[str, Any] = json.loads(json.dumps(config.to_dict()))
     restored = instantiate(wire)
     assert type(restored) is type(value)
     assert to_config(restored) == wire
@@ -85,7 +85,7 @@ def inference_model(tmp_path: Path, _patch_adapter: MagicMock) -> Any:
 # ---------------------------------------------------------------------------
 
 
-class TestSmootherComponentConfig:
+class TestSmootherConfig:
     def test_lerp_round_trip(self) -> None:
         from physicalai.runtime import LerpSmoother
 
@@ -107,7 +107,7 @@ class TestSmootherComponentConfig:
         assert wire["init_args"] == {}
 
 
-class TestActionQueueComponentConfig:
+class TestActionQueueConfig:
     def test_chunked_bare_restores_replace_smoother(self) -> None:
         from physicalai.runtime import ChunkedActionQueue, ReplaceSmoother
 
@@ -137,7 +137,7 @@ class TestActionQueueComponentConfig:
                 return incoming
 
         queue = ChunkedActionQueue(smoother=UndecoratedSmoother())
-        with pytest.raises(ComponentConfigError, match=r"init_args\.smoother"):
+        with pytest.raises(ConfigError, match=r"init_args\.smoother"):
             to_config(queue)
 
     def test_rtc_action_queue_round_trip(self) -> None:
@@ -148,7 +148,7 @@ class TestActionQueueComponentConfig:
         assert wire["init_args"] == {}
 
 
-class TestExecutionComponentConfig:
+class TestExecutionConfig:
     def test_sync_default_omitted(self) -> None:
         from physicalai.runtime import SyncExecution
 
@@ -189,14 +189,14 @@ class TestExecutionComponentConfig:
         from physicalai.runtime import RTCExecution
 
         execution = RTCExecution(latency_tracker=MagicMock())
-        with pytest.raises(ComponentConfigError, match=r"init_args\.latency_tracker"):
+        with pytest.raises(ConfigError, match=r"init_args\.latency_tracker"):
             to_config(execution)
 
     def test_rtc_live_postprocessors_fail(self) -> None:
         from physicalai.runtime import RTCExecution
 
         execution = RTCExecution(postprocessors=[MagicMock()])
-        with pytest.raises(ComponentConfigError, match=r"init_args\.postprocessors"):
+        with pytest.raises(ConfigError, match=r"init_args\.postprocessors"):
             to_config(execution)
 
 
@@ -205,7 +205,7 @@ class TestExecutionComponentConfig:
 # ---------------------------------------------------------------------------
 
 
-class TestPolicySourceComponentConfig:
+class TestPolicySourceConfig:
     def test_model_only_omits_execution_and_queue(
         self, inference_model: Any, _patch_adapter: MagicMock
     ) -> None:
@@ -263,7 +263,7 @@ class TestPolicySourceComponentConfig:
 # ---------------------------------------------------------------------------
 
 
-class TestTeleopSourceComponentConfig:
+class TestTeleopSourceConfig:
     def test_leader_nested_round_trip(self) -> None:
         from physicalai.robot import SO101
         from physicalai.runtime import TeleopSource
@@ -297,7 +297,7 @@ class TestTeleopSourceComponentConfig:
         }
         leader = SO101(port="/dev/ttyUSB0", calibration=calibration, role="leader")
         source = TeleopSource(leader=leader, to_action=lambda obs: obs.joint_positions)
-        with pytest.raises(ComponentConfigError, match=r"init_args\.to_action"):
+        with pytest.raises(ConfigError, match=r"init_args\.to_action"):
             to_config(source)
 
 
@@ -306,7 +306,7 @@ class TestTeleopSourceComponentConfig:
 # ---------------------------------------------------------------------------
 
 
-class TestCallbackComponentConfig:
+class TestCallbackConfig:
     def test_console_round_trip(self) -> None:
         from physicalai.runtime import ConsoleCallback
 
@@ -330,7 +330,7 @@ class TestCallbackComponentConfig:
         try:
             assert is_config_exportable(cb)
             config = to_config(cb)
-            wire: dict[str, Any] = json.loads(json.dumps(config))
+            wire: dict[str, Any] = json.loads(json.dumps(config.to_dict()))
             restored = instantiate(wire)
             assert type(restored) is type(cb)
             assert to_config(restored) == wire
@@ -389,7 +389,7 @@ class TestCallbackComponentConfig:
 
         cb = AsyncCallback(UndecoratedTickCallback())
         try:
-            with pytest.raises(ComponentConfigError, match=r"init_args\.inner"):
+            with pytest.raises(ConfigError, match=r"init_args\.inner"):
                 to_config(cb)
         finally:
             cb.close()
@@ -439,7 +439,7 @@ def _make_full_runtime(inference_model: Any) -> Any:
     )
 
 
-class TestRobotRuntimeComponentConfig:
+class TestRobotRuntimeConfig:
     def test_complete_tree_instantiate_round_trip(
         self, inference_model: Any, _patch_adapter: MagicMock
     ) -> None:
@@ -474,7 +474,7 @@ class TestRobotRuntimeComponentConfig:
 
         runtime = _make_full_runtime(inference_model)
         wire = to_config(runtime)
-        # CLI nests constructor args under ``runtime:`` (not the bare ComponentConfig).
+        # CLI nests constructor args under ``runtime:`` (not the bare Config).
         # Prefer JSON for the ActionConfigFile payload — avoids PyYAML C-loader
         # interaction with ``yaml.safe_dump`` that can poison later YAML parses in
         # the same process.
@@ -495,7 +495,7 @@ class TestRobotRuntimeComponentConfig:
         assert isinstance(restored._bus._callbacks[0], ConsoleCallback)  # noqa: SLF001
         # jsonargparse may supply omitted ctor defaults; check public class_path shape
         # after a JSON boundary (strips StrEnum identity / applied defaults noise).
-        restored_wire = json.loads(json.dumps(to_config(restored)))
+        restored_wire = json.loads(json.dumps(to_config(restored).to_dict()))
         assert restored_wire["class_path"] == "physicalai.runtime.RobotRuntime"
         assert restored_wire["init_args"]["fps"] == 30.0
         assert restored_wire["init_args"]["robot"]["class_path"] == "physicalai.robot.SO101"
@@ -521,7 +521,7 @@ class TestRobotRuntimeComponentConfig:
         # The bare to_config shape (top-level class_path) — no manual rewrite
         # to ``runtime:`` needed on either load path.
         cfg_path = tmp_path / "runtime_export.json"
-        cfg_path.write_text(json.dumps(to_config(runtime)))
+        cfg_path.write_text(json.dumps(to_config(runtime).to_dict()))
 
         parser = build_parser()
         ns = parser.parse_args(["--config", str(cfg_path)])
@@ -535,13 +535,13 @@ class TestRobotRuntimeComponentConfig:
         assert via_from_config._fps == 30.0  # noqa: SLF001
 
     def test_bare_export_foreign_class_path_rejected(self, tmp_path: Path) -> None:
-        from physicalai.config import ComponentConfigError
+        from physicalai.config import ConfigError
         from physicalai.runtime import RobotRuntime
 
         cfg_path = tmp_path / "not_runtime.json"
         cfg_path.write_text(json.dumps({"class_path": "physicalai.runtime.SyncExecution", "init_args": {}}))
 
-        with pytest.raises(ComponentConfigError, match="does not resolve to"):
+        with pytest.raises(ConfigError, match="does not resolve to"):
             RobotRuntime.from_config(cfg_path)
 
     def test_omitted_cameras_and_callbacks(
@@ -586,7 +586,7 @@ class TestRobotRuntimeComponentConfig:
             action_source=PolicySource(model=inference_model),
             fps=10.0,
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.robot"):
+        with pytest.raises(ConfigError, match=r"init_args\.robot"):
             to_config(runtime)
 
     def test_undecorated_action_source_fails(self) -> None:
@@ -603,7 +603,7 @@ class TestRobotRuntimeComponentConfig:
             action_source=UndecoratedSource(),  # type: ignore[arg-type]
             fps=10.0,
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.action_source"):
+        with pytest.raises(ConfigError, match=r"init_args\.action_source"):
             to_config(runtime)
 
     def test_undecorated_camera_fails(
@@ -621,7 +621,7 @@ class TestRobotRuntimeComponentConfig:
             fps=10.0,
             cameras={"wrist": UndecoratedCamera()},  # type: ignore[dict-item]
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.cameras\.wrist"):
+        with pytest.raises(ConfigError, match=r"init_args\.cameras\.wrist"):
             to_config(runtime)
 
     def test_undecorated_callback_fails(
@@ -639,7 +639,7 @@ class TestRobotRuntimeComponentConfig:
             fps=10.0,
             callbacks=[UndecoratedCallback()],
         )
-        with pytest.raises(ComponentConfigError, match=r"init_args\.callbacks\[0\]"):
+        with pytest.raises(ConfigError, match=r"init_args\.callbacks\[0\]"):
             to_config(runtime)
 
     def test_jsonargparse_sees_original_ctor_signature(self) -> None:


### PR DESCRIPTION
## Summary

- Consolidate the shared **`physicalai.config`** package in Runtime: typed dataclass `Config`, construction recipes (`@export_config`, strict `instantiate`), plus Studio-era helpers (`FromConfig`, `@from_config`, `instantiate_obj`, serialization).
- Finish the **`ComponentConfig` → `Config`** cutover across capture/robot transport, runtime, CLI, examples, and docs.
- Add config how-to docs (`instantiate-objects`, `use-from-config`), MkDocs nav, and agent skill `physicalai-runtime-working-with-config`.
- Expand and rename unit tests under `tests/unit/config/` (including FromConfig/instantiate coverage moved from Studio).

## Motivation

Physical AI Studio must consume config from the Runtime package only. This PR makes Runtime the single owner of implementation, documentation, tests, and agent skills for `physicalai.config`, unblocking a follow-up Studio PR that removes `library/src/physicalai/config/` and bumps the `physicalai` dependency.

## Follow-ups

- **Physical AI Studio**: merge after this lands; bump `[tool.uv.sources]` / `uv.lock` to this commit and remove any remaining Studio-only config scaffolding.