### PR TITLE
fix: use correct Apache 2.0 license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -131,6 +131,9 @@
       any Contribution intentionally submitted for inclusion in the Work
       by You to the Licensor shall be under the terms and conditions of
       this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
    6. Trademarks. This License does not grant permission to use the trade
       names, trademarks, service marks, or product names of the Licensor,


### PR DESCRIPTION
Use [correct ](https://www.apache.org/licenses/LICENSE-2.0.txt)Apache 2.0 license text.