### PR TITLE
fix: dotted paths with an empty segment

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,7 +15,6 @@ on:
     paths:
       - "tests/fuzz/**"
       - ".github/workflows/fuzz.yml"
-      - "src/**"
 
 permissions: {}
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - "tests/fuzz/**"
       - ".github/workflows/fuzz.yml"
+      - "src/**"
 
 permissions: {}
 

--- a/src/physicalai/config/importing.py
+++ b/src/physicalai/config/importing.py
@@ -19,6 +19,7 @@ def import_dotted_path(path: str) -> object:
 
     Raises:
         ValueError: If no module prefix can be imported, *path* has no ``'.'``,
+            *path* contains an empty segment (leading/trailing/consecutive ``'.'``),
             or the resolved module has no attribute matching the remaining segments.
         ModuleNotFoundError: If an existing module prefix fails because a
             dependency is missing (not merely because a longer prefix is not a
@@ -29,6 +30,13 @@ def import_dotted_path(path: str) -> object:
         raise ValueError(msg)
 
     segments = path.split(".")
+    # Reject leading/trailing/consecutive dots up front — an empty segment
+    # here would produce a relative-import module name (e.g. ".foo") that
+    # makes importlib raise TypeError instead of ModuleNotFoundError.
+    if any(not segment for segment in segments):
+        msg = f"dotted path must not contain empty segments: {path!r}"
+        raise ValueError(msg)
+
     for split_index in range(len(segments), 0, -1):
         module_name = ".".join(segments[:split_index])
         try:

--- a/tests/unit/config/test_component_config.py
+++ b/tests/unit/config/test_component_config.py
@@ -282,6 +282,14 @@ class TestImportDottedPath:
         with pytest.raises(ValueError, match="could not import"):
             import_dotted_path("totally.unknown.module.Cls")
 
+    @pytest.mark.parametrize("path", [".foo", "foo.", "foo..bar", ".", ".."])
+    def test_empty_segment_raises_value_error(self, path: str) -> None:
+        # Regression test: an empty segment (e.g. a leading '.') produces a
+        # relative-import module name, which importlib rejects with TypeError
+        # instead of ModuleNotFoundError if not caught up front.
+        with pytest.raises(ValueError, match="empty segment"):
+            import_dotted_path(path)
+
 
 class TestNormalizeComponentConfig:
     def test_rejects_nan(self) -> None:


### PR DESCRIPTION
This PR fixes a fuzzer discovered crash in `import_dotted_path()`: dotted paths with an empty segment (e.g. leading/trailing/consecutive `.`, such as `.foo` or `foo..bar`) were passed straight to `importlib.import_module()`, which raises an uncaught `TypeError` for relative import style names instead of the documented `ValueError`.

