### PR TITLE
chore(fuzzing): increase fuzzing duration

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -93,10 +93,9 @@ jobs:
       - name: Run fuzzer
         id: run_fuzzer
         env:
-          # TODO: revert PR duration back to '30' once done testing longer fuzz runs.
           FUZZ_DURATION: >-
             ${{
-              github.event_name == 'pull_request' && '1800' ||
+              github.event_name == 'pull_request' && '30' ||
               github.event.inputs.duration_s || '1800'
             }}
           # Dump the Python stack trace on crashes.
@@ -111,8 +110,7 @@ jobs:
             -rss_limit_mb=2048 \
             -print_final_stats=1 \
             2>&1 | tee "fuzz_output_${{ matrix.harness }}.txt"
-        # TODO: use 15 for PR
-        timeout-minutes: ${{ github.event_name == 'pull_request' && 45 || 360 }}
+        timeout-minutes: ${{ github.event_name == 'pull_request' && 15 || 360 }}
 
       # ── Crash detection ───────────────────────────────────────────────────
       # libFuzzer writes four artifact types to the working directory:
@@ -154,7 +152,7 @@ jobs:
             slow-unit-*
             fuzz_output_${{ matrix.harness }}.txt
           if-no-files-found: warn
-          retention-days: 90
+          retention-days: 7
 
       - name: Upload diagnostic log
         if: >-
@@ -169,7 +167,7 @@ jobs:
           name: log-${{ matrix.harness }}-${{ github.run_id }}
           path: fuzz_output_${{ matrix.harness }}.txt
           if-no-files-found: warn
-          retention-days: 14
+          retention-days: 7
 
       # ── Fail the job ──────────────────────────────────────────────────────
       - name: Fail on crashes or startup failure

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -173,10 +173,13 @@ jobs:
       # ── Fail the job ──────────────────────────────────────────────────────
       - name: Fail on crashes or startup failure
         if: ${{ always() && (steps.run_fuzzer.conclusion == 'failure' || steps.crash_check.outputs.crashes_found == 'true') }}
+        env:
+          CRASHES_FOUND: ${{ steps.crash_check.outputs.crashes_found }}
+          HARNESS: ${{ matrix.harness }}
         run: |
-          if [ "${{ steps.crash_check.outputs.crashes_found }}" == "true" ]; then
-            echo "::error::Crashes detected in ${{ matrix.harness }} — see crash artifacts"
+          if [ "$CRASHES_FOUND" == "true" ]; then
+            echo "::error::Crashes detected in ${HARNESS} — see crash artifacts"
           else
-            echo "::error::Fuzzer exited non-zero without crash files in ${{ matrix.harness }} — startup failure, see diagnostic log"
+            echo "::error::Fuzzer exited non-zero without crash files in ${HARNESS} — startup failure, see diagnostic log"
           fi
           exit 1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -111,7 +111,8 @@ jobs:
             -rss_limit_mb=2048 \
             -print_final_stats=1 \
             2>&1 | tee "fuzz_output_${{ matrix.harness }}.txt"
-        timeout-minutes: 360
+        # TODO: use 15 for PR
+        timeout-minutes: ${{ github.event_name == 'pull_request' && 45 || 360 }}
 
       # ── Crash detection ───────────────────────────────────────────────────
       # libFuzzer writes four artifact types to the working directory:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - "tests/fuzz/**"
       - ".github/workflows/fuzz.yml"
+      - "src/**"
 
 permissions: {}
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       duration_s:
         description: "Fuzzing duration per target (seconds)"
-        default: "300"
+        default: "1800"
         required: false
   pull_request:
     paths:
@@ -93,10 +93,11 @@ jobs:
       - name: Run fuzzer
         id: run_fuzzer
         env:
+          # TODO: revert PR duration back to '30' once done testing longer fuzz runs.
           FUZZ_DURATION: >-
             ${{
-              github.event_name == 'pull_request' && '30' ||
-              github.event.inputs.duration_s || '120'
+              github.event_name == 'pull_request' && '1800' ||
+              github.event.inputs.duration_s || '1800'
             }}
           # Dump the Python stack trace on crashes.
           PYTHONFAULTHANDLER: "1"
@@ -110,7 +111,7 @@ jobs:
             -rss_limit_mb=2048 \
             -print_final_stats=1 \
             2>&1 | tee "fuzz_output_${{ matrix.harness }}.txt"
-        timeout-minutes: 15
+        timeout-minutes: 360
 
       # ── Crash detection ───────────────────────────────────────────────────
       # libFuzzer writes four artifact types to the working directory:


### PR DESCRIPTION
This PR increase fuzzing duration for scheduled run and `src` path as a trigger to run lightweight fuzzing on PR.
Failed CI run will be fixed in a separate PR (code issue, not fuzzer automation).