### PR TITLE
feat: add runtime.stop()

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -22,6 +22,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Ensure full git history
+        run: |
+          if git rev-parse --is-shallow-repository | grep -q true; then
+            git fetch --unshallow origin
+          fi
+
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:

--- a/docs/explanation/runtime.md
+++ b/docs/explanation/runtime.md
@@ -30,6 +30,8 @@ The runtime loop follows this general pattern:
 
 ```text
 while running:
+    if stop_requested() or duration_reached():
+        break
     robot_state, camera_frames = read_observation()
     action = action_source.update(robot_state, camera_frames, step)
     action = on_action_ready(action)  # callback hook, may transform
@@ -39,6 +41,14 @@ while running:
 ```
 
 The exact observation structure and merging strategy may change as the API stabilizes. Everything left of `action_source.update()` — deciding whether to run inference, pulling from the queue, holding the last action — is internal to the action source; `RobotRuntime` itself only ever sees one action per tick.
+
+## Stopping
+
+A stop takes effect between ticks, never inside one. The tick already underway finishes and sends its action, so the robot is never left halfway through a command. That means a stop is not instant: it lands once the current tick is done, and a tick that happens to be waiting on inference or a slow robot read takes as long as it takes.
+
+Use `runtime.stop()` when the code asking for the stop lives in the same program. Use `run(stop_event=...)` when it does not: pass any object with an `is_set()` method, and one process can stop a session running in another. The runtime checks both, so whichever comes first ends the run.
+
+Stopping is not the same as shutting down. It ends the control loop, but the robot and cameras stay connected until the context manager releases them, so one runtime can stop and run again. `last_run_reason` and the `shutdown` event's `reason` field say why a run ended.
 
 ## Execution Modes
 

--- a/docs/how-to/runtime/run-policy-on-robot.md
+++ b/docs/how-to/runtime/run-policy-on-robot.md
@@ -23,6 +23,28 @@ with runtime:
     runtime.run(duration_s=60)
 ```
 
+## Stop Without a Fixed Duration
+
+Omit `duration_s` and the run continues until something stops it. Pass a `threading.Event` as `stop_event`, run the loop on a worker thread, and set the event when you want it to finish.
+
+```python
+import threading
+
+runtime = RobotRuntime(fps=30, robot=robot, action_source=source)
+stop = threading.Event()
+
+with runtime:
+    worker = threading.Thread(target=runtime.run, kwargs={"stop_event": stop})
+    worker.start()
+    ...
+    stop.set()          # finishes the current tick, then returns
+    worker.join()
+
+print(runtime.last_run_reason)      # stop_requested
+```
+
+The event only has to provide `is_set()`, so a `multiprocessing.Event` works the same way when the session runs in a subprocess. Either way the run ends through the normal shutdown path: the `shutdown` lifecycle event fires, callbacks are flushed, and the action source is disconnected.
+
 ## From Config
 
 Write a runtime configuration file.

--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -19,7 +19,9 @@ The most important methods are shown below.
 ```python
 runtime.connect() -> None
 runtime.disconnect() -> None
-runtime.run(*, duration_s: float | None = None) -> int
+runtime.run(*, duration_s: float | None = None, stop_event: StopSignal | None = None) -> int
+runtime.stop() -> None
+runtime.last_run_reason -> RunReason | None
 ```
 
 `RobotRuntime` also supports context-manager usage so connections are cleaned up automatically. A "step" is one iteration of the control loop at `fps`: read an observation, get one action from `action_source`, and send it to the robot. `run()` returns the number of steps completed this run — there is no aggregate stats object. Other stats are read directly off the objects the caller already holds, e.g. `runtime.action_source.action_queue.total_pops` or `execution.inference_count`.
@@ -28,6 +30,27 @@ runtime.run(*, duration_s: float | None = None) -> int
 with RobotRuntime(...) as runtime:
     steps = runtime.run(duration_s=60)
 ```
+
+## Stopping a Run
+
+`stop()` is thread-safe and may be called before, during, or between runs. `run(stop_event=...)` takes any object with `is_set()`, so `threading.Event` and `multiprocessing.Event` both work. Both are polled at the top of each tick — whichever trips first ends the run, and the tick in flight still completes and sends its action.
+
+```python
+from physicalai.runtime import StopSignal   # Protocol: is_set() -> bool
+```
+
+Calling `stop()` when no run is active is remembered rather than ignored: the next `run()` sees it, returns immediately, and reports zero steps. The request is cleared once a run ends, so one runtime can serve consecutive sessions.
+
+`run()` returns the step count. `last_run_reason` reports why it ended, and the same string is emitted as `reason` in the `shutdown` lifecycle event.
+
+| `last_run_reason`  | Cause                                                         |
+| ------------------ | ------------------------------------------------------------- |
+| `stop_requested`   | `runtime.stop()` was called, or `stop_event.is_set()` is true |
+| `duration_elapsed` | `duration_s` was reached                                      |
+| `interrupted`      | `KeyboardInterrupt` (swallowed; `run()` returns normally)     |
+| `error`            | Any other exception, which then propagates to the caller      |
+
+`stop_event` is absent from the config schema and the CLI, since a live synchronisation object has no serialisable form; `physicalai run` stops via `--run.duration_s` or Ctrl+C.
 
 ## `ActionSource`
 

--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -24,7 +24,7 @@ runtime.stop() -> None
 runtime.last_run_reason -> RunReason | None
 ```
 
-`RobotRuntime` also supports context-manager usage so connections are cleaned up automatically. A "step" is one iteration of the control loop at `fps`: read an observation, get one action from `action_source`, and send it to the robot. `run()` returns the number of steps completed this run — there is no aggregate stats object. Other stats are read directly off the objects the caller already holds, e.g. `runtime.action_source.action_queue.total_pops` or `execution.inference_count`.
+`RobotRuntime` also supports context-manager usage so connections are cleaned up automatically. A "step" is one iteration of the control loop at `fps`: read an observation, get one action from `action_source`, and send it to the robot. `run()` returns the number of steps completed this run — there is no aggregate stats object. Other stats are read directly off the objects the caller already holds, e.g. `runtime.action_source.action_queue.total_pops` or `execution.inference_count`. Each `run()` starts those counters from zero, so they describe the latest run rather than a running total.
 
 ```python
 with RobotRuntime(...) as runtime:
@@ -40,6 +40,8 @@ from physicalai.runtime import StopSignal   # Protocol: is_set() -> bool
 ```
 
 Calling `stop()` when no run is active is remembered rather than ignored: the next `run()` sees it, returns immediately, and reports zero steps. The request is cleared once a run ends, so one runtime can serve consecutive sessions.
+
+Running again starts a fresh session rather than continuing the old one. Actions still queued from the previous run are dropped, because they were computed from observations that are now out of date. If a background worker is still inside the model when the next run starts, `run()` waits a moment for it and then raises `RuntimeError` if it is still busy, rather than letting two runs share one model.
 
 `run()` returns the step count. `last_run_reason` reports why it ended, and the same string is emitted as `reason` in the `shutdown` lifecycle event.
 

--- a/src/physicalai/cli/run.py
+++ b/src/physicalai/cli/run.py
@@ -122,7 +122,9 @@ def build_parser() -> ArgumentParser:
         help="Enable debug logging during startup and runtime.",
     )
     parser.add_class_arguments(RobotRuntime, "runtime")
-    parser.add_method_arguments(RobotRuntime, "run", "run")
+    # stop_event is a live in-process object with no serializable form, so it is
+    # kept out of the CLI schema; the CLI stops via --run.duration_s or Ctrl+C.
+    parser.add_method_arguments(RobotRuntime, "run", "run", skip={"stop_event"})
     return parser
 
 

--- a/src/physicalai/runtime/__init__.py
+++ b/src/physicalai/runtime/__init__.py
@@ -7,6 +7,7 @@ Public API::
 
     from physicalai.runtime import ActionSource, PolicySource, TeleopSource
     from physicalai.runtime import RobotRuntime, RuntimeCallback
+    from physicalai.runtime import RunReason, StopSignal
     from physicalai.runtime import SyncExecution, AsyncExecution, Execution, WorkerDiedError
     from physicalai.runtime import ActionQueue, ChunkedActionQueue
     from physicalai.runtime import ChunkSmoother, LerpSmoother, ReplaceSmoother
@@ -22,7 +23,7 @@ from physicalai.runtime.callbacks import (
     LowPassFilterCallback,
     RerunCallback,
 )
-from physicalai.runtime.core import RobotRuntime, RuntimeCallback
+from physicalai.runtime.core import RobotRuntime, RunReason, RuntimeCallback, StopSignal
 from physicalai.runtime.events import InferenceEvent, LifecycleEvent, MetricsEvent, TickEvent
 from physicalai.runtime.execution import (
     ActionQueue,
@@ -57,7 +58,9 @@ __all__ = [
     "ReplaceSmoother",
     "RerunCallback",
     "RobotRuntime",
+    "RunReason",
     "RuntimeCallback",
+    "StopSignal",
     "SyncExecution",
     "TeleopSource",
     "TickEvent",

--- a/src/physicalai/runtime/action_sources/policy.py
+++ b/src/physicalai/runtime/action_sources/policy.py
@@ -77,8 +77,12 @@ class PolicySource(ActionSource):
             self._session_id = session_id
             self._execution.set_bus(bus, session_id)
             self._execution.start(self._model, self._action_queue)
-            self._action_queue.clear()
+            # reset(): also zeroes total_pops/total_holds, so the
+            # queue's counters describe this run rather than every run so far.
+            self._action_queue.reset()
             self._last = None
+            # Re-seed on every run. connect() has just emptied the queue
+            self._warmed_up = False
 
     def update(self, robot_state: RobotObservation, camera_frames: Mapping[str, Frame], step: int) -> np.ndarray:
         """Maybe request inference and return the next action.

--- a/src/physicalai/runtime/core.py
+++ b/src/physicalai/runtime/core.py
@@ -362,6 +362,15 @@ class RobotRuntime:
             while True:
                 if self._stop.is_set() or (stop_event is not None and stop_event.is_set()):
                     reason = "stop_requested"
+                    # Fires after the last tick. Callbacks may take control of the robot from this point.
+                    self._bus.emit_lifecycle(
+                        LifecycleEvent(
+                            session_id=self._session_id,
+                            timestamp=time.time(),
+                            event="stop_requested",
+                            metadata={"step": step},
+                        )
+                    )
                     break
                 if duration_s is not None and step * goal_time >= duration_s:
                     reason = "duration_elapsed"

--- a/src/physicalai/runtime/core.py
+++ b/src/physicalai/runtime/core.py
@@ -6,10 +6,11 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, Self
+from typing import TYPE_CHECKING, Literal, Protocol, Self
 
 from physicalai.capture.errors import CaptureError
 from physicalai.config import export_config
@@ -35,6 +36,9 @@ _MAX_OBS_RETRIES = 3
 _MAX_SEND_RETRIES = 2
 _RETRY_BACKOFF_S = 0.001
 _GOAL_TIME_TICKS = 3
+
+RunReason = Literal["stop_requested", "duration_elapsed", "interrupted", "error"]
+"""Why a :meth:`RobotRuntime.run` call ended."""
 
 
 def _unwrap_runtime_document(document: dict[str, Any], *, target: type) -> dict[str, Any]:
@@ -71,6 +75,24 @@ def _unwrap_runtime_document(document: dict[str, Any], *, target: type) -> dict[
         )
         raise ConfigError(msg)
     return {"runtime": dict(config["init_args"])}
+
+
+class StopSignal(Protocol):
+    """A stop flag the control loop polls once per tick.
+
+    Anything exposing a thread- or process-safe ``is_set()`` satisfies it, so
+    ``threading.Event`` and ``multiprocessing.Event`` both work unchanged. Duck
+    typing is the point: a parent process can end a session process directly,
+    with no mailbox round-trip, and the loop keeps its no-``isinstance`` rule.
+    """
+
+    def is_set(self) -> bool:
+        """Report whether a stop has been requested.
+
+        Returns:
+            ``True`` once a stop has been requested.
+        """
+        ...
 
 
 class RuntimeCallback(Protocol):
@@ -131,6 +153,11 @@ class RobotRuntime:
         self._transient_errors: int = 0
         self._session_id: str = ""
         self._last_tick_stale: bool = False
+        # Cleared in _shutdown(), not _reset_session(): _reset_session() runs at
+        # the top of run(), so clearing there would drop a stop() that landed
+        # between connect() and run() and the session would never end.
+        self._stop = threading.Event()
+        self._last_run_reason: RunReason | None = None
 
     @property
     def robot(self) -> Robot:
@@ -151,6 +178,22 @@ class RobotRuntime:
         after ``run()`` returns.
         """
         return self._action_source
+
+    @property
+    def last_run_reason(self) -> RunReason | None:
+        """Why the most recent :meth:`run` ended.
+
+        Also emitted as ``reason`` in the ``shutdown`` lifecycle event, so
+        telemetry sinks receive it without the caller wiring up a callback.
+
+        Reports ``None`` before any run has started and while a run is in
+        flight. A :meth:`run` rejected before it starts — the not-connected
+        ``RuntimeError`` — leaves the previous run's value untouched.
+
+        Returns:
+            The reason the last started run ended, or ``None``.
+        """
+        return self._last_run_reason
 
     def connect(self) -> None:
         """Connect robot and cameras.
@@ -241,12 +284,39 @@ class RobotRuntime:
         document = _unwrap_runtime_document(document, target=cls)
         parser = ArgumentParser()
         parser.add_class_arguments(cls, "runtime")
-        parser.add_method_arguments(cls, "run", "run")
+        # stop_event is a live in-process object with no serializable form, so
+        # it stays out of the config schema entirely.
+        parser.add_method_arguments(cls, "run", "run", skip={"stop_event"})
         ns = parser.parse_object(document)
         return parser.instantiate(ns).runtime
 
-    def run(self, *, duration_s: float | None = None) -> int:
+    def stop(self) -> None:
+        """Request the loop to exit after the current tick. Thread-safe.
+
+        The tick already in flight finishes and its action is still sent, so the
+        robot is never left mid-command. Safe to call before :meth:`run` (that
+        run then exits after zero steps), from another thread while :meth:`run`
+        is in flight, or on an idle runtime. The flag clears once the run ends,
+        so the runtime stays reusable.
+
+        Distinct from ``Execution.stop()`` (tear down the inference worker) and
+        ``ActionSource.disconnect()`` (release source-owned resources): this
+        only asks the control loop to finish.
+        """
+        self._stop.set()
+
+    def run(self, *, duration_s: float | None = None, stop_event: StopSignal | None = None) -> int:
         """Run the control loop.
+
+        Exits on the first of: a stop request (:meth:`stop` or *stop_event*),
+        *duration_s* elapsing, ``KeyboardInterrupt``, or a propagating
+        exception. :attr:`last_run_reason` records which one it was.
+
+        Args:
+            duration_s: Maximum duration in seconds. ``None`` runs until stopped.
+            stop_event: External stop flag polled once per tick, honoured in
+                addition to :meth:`stop`. Any object with ``is_set()`` works,
+                ``multiprocessing.Event`` included — see :class:`StopSignal`.
 
         Returns:
             Number of steps completed this run.
@@ -262,27 +332,39 @@ class RobotRuntime:
             raise RuntimeError(msg)
 
         self._reset_session()
-        self._action_source.connect(bus=self._bus, session_id=self._session_id)
-        self._bus.emit_lifecycle(
-            LifecycleEvent(
-                session_id=self._session_id,
-                timestamp=time.time(),
-                event="start",
-                metadata={
-                    "fps": self._fps,
-                    "duration_s": duration_s,
-                    "cameras": list(self._cameras.keys()),
-                    "joint_names": self._robot.joint_names,
-                },
-            )
-        )
 
         goal_time = 1.0 / self._fps
         step = 0
+        # Every normal exit overwrites this, so only a propagating exception
+        # leaves "error" in place — the shutdown event then reports the truth
+        # instead of inheriting whichever normal reason happened to be set.
+        reason: RunReason = "error"
 
+        # Source connect and the start event sit inside the try so a failure
+        # there still runs _shutdown(): otherwise the stop flag would survive
+        # into the next run() and silently zero-step every later session.
         try:
+            self._action_source.connect(bus=self._bus, session_id=self._session_id)
+            self._bus.emit_lifecycle(
+                LifecycleEvent(
+                    session_id=self._session_id,
+                    timestamp=time.time(),
+                    event="start",
+                    metadata={
+                        "fps": self._fps,
+                        "duration_s": duration_s,
+                        "cameras": list(self._cameras.keys()),
+                        "joint_names": self._robot.joint_names,
+                    },
+                )
+            )
+
             while True:
+                if self._stop.is_set() or (stop_event is not None and stop_event.is_set()):
+                    reason = "stop_requested"
+                    break
                 if duration_s is not None and step * goal_time >= duration_s:
+                    reason = "duration_elapsed"
                     break
 
                 loop_start = time.perf_counter()
@@ -311,17 +393,23 @@ class RobotRuntime:
                 step += 1
 
         except KeyboardInterrupt:
+            reason = "interrupted"
             logger.info("Interrupted by user")
         except WorkerDiedError:
             logger.exception("Worker died during runtime")
             raise
         finally:
-            self._shutdown(step)
+            self._shutdown(step, reason=reason)
 
         return step
 
     def _reset_session(self) -> None:
-        """Reset all session-scoped state for a fresh run."""
+        """Reset all session-scoped state for a fresh run.
+
+        Deliberately leaves ``self._stop`` alone: this runs at the top of
+        ``run()``, so clearing the flag here would discard a ``stop()`` that
+        arrived between ``connect()`` and ``run()``. ``_shutdown()`` clears it.
+        """
         # Telemetry/log correlation id only (ties together events from one run()
         # call), not a security token or capability.
         self._session_id = uuid.uuid4().hex[:8]
@@ -331,6 +419,7 @@ class RobotRuntime:
         self._stale_obs_ticks = 0
         self._transient_errors = 0
         self._last_tick_stale = False
+        self._last_run_reason = None
 
     @staticmethod
     def _tick_sleep(loop_start: float, goal_time: float) -> tuple[float, float]:
@@ -474,24 +563,50 @@ class RobotRuntime:
             last_error,
         )
 
-    def _shutdown(self, step: int) -> None:
+    def _disconnect_and_log_errors(self) -> None:
+        """Release action-source resources, logging rather than raising on failure.
+
+        Only ``Exception`` is swallowed. A ``BaseException`` — a Ctrl+C landing
+        mid-teardown — still propagates; the caller's ``finally`` chain keeps the
+        rest of shutdown intact.
+        """
         try:
             self._action_source.disconnect()
         except Exception:
             logger.exception("Action source disconnect failed")
 
-        self._bus.emit_lifecycle(
-            LifecycleEvent(
-                session_id=self._session_id,
-                timestamp=time.time(),
-                event="shutdown",
-                metadata={
-                    "steps": step,
-                    "transient_errors": self._transient_errors,
-                    "stale_obs_ticks": self._stale_obs_ticks,
-                },
+    def _emit_shutdown(self, step: int, *, reason: RunReason) -> None:
+        """Emit the shutdown lifecycle event, then flush every callback."""
+        try:
+            self._bus.emit_lifecycle(
+                LifecycleEvent(
+                    session_id=self._session_id,
+                    timestamp=time.time(),
+                    event="shutdown",
+                    metadata={
+                        "steps": step,
+                        "reason": reason,
+                        "transient_errors": self._transient_errors,
+                        "stale_obs_ticks": self._stale_obs_ticks,
+                    },
+                )
             )
-        )
-        self._bus.close()
+        finally:
+            # The bus isolates Exception but deliberately lets BaseException
+            # through, so the flush needs its own guarantee — otherwise a Ctrl+C
+            # in on_lifecycle loses the session's buffered telemetry.
+            self._bus.close()
 
-        logger.info("Shutdown complete — %d steps", step)
+    def _shutdown(self, step: int, *, reason: RunReason) -> None:
+        self._last_run_reason = reason
+        try:
+            self._disconnect_and_log_errors()
+        finally:
+            try:
+                self._emit_shutdown(step, reason=reason)
+            finally:
+                # Outermost guarantee: whatever a callback throws — including a
+                # Ctrl+C the bus does not swallow — the stop flag must not
+                # survive into the next run() and silently zero-step it.
+                self._stop.clear()
+                logger.info("Shutdown complete — %d steps (%s)", step, reason)

--- a/src/physicalai/runtime/execution/async_execution.py
+++ b/src/physicalai/runtime/execution/async_execution.py
@@ -66,6 +66,17 @@ class AsyncExecution(Execution):
         """Bind model/queue and spawn inference thread."""
         self._model = model
         self._queue = cast("ChunkedActionQueue", action_queue)
+        self._stop_event.clear()
+        self._obs_ready.clear()
+        self._inference_count = 0
+        with self._lock:
+            # A stale observation would be inferred on as if it were current.
+            self._obs_slot = None
+            self._running_inference = False
+            self._request_time = 0.0
+            self._pops_at_request = 0
+        # A death from the previous run must not fail this one.
+        self._death_cause = None
         self._thread = threading.Thread(target=self._run, name="InferenceThread", daemon=True)
         self._thread.start()
 

--- a/src/physicalai/runtime/execution/async_execution.py
+++ b/src/physicalai/runtime/execution/async_execution.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_JOIN_TIMEOUT_S: float = 10.0
+_STRAGGLER_GRACE_S: float = 2.0
+
 
 @export_config(class_path="physicalai.runtime.AsyncExecution")
 class AsyncExecution(Execution):
@@ -63,11 +66,26 @@ class AsyncExecution(Execution):
         self._session_id: str = ""
 
     def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
-        """Bind model/queue and spawn inference thread."""
+        """Bind model/queue and spawn a worker owned by this run.
+
+        Each run gets fresh stop and wake events, passed straight to its worker.
+        A straggler from a previous run therefore keeps its own, already-set stop
+        event: this ``start()`` cannot revive it, it cannot steal the new
+        worker's wake-up, and it discards its in-flight result instead of pushing
+        it into this run's queue.
+
+        Raises:
+            RuntimeError: If the previous worker is still inside the model after
+                a short grace period. Running anyway would put two threads
+                through one ``InferenceModel``, which is not synchronised.
+        """  # noqa: DOC502 — raised by the delegated _await_previous_worker(), but callers see it here.
+        self._await_previous_worker()
+
         self._model = model
         self._queue = cast("ChunkedActionQueue", action_queue)
-        self._stop_event.clear()
-        self._obs_ready.clear()
+        # New objects, not clear(): a straggler keeps its own set stop event.
+        self._stop_event = threading.Event()
+        self._obs_ready = threading.Event()
         self._inference_count = 0
         with self._lock:
             # A stale observation would be inferred on as if it were current.
@@ -77,8 +95,41 @@ class AsyncExecution(Execution):
             self._pops_at_request = 0
         # A death from the previous run must not fail this one.
         self._death_cause = None
-        self._thread = threading.Thread(target=self._run, name="InferenceThread", daemon=True)
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(self._stop_event, self._obs_ready),
+            name="InferenceThread",
+            daemon=True,
+        )
         self._thread.start()
+
+    def _await_previous_worker(self) -> None:
+        """Wait briefly for a worker that outlived ``stop()``, then refuse.
+
+        ``InferenceModel`` is not synchronised, so letting a new run start while
+        a straggler is still inside the model would put two threads through one
+        model instance. Failing loudly here beats corrupting both.
+
+        Raises:
+            RuntimeError: If the straggler is still running after the grace period.
+        """
+        previous = self._thread
+        if previous is None or not previous.is_alive():
+            return
+
+        logger.warning(
+            "Previous inference worker is still running — waiting up to %.1fs for it to exit.",
+            _STRAGGLER_GRACE_S,
+        )
+        previous.join(timeout=_STRAGGLER_GRACE_S)
+        if previous.is_alive():
+            msg = (
+                "Previous inference worker is still inside the model after "
+                f"{_JOIN_TIMEOUT_S + _STRAGGLER_GRACE_S:.1f}s. Refusing to start a second "
+                "worker: InferenceModel is not safe for concurrent use. Wait for the "
+                "inference to finish, or build a new execution with its own model."
+            )
+            raise RuntimeError(msg)
 
     def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
         """Run one inference in main thread, seed queue, discover chunk_size.
@@ -119,11 +170,23 @@ class AsyncExecution(Execution):
             self._obs_ready.set()
 
     def stop(self) -> None:
-        """Signal thread and join with timeout."""
+        """Signal the worker and join it, with a timeout.
+
+        Best-effort by nature: a worker inside a blocking inference cannot be
+        preempted. It is left to finish and discard its result, so this never
+        raises — teardown must not fail. A worker that outlives the join is
+        logged, and the next :meth:`start` refuses to run alongside it.
+        """
         if self._thread is not None:
             self._stop_event.set()
             self._obs_ready.set()
-            self._thread.join(timeout=10.0)
+            self._thread.join(timeout=_JOIN_TIMEOUT_S)
+            if self._thread.is_alive():
+                logger.warning(
+                    "Inference worker did not exit within %.1fs — still inside the model. "
+                    "It will discard its result and exit on its own.",
+                    _JOIN_TIMEOUT_S,
+                )
 
     @property
     def chunk_size(self) -> int:
@@ -158,13 +221,27 @@ class AsyncExecution(Execution):
             self._running_inference = False
         logger.warning("Force reset — cleared stuck inference state")
 
-    def _run(self) -> None:
-        try:
-            while not self._stop_event.is_set():
-                self._obs_ready.wait()
-                self._obs_ready.clear()
+    def _run(self, stop_event: threading.Event, obs_ready: threading.Event) -> None:
+        """Worker loop for one run.
 
-                if self._stop_event.is_set():
+        Takes its own events rather than reading ``self``, so a worker that
+        outlives ``stop()`` keeps observing its own set stop event even after a
+        later ``start()`` has installed fresh ones.
+
+        Nothing propagates out of this thread.
+
+        Raises:
+            RuntimeError: If the model or queue is unset. Captured into
+                ``_death_cause`` rather than leaving this thread; the control
+                thread surfaces it as ``WorkerDiedError`` on the next
+                ``maybe_request()``.
+        """
+        try:
+            while not stop_event.is_set():
+                obs_ready.wait()
+                obs_ready.clear()
+
+                if stop_event.is_set():
                     return
 
                 with self._lock:
@@ -179,6 +256,12 @@ class AsyncExecution(Execution):
                 t0 = time.perf_counter()
                 actions = self._model.predict_action_chunk(obs)
                 latency = time.perf_counter() - t0
+
+                if stop_event.is_set():
+                    # This run ended while the inference was in flight. The
+                    # actions describe an observation from a finished session,
+                    # so they must not reach a later run's queue.
+                    return
 
                 # Offset = actions actually sent since the observation was
                 # captured. This is exact (no fps estimation error).

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -35,6 +35,7 @@ _IDLE_SLEEP_S: float = 0.005
 _ERROR_RETRY_DELAY_S: float = 0.5
 _MAX_CONSECUTIVE_ERRORS: int = 10
 _JOIN_TIMEOUT_S: float = 5.0
+_STRAGGLER_GRACE_S: float = 2.0
 
 
 @export_config(class_path="physicalai.runtime.RTCExecution")
@@ -167,7 +168,16 @@ class RTCExecution(Execution):
         Args:
             model: The inference model.
             action_queue: The RTC dual-track action queue.
-        """
+
+        Raises:
+            RuntimeError: If the previous worker is still inside the model after
+                a short grace period. Running anyway would put two threads
+                through one ``InferenceModel``, which is not synchronised.
+        """  # noqa: DOC502 — raised by the delegated _await_previous_worker(), but callers see it here.
+        # First, before any state is touched: a refusal here must not leave the
+        # execution half-configured or the model stripped of its postprocessors.
+        self._await_previous_worker()
+
         self._model = model
         self._rtc_queue = action_queue
 
@@ -206,8 +216,11 @@ class RTCExecution(Execution):
             self._postprocessors = model.postprocessors
             model.postprocessors = []  # Clear from model so they aren't run twice
 
-        self._stop_event.clear()
-        self._first_chunk_ready.clear()
+        # Fresh events rather than clearing the shared ones: a worker that
+        # outlived stop() keeps its own set stop event, so it cannot be revived
+        # by this start(), and its in-flight chunk is discarded.
+        self._stop_event = threading.Event()
+        self._first_chunk_ready = threading.Event()
         self._inference_count = 0
         # A death from the previous run must not fail this one, and a stale
         # observation must not be inferred on as if it were current.
@@ -216,6 +229,7 @@ class RTCExecution(Execution):
             self._obs_slot = None
         self._thread = threading.Thread(
             target=self._rtc_loop,
+            args=(self._stop_event, self._first_chunk_ready),
             name="rtc-inference",
             daemon=True,
         )
@@ -278,22 +292,67 @@ class RTCExecution(Execution):
             self._obs_slot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
 
     def stop(self) -> None:
-        """Signal shutdown and join the background thread."""
+        """Signal the worker and join it, with a timeout.
+
+        Best-effort by nature: a worker inside a blocking inference cannot be
+        preempted. It is left to finish and discard its chunk, so this never
+        raises — teardown must not fail. A worker that outlives the join keeps
+        its reference here so the next :meth:`start` can refuse to run
+        alongside it.
+        """
         if self._thread is not None:
             self._stop_event.set()
             self._thread.join(timeout=_JOIN_TIMEOUT_S)
             if self._thread.is_alive():
-                logger.warning("RTC thread did not join within %.1fs", _JOIN_TIMEOUT_S)
-            self._thread = None
+                logger.warning(
+                    "RTC worker did not exit within %.1fs — still inside the model. "
+                    "It will discard its chunk and exit on its own.",
+                    _JOIN_TIMEOUT_S,
+                )
+            else:
+                self._thread = None
             logger.info("RTCExecution stopped (%d inferences)", self._inference_count)
 
-    def _rtc_loop(self) -> None:
-        """Background loop: infer chunks and merge into queue."""
+    def _await_previous_worker(self) -> None:
+        """Wait briefly for a worker that outlived ``stop()``, then refuse.
+
+        ``InferenceModel`` is not synchronised, so letting a new run start while
+        a straggler is still inside the model would put two threads through one
+        model instance. Failing loudly here beats corrupting both.
+
+        Raises:
+            RuntimeError: If the straggler is still running after the grace period.
+        """
+        previous = self._thread
+        if previous is None or not previous.is_alive():
+            return
+
+        logger.warning(
+            "Previous RTC worker is still running — waiting up to %.1fs for it to exit.",
+            _STRAGGLER_GRACE_S,
+        )
+        previous.join(timeout=_STRAGGLER_GRACE_S)
+        if previous.is_alive():
+            msg = (
+                "Previous RTC worker is still inside the model after "
+                f"{_JOIN_TIMEOUT_S + _STRAGGLER_GRACE_S:.1f}s. Refusing to start a second "
+                "worker: InferenceModel is not safe for concurrent use. Wait for the "
+                "inference to finish, or build a new execution with its own model."
+            )
+            raise RuntimeError(msg)
+
+    def _rtc_loop(self, stop_event: threading.Event, first_chunk_ready: threading.Event) -> None:
+        """Background loop for one run: infer chunks and merge into queue.
+
+        Takes its own events rather than reading ``self``, so a worker that
+        outlives ``stop()`` keeps observing its own set stop event even after a
+        later ``start()`` has installed fresh ones.
+        """
         assert self._model is not None  # noqa: S101
         assert self._rtc_queue is not None  # noqa: S101
         consecutive_errors = 0
 
-        while not self._stop_event.is_set():
+        while not stop_event.is_set():
             # Only re-infer when queue is running low
             if not self._rtc_queue.below_threshold(self.queue_threshold):
                 time.sleep(_IDLE_SLEEP_S)
@@ -334,6 +393,12 @@ class RTCExecution(Execution):
                 time.sleep(_ERROR_RETRY_DELAY_S)
                 continue
 
+            if stop_event.is_set():
+                # This run ended while the inference was in flight. The chunk
+                # describes an observation from a finished session, so it must
+                # not reach a later run's queue.
+                return
+
             self._inference_count += 1
             self._lifetime_inferences += 1
 
@@ -367,7 +432,7 @@ class RTCExecution(Execution):
                 processed_actions,
                 action_index_before_inference=action_index_before,
             )
-            self._first_chunk_ready.set()
+            first_chunk_ready.set()
 
             # Emit inference event so callbacks (e.g. RerunCallback) can
             # plot predicted future actions.

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -130,6 +130,10 @@ class RTCExecution(Execution):
         self._thread: threading.Thread | None = None
         self._death_cause: BaseException | None = None
         self._inference_count: int = 0
+        # Separate from _inference_count, which restarts each run: model
+        # compilation overhead is paid once per process, so the cold-start
+        # latency discard must not re-arm on a second run.
+        self._lifetime_inferences: int = 0
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
 
@@ -204,6 +208,12 @@ class RTCExecution(Execution):
 
         self._stop_event.clear()
         self._first_chunk_ready.clear()
+        self._inference_count = 0
+        # A death from the previous run must not fail this one, and a stale
+        # observation must not be inferred on as if it were current.
+        self._death_cause = None
+        with self._obs_lock:
+            self._obs_slot = None
         self._thread = threading.Thread(
             target=self._rtc_loop,
             name="rtc-inference",
@@ -325,14 +335,17 @@ class RTCExecution(Execution):
                 continue
 
             self._inference_count += 1
+            self._lifetime_inferences += 1
 
             # Reset latency tracker after warmup inferences to discard
-            # compilation overhead (e.g. OpenVINO first-run latency).
-            if self._inference_count <= self._warmup_inferences and self._latency_tracker is not None:
+            # compilation overhead (e.g. OpenVINO first-run latency). Gated on
+            # the lifetime count: the model is compiled once, so a second run
+            # must not discard its perfectly good samples.
+            if self._lifetime_inferences <= self._warmup_inferences and self._latency_tracker is not None:
                 self._latency_tracker.on_reset()
                 logger.info(
                     "Warmup inference %d/%d complete (%.2fs) — latency tracker reset",
-                    self._inference_count,
+                    self._lifetime_inferences,
                     self._warmup_inferences,
                     elapsed,
                 )

--- a/src/physicalai/runtime/execution/sync.py
+++ b/src/physicalai/runtime/execution/sync.py
@@ -46,9 +46,10 @@ class SyncExecution(Execution):
         self._session_id: str = ""
 
     def start(self, model: InferenceModel, action_queue: ActionQueue) -> None:
-        """Bind model and queue."""
+        """Bind model and queue, and start a fresh inference count for this run."""
         self._model = model
         self._queue = cast("ChunkedActionQueue", action_queue)
+        self._inference_count = 0
 
     def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
         """Run one inference, seed queue, discover chunk_size.

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -190,7 +190,7 @@ class TestRunParser:
         assert "fps: 30" in output
         assert "FakeRobot" in output
 
-    def test_stop_event_absent_from_schema(self) -> None:
+    def test_stop_event_absent_from_cli_surface(self) -> None:
         """``run(stop_event=...)`` is a live object, so it is skipped from the CLI.
 
         Without ``skip={"stop_event"}`` jsonargparse adds ``run.stop_event`` and
@@ -201,9 +201,6 @@ class TestRunParser:
         dests = {action.dest for action in parser._actions}  # noqa: SLF001
         assert "run.duration_s" in dests
         assert not any(dest.startswith("run.stop_event") for dest in dests)
-
-    def test_stop_event_absent_from_help_and_print_config(self) -> None:
-        parser = run_module.build_parser()
         assert "stop_event" not in parser.format_help()
 
         buf = io.StringIO()

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -190,6 +190,27 @@ class TestRunParser:
         assert "fps: 30" in output
         assert "FakeRobot" in output
 
+    def test_stop_event_absent_from_schema(self) -> None:
+        """``run(stop_event=...)`` is a live object, so it is skipped from the CLI.
+
+        Without ``skip={"stop_event"}`` jsonargparse adds ``run.stop_event`` and
+        ``run.stop_event.help``, and the dispatcher then forwards
+        ``stop_event=None`` into ``run()``.
+        """
+        parser = run_module.build_parser()
+        dests = {action.dest for action in parser._actions}  # noqa: SLF001
+        assert "run.duration_s" in dests
+        assert not any(dest.startswith("run.stop_event") for dest in dests)
+
+    def test_stop_event_absent_from_help_and_print_config(self) -> None:
+        parser = run_module.build_parser()
+        assert "stop_event" not in parser.format_help()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf), pytest.raises(SystemExit):
+            parser.parse_args([*_MINIMAL_ARGV, "--print_config"])
+        assert "stop_event" not in buf.getvalue()
+
     def test_parses_minimal_argv(self) -> None:
         parser = run_module.build_parser()
         cfg = parser.parse_args(list(_MINIMAL_ARGV))
@@ -344,6 +365,18 @@ class TestRunDispatcher:
             run_module.run(parser, cfg)
 
         fake.run.assert_called_once_with(duration_s=None)
+
+    def test_never_forwards_stop_event_to_run(self) -> None:
+        """The dispatcher splats ``cfg.run``, so a leaked key would reach run()."""
+        parser = run_module.build_parser()
+        cfg = parser.parse_args([*_MINIMAL_ARGV, "--run.duration_s=3"])
+        fake = self._fake_runtime(0)
+
+        with patch.object(parser, "instantiate") as inst:
+            inst.return_value = MagicMock(runtime=fake)
+            run_module.run(parser, cfg)
+
+        assert "stop_event" not in fake.run.call_args.kwargs
 
     def test_configures_logging_before_instantiate(self) -> None:
         parser = run_module.build_parser()

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -309,3 +309,200 @@ class TestRTCExecutionObsSlot:
                 assert ex._obs_slot is None  # noqa: SLF001
         finally:
             ex.stop()
+
+
+class TestRestartAfterStop:
+    """``start()`` must hand back a usable execution after a previous ``stop()``.
+
+    A runtime can be stopped and run again, which calls ``stop()`` then
+    ``start()`` on the same execution object. Per-session state left over from
+    the previous run has to be cleared here, or the second run misbehaves
+    silently rather than failing loudly.
+    """
+
+    def test_async_revives_worker_after_stop(self) -> None:
+        """The worker must actually infer again, not exit on a stale stop flag."""
+        chunk = np.random.randn(6, 4).astype(np.float32)
+        model = _make_mock_model(chunk)
+        queue = ChunkedActionQueue()
+
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        ex.warmup({"state": np.zeros(4, dtype=np.float32)})
+        ex.stop()
+
+        # Second session on the same object.
+        queue.clear()
+        ex.start(model, queue)
+        try:
+            assert ex._thread is not None  # noqa: SLF001
+            assert ex._thread.is_alive(), "worker exited immediately on a stale _stop_event"  # noqa: SLF001
+            # start() begins a fresh count, so any inference below is this session's.
+            assert ex.inference_count == 0
+
+            ex.warmup({"state": np.zeros(4, dtype=np.float32)})
+            for _ in range(len(chunk)):
+                queue.pop()
+            ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})
+
+            deadline = time.perf_counter() + 5.0
+            while ex.inference_count == 0 and time.perf_counter() < deadline:
+                time.sleep(0.01)
+
+            assert ex.inference_count >= 1, "worker never ran inference in the second session"
+        finally:
+            ex.stop()
+
+    def test_async_start_clears_stale_death_cause(self) -> None:
+        """A worker death in run 1 must not fail run 2."""
+        model = _make_mock_model()
+        queue = ChunkedActionQueue()
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        ex.stop()
+        ex._death_cause = RuntimeError("died in the previous session")  # noqa: SLF001
+
+        ex.start(model, queue)
+        try:
+            assert ex._death_cause is None  # noqa: SLF001
+            ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})  # must not raise
+        finally:
+            ex.stop()
+
+    def test_async_start_drops_stale_observation(self) -> None:
+        """A leftover observation must not be inferred on as if it were current."""
+        model = _make_mock_model()
+        queue = ChunkedActionQueue()
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        ex.stop()
+        with ex._lock:  # noqa: SLF001
+            ex._obs_slot = {"state": np.full(4, 99.0, dtype=np.float32)}  # noqa: SLF001
+            ex._running_inference = True  # noqa: SLF001
+
+        ex.start(model, queue)
+        try:
+            with ex._lock:  # noqa: SLF001
+                assert ex._obs_slot is None  # noqa: SLF001
+                assert ex._running_inference is False  # noqa: SLF001
+            # _busy is derived from both, so a submission is possible again.
+            assert ex._busy is False  # noqa: SLF001
+        finally:
+            ex.stop()
+
+    def test_rtc_start_clears_stale_death_cause_and_observation(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        chunk_size, action_dim = 20, 3
+        model = MagicMock()
+        model.chunk_size = chunk_size
+        model.postprocessors = []
+        model.return_value = {"action": np.random.randn(1, chunk_size, action_dim).astype(np.float32)}
+
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=chunk_size, max_action_dim=action_dim, fps=30.0)
+        ex.start(model, queue)
+        ex.stop()
+        ex._death_cause = RuntimeError("died in the previous session")  # noqa: SLF001
+        with ex._obs_lock:  # noqa: SLF001
+            ex._obs_slot = {"state": np.full(action_dim, 99.0, dtype=np.float32)}  # noqa: SLF001
+
+        ex.start(model, queue)
+        try:
+            assert ex._death_cause is None  # noqa: SLF001
+            with ex._obs_lock:  # noqa: SLF001
+                assert ex._obs_slot is None  # noqa: SLF001
+            # warmup() blocks on _first_chunk_ready, which start() also reset.
+            ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
+        finally:
+            ex.stop()
+
+
+class TestInferenceCountIsPerRun:
+    """``inference_count`` describes one run, matching the queue's counters.
+
+    ``docs/reference/runtime-api.md`` points callers at both
+    ``action_queue.total_pops`` and ``execution.inference_count`` for run
+    stats, so the two must agree on scope.
+    """
+
+    def test_sync_resets_on_start(self) -> None:
+        model = _make_mock_model()
+        queue = ChunkedActionQueue()
+        ex = SyncExecution()
+
+        ex.start(model, queue)
+        ex.warmup({"state": np.zeros(4, dtype=np.float32)})
+        for _ in range(6):
+            queue.pop()
+        ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})
+        assert ex.inference_count == 1
+
+        ex.start(model, queue)
+        assert ex.inference_count == 0
+
+    def test_async_resets_on_start(self) -> None:
+        model = _make_mock_model()
+        queue = ChunkedActionQueue()
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        ex._inference_count = 5  # noqa: SLF001 — stand in for a completed run
+        ex.stop()
+
+        ex.start(model, queue)
+        try:
+            assert ex.inference_count == 0
+        finally:
+            ex.stop()
+
+    def test_rtc_resets_stat_but_not_the_cold_start_gate(self) -> None:
+        """The public stat restarts; the compilation-warmup gate does not.
+
+        Model compilation is paid once per process, so a second run must not
+        re-discard its latency samples as though they were cold. Asserted on
+        the gated behaviour — whether ``on_reset()`` fires — not just on the
+        counters, so wiring the gate back to the per-run count is caught.
+        """
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        chunk_size, action_dim = 20, 3
+        model = MagicMock()
+        model.chunk_size = chunk_size
+        model.postprocessors = []
+        model.return_value = {"action": np.random.randn(1, chunk_size, action_dim).astype(np.float32)}
+
+        tracker = MagicMock()
+        tracker.compute_delay.return_value = 0
+        queue = RTCActionQueue()
+        ex = RTCExecution(
+            chunk_size=chunk_size,
+            max_action_dim=action_dim,
+            fps=30.0,
+            latency_tracker=tracker,
+            warmup_inferences=1,
+        )
+
+        ex.start(model, queue)
+        try:
+            ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
+            assert ex.inference_count >= 1
+            lifetime_after_first = ex._lifetime_inferences  # noqa: SLF001
+            assert lifetime_after_first >= 1
+            assert tracker.on_reset.call_count == 1, "cold-start discard should fire once"
+        finally:
+            ex.stop()
+
+        tracker.on_reset.reset_mock()
+        ex.start(model, queue)
+        try:
+            # Public stat restarts...
+            assert ex.inference_count == 0
+            # ...while the lifetime count carries on, keeping the gate closed.
+            assert ex._lifetime_inferences == lifetime_after_first  # noqa: SLF001
+
+            queue.clear()
+            ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
+            assert ex.inference_count >= 1
+            tracker.on_reset.assert_not_called()
+        finally:
+            ex.stop()

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -311,122 +313,83 @@ class TestRTCExecutionObsSlot:
             ex.stop()
 
 
+def _blocking_model(entered: threading.Event, release: threading.Event, rows: int = 6) -> MagicMock:
+    """Model whose inference blocks until *release* is set."""
+
+    def blocking(_obs: object) -> np.ndarray:
+        entered.set()
+        release.wait(timeout=30.0)
+        return np.zeros((rows, 4), dtype=np.float32)
+
+    model = MagicMock()
+    model.predict_action_chunk.side_effect = blocking
+    return model
+
+
+def _rtc_model(chunk_size: int = 20, action_dim: int = 3) -> MagicMock:
+    model = MagicMock()
+    model.chunk_size = chunk_size
+    model.postprocessors = []
+    model.return_value = {"action": np.random.randn(1, chunk_size, action_dim).astype(np.float32)}
+    return model
+
+
 class TestRestartAfterStop:
     """``start()`` must hand back a usable execution after a previous ``stop()``.
 
-    A runtime can be stopped and run again, which calls ``stop()`` then
-    ``start()`` on the same execution object. Per-session state left over from
-    the previous run has to be cleared here, or the second run misbehaves
-    silently rather than failing loudly.
+    A stopped runtime can be run again, which calls ``stop()`` then ``start()``
+    on the same execution. Per-run state left behind here makes the second run
+    misbehave silently rather than fail.
     """
 
-    def test_async_revives_worker_after_stop(self) -> None:
-        """The worker must actually infer again, not exit on a stale stop flag."""
-        chunk = np.random.randn(6, 4).astype(np.float32)
-        model = _make_mock_model(chunk)
-        queue = ChunkedActionQueue()
-
-        ex = AsyncExecution()
-        ex.start(model, queue)
-        ex.warmup({"state": np.zeros(4, dtype=np.float32)})
-        ex.stop()
-
-        # Second session on the same object.
-        queue.clear()
-        ex.start(model, queue)
-        try:
-            assert ex._thread is not None  # noqa: SLF001
-            assert ex._thread.is_alive(), "worker exited immediately on a stale _stop_event"  # noqa: SLF001
-            # start() begins a fresh count, so any inference below is this session's.
-            assert ex.inference_count == 0
-
-            ex.warmup({"state": np.zeros(4, dtype=np.float32)})
-            for _ in range(len(chunk)):
-                queue.pop()
-            ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})
-
-            deadline = time.perf_counter() + 5.0
-            while ex.inference_count == 0 and time.perf_counter() < deadline:
-                time.sleep(0.01)
-
-            assert ex.inference_count >= 1, "worker never ran inference in the second session"
-        finally:
-            ex.stop()
-
-    def test_async_start_clears_stale_death_cause(self) -> None:
-        """A worker death in run 1 must not fail run 2."""
+    def test_async_clears_stale_per_run_state(self) -> None:
         model = _make_mock_model()
         queue = ChunkedActionQueue()
         ex = AsyncExecution()
         ex.start(model, queue)
         ex.stop()
-        ex._death_cause = RuntimeError("died in the previous session")  # noqa: SLF001
 
-        ex.start(model, queue)
-        try:
-            assert ex._death_cause is None  # noqa: SLF001
-            ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})  # must not raise
-        finally:
-            ex.stop()
-
-    def test_async_start_drops_stale_observation(self) -> None:
-        """A leftover observation must not be inferred on as if it were current."""
-        model = _make_mock_model()
-        queue = ChunkedActionQueue()
-        ex = AsyncExecution()
-        ex.start(model, queue)
-        ex.stop()
+        # Leftovers from the finished run.
+        ex._death_cause = RuntimeError("died previously")  # noqa: SLF001
+        ex._inference_count = 5  # noqa: SLF001
         with ex._lock:  # noqa: SLF001
             ex._obs_slot = {"state": np.full(4, 99.0, dtype=np.float32)}  # noqa: SLF001
             ex._running_inference = True  # noqa: SLF001
 
         ex.start(model, queue)
         try:
-            with ex._lock:  # noqa: SLF001
-                assert ex._obs_slot is None  # noqa: SLF001
-                assert ex._running_inference is False  # noqa: SLF001
-            # _busy is derived from both, so a submission is possible again.
-            assert ex._busy is False  # noqa: SLF001
+            assert ex._death_cause is None  # noqa: SLF001
+            assert ex.inference_count == 0
+            assert ex._busy is False  # derived from _obs_slot and _running_inference  # noqa: SLF001
+            ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})  # must not raise WorkerDiedError
         finally:
             ex.stop()
 
-    def test_rtc_start_clears_stale_death_cause_and_observation(self) -> None:
+    def test_rtc_clears_stale_per_run_state(self) -> None:
         from physicalai.runtime import RTCActionQueue, RTCExecution
 
-        chunk_size, action_dim = 20, 3
-        model = MagicMock()
-        model.chunk_size = chunk_size
-        model.postprocessors = []
-        model.return_value = {"action": np.random.randn(1, chunk_size, action_dim).astype(np.float32)}
-
+        model = _rtc_model()
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=chunk_size, max_action_dim=action_dim, fps=30.0)
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
         ex.start(model, queue)
         ex.stop()
-        ex._death_cause = RuntimeError("died in the previous session")  # noqa: SLF001
+
+        ex._death_cause = RuntimeError("died previously")  # noqa: SLF001
         with ex._obs_lock:  # noqa: SLF001
-            ex._obs_slot = {"state": np.full(action_dim, 99.0, dtype=np.float32)}  # noqa: SLF001
+            ex._obs_slot = {"state": np.full(3, 99.0, dtype=np.float32)}  # noqa: SLF001
 
         ex.start(model, queue)
         try:
             assert ex._death_cause is None  # noqa: SLF001
+            assert ex.inference_count == 0
             with ex._obs_lock:  # noqa: SLF001
                 assert ex._obs_slot is None  # noqa: SLF001
-            # warmup() blocks on _first_chunk_ready, which start() also reset.
-            ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
+            # warmup() blocks on _first_chunk_ready, which start() also replaced.
+            ex.warmup({"state": np.zeros(3, dtype=np.float32)})
         finally:
             ex.stop()
 
-
-class TestInferenceCountIsPerRun:
-    """``inference_count`` describes one run, matching the queue's counters.
-
-    ``docs/reference/runtime-api.md`` points callers at both
-    ``action_queue.total_pops`` and ``execution.inference_count`` for run
-    stats, so the two must agree on scope.
-    """
-
-    def test_sync_resets_on_start(self) -> None:
+    def test_sync_inference_count_is_per_run(self) -> None:
         model = _make_mock_model()
         queue = ChunkedActionQueue()
         ex = SyncExecution()
@@ -441,42 +404,22 @@ class TestInferenceCountIsPerRun:
         ex.start(model, queue)
         assert ex.inference_count == 0
 
-    def test_async_resets_on_start(self) -> None:
-        model = _make_mock_model()
-        queue = ChunkedActionQueue()
-        ex = AsyncExecution()
-        ex.start(model, queue)
-        ex._inference_count = 5  # noqa: SLF001 — stand in for a completed run
-        ex.stop()
-
-        ex.start(model, queue)
-        try:
-            assert ex.inference_count == 0
-        finally:
-            ex.stop()
-
     def test_rtc_resets_stat_but_not_the_cold_start_gate(self) -> None:
         """The public stat restarts; the compilation-warmup gate does not.
 
-        Model compilation is paid once per process, so a second run must not
-        re-discard its latency samples as though they were cold. Asserted on
-        the gated behaviour — whether ``on_reset()`` fires — not just on the
-        counters, so wiring the gate back to the per-run count is caught.
+        Compilation is paid once per process, so a second run must not discard
+        its latency samples as though they were cold. Asserted on whether
+        ``on_reset()`` fires, so rewiring the gate to the per-run count is caught.
         """
         from physicalai.runtime import RTCActionQueue, RTCExecution
 
-        chunk_size, action_dim = 20, 3
-        model = MagicMock()
-        model.chunk_size = chunk_size
-        model.postprocessors = []
-        model.return_value = {"action": np.random.randn(1, chunk_size, action_dim).astype(np.float32)}
-
         tracker = MagicMock()
         tracker.compute_delay.return_value = 0
+        model = _rtc_model()
         queue = RTCActionQueue()
         ex = RTCExecution(
-            chunk_size=chunk_size,
-            max_action_dim=action_dim,
+            chunk_size=20,
+            max_action_dim=3,
             fps=30.0,
             latency_tracker=tracker,
             warmup_inferences=1,
@@ -484,25 +427,133 @@ class TestInferenceCountIsPerRun:
 
         ex.start(model, queue)
         try:
-            ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
+            ex.warmup({"state": np.zeros(3, dtype=np.float32)})
+            lifetime = ex._lifetime_inferences  # noqa: SLF001
             assert ex.inference_count >= 1
-            lifetime_after_first = ex._lifetime_inferences  # noqa: SLF001
-            assert lifetime_after_first >= 1
-            assert tracker.on_reset.call_count == 1, "cold-start discard should fire once"
+            assert tracker.on_reset.call_count == 1
         finally:
             ex.stop()
 
         tracker.on_reset.reset_mock()
         ex.start(model, queue)
         try:
-            # Public stat restarts...
             assert ex.inference_count == 0
-            # ...while the lifetime count carries on, keeping the gate closed.
-            assert ex._lifetime_inferences == lifetime_after_first  # noqa: SLF001
-
+            assert ex._lifetime_inferences == lifetime  # noqa: SLF001
             queue.clear()
-            ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
-            assert ex.inference_count >= 1
+            ex.warmup({"state": np.zeros(3, dtype=np.float32)})
             tracker.on_reset.assert_not_called()
         finally:
             ex.stop()
+
+
+def _async_setup() -> tuple[Any, MagicMock, Any]:
+    return AsyncExecution(), _make_mock_model(), ChunkedActionQueue()
+
+
+def _rtc_setup() -> tuple[Any, MagicMock, Any]:
+    from physicalai.runtime import RTCActionQueue, RTCExecution
+
+    return RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0), _rtc_model(), RTCActionQueue()
+
+
+class TestStopTimeoutStraggler:
+    """``stop()`` only joins with a timeout, so a worker can outlive it.
+
+    Such a straggler must not be revived by a later ``start()``, must discard the
+    result it was computing, and must not run concurrently with a new worker
+    through the same unsynchronised ``InferenceModel``.
+    """
+
+    @staticmethod
+    def _timed_out_stop(ex: Any) -> None:
+        """Call ``stop()`` with ``join`` neutered, simulating a timeout fast."""
+        with patch.object(threading.Thread, "join", lambda _self, timeout=None: None):  # noqa: ARG005
+            ex.stop()
+
+    @pytest.mark.parametrize("setup", [_async_setup, _rtc_setup], ids=["async", "rtc"])
+    def test_outgoing_runs_stop_flag_survives_a_new_start(self, setup: Callable[[], tuple[Any, MagicMock, Any]]) -> None:
+        """Each run owns its stop event, so a new run cannot un-stop the old one.
+
+        Clearing a shared event here is what previously revived a straggler.
+        """
+        ex, model, queue = setup()
+        ex.start(model, queue)
+        outgoing = ex._stop_event  # noqa: SLF001
+        ex.stop()
+        assert outgoing.is_set()
+
+        ex.start(model, queue)
+        try:
+            assert outgoing.is_set(), "outgoing run's flag was cleared — its worker would be revived"
+            assert ex._stop_event is not outgoing  # noqa: SLF001
+            assert not ex._stop_event.is_set()  # noqa: SLF001
+        finally:
+            ex.stop()
+
+    @pytest.mark.parametrize("kind", ["async", "rtc"], ids=["async", "rtc"])
+    def test_straggler_discards_the_result_it_was_computing(self, kind: str, caplog: pytest.LogCaptureFixture) -> None:
+        """A result finished after its run ended describes a stale observation."""
+        entered, release = threading.Event(), threading.Event()
+        obs = {"state": np.zeros(3 if kind == "rtc" else 4, dtype=np.float32)}
+
+        if kind == "async":
+            ex, _model, queue = _async_setup()
+            model = _blocking_model(entered, release)
+            ex.start(model, queue)
+            ex._threshold_count = 1  # noqa: SLF001 — submit on an empty queue
+            ex.maybe_request(obs)
+        else:
+            ex, model, queue = _rtc_setup()
+
+            def blocking(*_args: object, **_kwargs: object) -> dict[str, np.ndarray]:
+                entered.set()
+                release.wait(timeout=30.0)
+                return {"action": np.zeros((1, 20, 3), dtype=np.float32)}
+
+            model.side_effect = blocking
+            ex.start(model, queue)
+            with ex._obs_lock:  # noqa: SLF001
+                ex._obs_slot = dict(obs)  # noqa: SLF001
+
+        assert entered.wait(timeout=5.0), "worker never entered inference"
+        straggler = ex._thread  # noqa: SLF001
+        assert straggler is not None
+
+        self._timed_out_stop(ex)
+        assert straggler.is_alive()
+        # A worker outliving the join is reported, not silently abandoned.
+        assert "did not exit within" in caplog.text
+
+        release.set()
+        straggler.join(timeout=5.0)
+        assert not straggler.is_alive()
+        # The discard happens before the counter and the push, so both stay put.
+        assert ex.inference_count == 0
+        assert queue.remaining == 0
+
+    def test_start_refuses_while_straggler_holds_the_model(self) -> None:
+        """Two threads through one InferenceModel is worse than a failed resume."""
+        from physicalai.runtime.execution import async_execution
+
+        entered, release = threading.Event(), threading.Event()
+        model = _blocking_model(entered, release)
+        queue = ChunkedActionQueue()
+
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        ex._threshold_count = 1  # noqa: SLF001
+        ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})
+        assert entered.wait(timeout=5.0)
+        straggler = ex._thread  # noqa: SLF001
+        assert straggler is not None
+
+        self._timed_out_stop(ex)
+        try:
+            with (
+                patch.object(async_execution, "_STRAGGLER_GRACE_S", 0.05),
+                pytest.raises(RuntimeError, match="not safe for concurrent use"),
+            ):
+                ex.start(model, queue)
+        finally:
+            release.set()
+            straggler.join(timeout=5.0)

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -5,9 +5,12 @@
 
 from __future__ import annotations
 
+import multiprocessing as mp
+import threading
 import time
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -15,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from physicalai.runtime import ChunkedActionQueue as ActionQueue, ChunkedActionQueue, PolicySource, RobotRuntime, SyncExecution, WorkerDiedError
+from physicalai.runtime import ChunkedActionQueue as ActionQueue, ChunkedActionQueue, LifecycleEvent, PolicySource, RobotRuntime, StopSignal, SyncExecution, WorkerDiedError
 from physicalai.robot.interface import RobotObservation
 from physicalai.inference.model import InferenceModel
 from physicalai.inference.constants import IMAGES, STATE, TASK
@@ -631,3 +634,485 @@ class TestPolicySourceModelInput:
 
         assert model_input[TASK] == ["pick the cube"]
 
+
+@dataclass
+class _LifecycleRecorder:
+    """Callback capturing lifecycle events and bus close, for shutdown assertions."""
+
+    events: list[str] = field(default_factory=list)
+    metadata: list[dict[str, Any]] = field(default_factory=list)
+    closed: bool = False
+
+    def on_lifecycle(self, event: LifecycleEvent) -> None:
+        self.events.append(event.event)
+        self.metadata.append(event.metadata)
+
+    def close(self) -> None:
+        self.closed = True
+
+    @property
+    def shutdown_metadata(self) -> dict[str, Any]:
+        return next(m for e, m in zip(self.events, self.metadata, strict=True) if e == "shutdown")
+
+
+@dataclass
+class _StopBeforeSend:
+    """Requests a stop from ``on_action_ready`` — i.e. *before* the tick's send.
+
+    Stopping here is what makes the "in-flight action is still sent" guarantee
+    falsifiable: an implementation that bailed out between the stop check and
+    ``_resilient_send`` would drop this tick's action and fail the assertion.
+    Wired post-construction because the runtime needs its callbacks at
+    construction time.
+    """
+
+    step: int
+    runtime: RobotRuntime | None = None
+
+    def on_action_ready(self, *, action: np.ndarray, step: int) -> np.ndarray:
+        if step >= self.step:
+            assert self.runtime is not None
+            self.runtime.stop()
+        return action
+
+
+@dataclass
+class _RaisingActionSource:
+    """Action source whose ``update()`` always raises, to drive the exit paths."""
+
+    exc: BaseException
+    connect_exc: BaseException | None = None
+    disconnect_exc: BaseException | None = None
+    disconnected: bool = False
+
+    def connect(self, *, bus: Any, session_id: str) -> None:
+        if self.connect_exc is not None:
+            raise self.connect_exc
+
+    def update(self, robot_state: Any, camera_frames: Any, step: int) -> np.ndarray:
+        raise self.exc
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+        if self.disconnect_exc is not None:
+            raise self.disconnect_exc
+
+
+class _InterruptOnceOnShutdown:
+    """Raises ``KeyboardInterrupt`` from ``on_lifecycle``, once, on shutdown.
+
+    Fires a single time so a follow-up ``run()`` in the same test tears down
+    cleanly and can prove the stop flag did not survive.
+    """
+
+    def __init__(self) -> None:
+        self.fired = False
+
+    def on_lifecycle(self, event: LifecycleEvent) -> None:
+        if event.event == "shutdown" and not self.fired:
+            self.fired = True
+            raise KeyboardInterrupt
+
+
+class _CountdownStopSignal:
+    """Stop signal that trips after *polls* checks.
+
+    Implements only ``is_set()`` — nothing else — so it proves the runtime
+    duck-types the signal and never reaches for ``isinstance``.
+    """
+
+    def __init__(self, polls: int) -> None:
+        self.polls = polls
+        self.calls = 0
+
+    def is_set(self) -> bool:
+        self.calls += 1
+        return self.calls > self.polls
+
+
+@contextmanager
+def _frozen_time() -> Iterator[MagicMock]:
+    """Patch ``core.time`` so ticks are instantaneous and deterministic.
+
+    Yields:
+        The mock standing in for ``physicalai.runtime.core.time``.
+    """
+    with patch("physicalai.runtime.core.time") as mock_time:
+        mock_time.perf_counter.return_value = 0.0
+        mock_time.time.return_value = 0.0
+        mock_time.sleep = MagicMock()
+        yield mock_time
+
+
+def _stop_runtime(**kwargs: Any) -> tuple[RobotRuntime, MagicMock]:
+    """Build a connected runtime with a trivial action source.
+
+    Returns:
+        Tuple ``(runtime, robot_mock)``.
+    """
+    robot = kwargs.pop("robot", None) or _make_mock_robot()
+    source = kwargs.pop("action_source", None) or FakeActionSource(next_action=np.zeros(3, dtype=np.float32))
+    fps = kwargs.pop("fps", 10.0)
+    runtime = RobotRuntime(robot=robot, action_source=source, fps=fps, **kwargs)
+    runtime._connected = True  # noqa: SLF001
+    return runtime, robot
+
+
+class TestCooperativeStop:
+    """``stop()`` / ``stop_event`` — the cooperative exit path."""
+
+    def test_stop_mid_run_still_sends_the_in_flight_action(self) -> None:
+        """A stop raised before the send still lets that tick's action through."""
+        stopper = _StopBeforeSend(step=2)
+        runtime, robot = _stop_runtime(callbacks=[stopper])
+        stopper.runtime = runtime
+
+        with _frozen_time():
+            steps = runtime.run(duration_s=100.0)
+
+        assert steps == 3
+        # Step 2 requested the stop before its send; that send must still happen.
+        assert robot.send_action.call_count == 3
+        assert runtime.last_run_reason == "stop_requested"
+
+    def test_stop_before_run_exits_at_zero_steps(self) -> None:
+        """One code path, asserted end to end: the loop's stop check at step 0.
+
+        A ``stop()`` arriving before ``run()`` — between ``connect()`` and
+        ``run()``, or on a fully idle runtime — is remembered rather than
+        dropped, and repeating it changes nothing. The next ``run()`` sees it
+        and returns immediately without sending anything.
+        """
+        runtime, robot = _stop_runtime()
+
+        runtime.stop()
+        runtime.stop()  # idempotent
+        assert runtime.last_run_reason is None  # stop() alone reports nothing
+
+        with _frozen_time():
+            steps = runtime.run(duration_s=100.0)
+
+        assert steps == 0
+        assert type(steps) is int  # noqa: E721 — must not be np.int64
+        robot.send_action.assert_not_called()
+        assert runtime.last_run_reason == "stop_requested"
+
+    @pytest.mark.parametrize(
+        "make_event",
+        [threading.Event, mp.Event],
+        ids=["threading", "multiprocessing"],
+    )
+    def test_external_stop_event(self, make_event: Callable[[], Any]) -> None:
+        """Both Event flavours work; multiprocessing is the parent-process case.
+
+        Parametrized on the factory, not an instance, so no multiprocessing
+        semaphore is created at collection time.
+        """
+        runtime, robot = _stop_runtime()
+        stop_event = make_event()
+        stop_event.set()
+
+        with _frozen_time():
+            steps = runtime.run(duration_s=100.0, stop_event=stop_event)
+
+        assert steps == 0
+        robot.send_action.assert_not_called()
+        assert runtime.last_run_reason == "stop_requested"
+
+    def test_duck_typed_stop_signal_needs_only_is_set(self) -> None:
+        runtime, robot = _stop_runtime()
+        signal = _CountdownStopSignal(polls=3)
+
+        with _frozen_time():
+            steps = runtime.run(duration_s=100.0, stop_event=signal)
+
+        assert steps == 3
+        assert robot.send_action.call_count == 3
+        assert runtime.last_run_reason == "stop_requested"
+
+    def test_stop_signal_is_not_runtime_checkable(self) -> None:
+        """The runtime does no isinstance anywhere; the protocol must not invite it."""
+        with pytest.raises(TypeError):
+            isinstance(threading.Event(), StopSignal)  # type: ignore[misc]  # noqa: S101
+
+    def test_stop_from_another_thread_ends_a_live_loop(self) -> None:
+        """The headline claim, against a real running loop and real time."""
+        first_tick = threading.Event()
+
+        class _Signal:
+            def on_action_sent(self, *, action: np.ndarray, step: int) -> None:  # noqa: ARG002
+                first_tick.set()
+
+        runtime, _robot = _stop_runtime(fps=50.0, callbacks=[_Signal()])
+
+        def stopper() -> None:
+            first_tick.wait(timeout=5.0)
+            runtime.stop()
+
+        thread = threading.Thread(target=stopper)
+        thread.start()
+        try:
+            steps = runtime.run(duration_s=30.0)
+        finally:
+            thread.join(timeout=5.0)
+
+        assert runtime.last_run_reason == "stop_requested"
+        # Ended on the stop, nowhere near the 1500 steps duration_s allows.
+        assert 1 <= steps < 500
+
+    def test_stop_checked_before_duration(self) -> None:
+        """Both exits satisfied at once reports stop_requested, not duration_elapsed."""
+        runtime, _robot = _stop_runtime()
+        runtime.stop()
+
+        with _frozen_time():
+            steps = runtime.run(duration_s=0.0)
+
+        assert steps == 0
+        assert runtime.last_run_reason == "stop_requested"
+
+    def test_runtime_reusable_after_stop(self) -> None:
+        """_shutdown() clears the flag, so the next run() is unaffected."""
+        runtime, robot = _stop_runtime()
+
+        runtime.stop()
+        with _frozen_time():
+            assert runtime.run(duration_s=100.0) == 0
+            assert runtime.last_run_reason == "stop_requested"
+
+            second = runtime.run(duration_s=0.3)
+
+        assert second == 3
+        assert robot.send_action.call_count == 3
+        assert runtime.last_run_reason == "duration_elapsed"
+
+
+class TestStopFlagLifecycle:
+    """The stop flag must never survive a run, however that run ended."""
+
+    def test_action_source_connect_failure_does_not_poison_runtime(self) -> None:
+        """A failed connect() still runs _shutdown(), so the flag cannot leak."""
+        source = _RaisingActionSource(
+            exc=RuntimeError("unused"),
+            connect_exc=RuntimeError("model load failed"),
+        )
+        recorder = _LifecycleRecorder()
+        runtime, robot = _stop_runtime(action_source=source, callbacks=[recorder])
+
+        runtime.stop()
+        with _frozen_time(), pytest.raises(RuntimeError, match="model load failed"):
+            runtime.run(duration_s=1.0)
+
+        assert runtime.last_run_reason == "error"
+        assert recorder.shutdown_metadata["reason"] == "error"
+        assert recorder.closed
+
+        # The flag is gone, so a healthy source runs normally afterwards.
+        runtime._action_source = FakeActionSource(next_action=np.zeros(3, dtype=np.float32))  # noqa: SLF001
+        with _frozen_time():
+            assert runtime.run(duration_s=0.3) == 3
+        assert robot.send_action.call_count == 3
+
+    def test_base_exception_in_disconnect_still_completes_shutdown(self) -> None:
+        """A Ctrl+C mid-teardown must not skip the shutdown event or the flush."""
+        source = _RaisingActionSource(exc=RuntimeError("unused"), disconnect_exc=KeyboardInterrupt())
+        recorder = _LifecycleRecorder()
+        runtime, _robot = _stop_runtime(action_source=source, callbacks=[recorder])
+        runtime.stop()
+
+        with _frozen_time(), pytest.raises(KeyboardInterrupt):
+            runtime.run(duration_s=1.0)
+
+        assert "shutdown" in recorder.events
+        assert recorder.closed
+        assert runtime.last_run_reason == "stop_requested"
+
+    def test_base_exception_in_lifecycle_callback_still_clears_flag(self) -> None:
+        """The mirror of the disconnect case: a Ctrl+C from ``on_lifecycle``.
+
+        The bus isolates ``Exception`` but deliberately lets ``BaseException``
+        through (``_callback_bus.emit_lifecycle``/``close``), so the flush and
+        the flag clear each need their own ``finally``. Without them the flag
+        survives and the next ``run()`` silently zero-steps.
+        """
+        recorder = _LifecycleRecorder()
+        # Registered after the recorder, so the recorder still receives the
+        # event; fires once, so the follow-up run tears down cleanly.
+        interrupter = _InterruptOnceOnShutdown()
+        runtime, robot = _stop_runtime(callbacks=[recorder, interrupter])
+        runtime.stop()
+
+        with _frozen_time(), pytest.raises(KeyboardInterrupt):
+            runtime.run(duration_s=1.0)
+
+        assert interrupter.fired
+        assert runtime.last_run_reason == "stop_requested"
+        assert recorder.shutdown_metadata["reason"] == "stop_requested"
+        assert recorder.closed  # the flush ran despite the BaseException
+
+        # The flag did not survive into the next session.
+        with _frozen_time():
+            assert runtime.run(duration_s=0.3) == 3
+        assert robot.send_action.call_count == 3
+
+    def test_not_connected_run_leaves_previous_reason_untouched(self) -> None:
+        """Documented behaviour: a run rejected before it starts changes nothing."""
+        runtime, _robot = _stop_runtime()
+        with _frozen_time():
+            runtime.run(duration_s=0.1)
+        assert runtime.last_run_reason == "duration_elapsed"
+
+        runtime._connected = False  # noqa: SLF001
+        with pytest.raises(RuntimeError, match="connect"):
+            runtime.run(duration_s=0.1)
+
+        assert runtime.last_run_reason == "duration_elapsed"
+
+    def test_stop_during_teardown_does_not_leak_into_next_run(self) -> None:
+        """Teardown is slow (joining workers, flushing sinks); a stop landing in
+        that window must not silently zero-step the following session.
+
+        This is why the flag clears at the *end* of ``_shutdown()``: clearing it
+        first would let this stop survive into the next ``run()``.
+        """
+
+        class _StopOnDisconnect:
+            runtime: RobotRuntime | None = None
+
+            def connect(self, *, bus: Any, session_id: str) -> None:
+                pass
+
+            def update(self, robot_state: Any, camera_frames: Any, step: int) -> np.ndarray:
+                return np.zeros(3, dtype=np.float32)
+
+            def disconnect(self) -> None:
+                assert self.runtime is not None
+                self.runtime.stop()
+
+        source = _StopOnDisconnect()
+        runtime, _robot = _stop_runtime(action_source=source)
+        source.runtime = runtime
+
+        with _frozen_time():
+            assert runtime.run(duration_s=0.2) == 2
+            assert runtime.last_run_reason == "duration_elapsed"
+            assert runtime.run(duration_s=0.3) == 3
+
+        assert runtime.last_run_reason == "duration_elapsed"
+
+
+class TestRunReason:
+    """All four exit reasons, on both the property and the shutdown event."""
+
+    @staticmethod
+    def _runtime(action_source: Any, recorder: _LifecycleRecorder) -> RobotRuntime:
+        runtime, _robot = _stop_runtime(action_source=action_source, callbacks=[recorder])
+        return runtime
+
+    def test_duration_elapsed(self) -> None:
+        recorder = _LifecycleRecorder()
+        runtime = self._runtime(FakeActionSource(next_action=np.zeros(3, dtype=np.float32)), recorder)
+
+        with _frozen_time():
+            runtime.run(duration_s=0.2)
+
+        assert runtime.last_run_reason == "duration_elapsed"
+        assert recorder.shutdown_metadata["reason"] == "duration_elapsed"
+
+    def test_stop_requested(self) -> None:
+        recorder = _LifecycleRecorder()
+        runtime = self._runtime(FakeActionSource(next_action=np.zeros(3, dtype=np.float32)), recorder)
+        runtime.stop()
+
+        with _frozen_time():
+            runtime.run(duration_s=100.0)
+
+        assert runtime.last_run_reason == "stop_requested"
+        assert recorder.shutdown_metadata["reason"] == "stop_requested"
+
+    def test_interrupted(self) -> None:
+        """KeyboardInterrupt is still swallowed, and now labelled."""
+        recorder = _LifecycleRecorder()
+        runtime = self._runtime(_RaisingActionSource(exc=KeyboardInterrupt()), recorder)
+
+        with _frozen_time():
+            steps = runtime.run(duration_s=100.0)
+
+        assert steps == 0
+        assert runtime.last_run_reason == "interrupted"
+        assert recorder.shutdown_metadata["reason"] == "interrupted"
+
+    @pytest.mark.parametrize(
+        ("exc_type", "message"),
+        [(ConnectionError, "link down"), (WorkerDiedError, "dead")],
+        ids=["connection_error", "worker_died"],
+    )
+    def test_error_on_propagating_exception(self, exc_type: type[Exception], message: str) -> None:
+        """A crashed run is not mislabelled as a normal exit."""
+        recorder = _LifecycleRecorder()
+        runtime = self._runtime(_RaisingActionSource(exc=exc_type(message)), recorder)
+
+        with _frozen_time(), pytest.raises(exc_type, match=message):
+            runtime.run(duration_s=100.0)
+
+        assert runtime.last_run_reason == "error"
+        assert recorder.shutdown_metadata["reason"] == "error"
+
+    def test_error_on_callback_raising_in_action_ready(self) -> None:
+        bad = MagicMock()
+        bad.on_action_ready.side_effect = RuntimeError("filter blew up")
+        recorder = _LifecycleRecorder()
+        runtime, _robot = _stop_runtime(callbacks=[recorder, bad])
+
+        with _frozen_time(), pytest.raises(RuntimeError, match="filter blew up"):
+            runtime.run(duration_s=100.0)
+
+        assert runtime.last_run_reason == "error"
+        assert recorder.shutdown_metadata["reason"] == "error"
+
+    def test_reason_is_none_while_run_in_flight(self) -> None:
+        """_reset_session() clears the previous run's reason at the top of run()."""
+        seen: list[Any] = []
+
+        class _ReasonProbe:
+            def on_action_sent(self, *, action: np.ndarray, step: int) -> None:  # noqa: ARG002
+                seen.append(runtime.last_run_reason)
+
+        runtime, _robot = _stop_runtime(callbacks=[_ReasonProbe()])
+
+        with _frozen_time():
+            runtime.run(duration_s=0.1)
+            assert runtime.last_run_reason == "duration_elapsed"
+            runtime.run(duration_s=0.1)
+
+        # Mid-run the property reports None, never the prior run's reason.
+        assert seen == [None, None]
+
+
+class TestStopEventNotInConfigSchema:
+    """``stop_event`` is a live object; it must never reach the config surface."""
+
+    def test_from_config_still_loads(self, tmp_path: Path) -> None:
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text(_minimal_yaml(include_run_block=True))
+
+        assert isinstance(RobotRuntime.from_config(cfg_path), RobotRuntime)
+
+    def test_from_config_rejects_stop_event_as_unknown_option(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Asserts the *reason* for rejection, which is what the skip controls.
+
+        Without ``skip={"stop_event"}`` the key is a known option and fails
+        type validation instead ("Parser key ..."), so asserting on plain
+        ``SystemExit`` would pass either way and cover nothing.
+        """
+        cfg_path = tmp_path / "runtime.yaml"
+        cfg_path.write_text(_minimal_yaml() + "run:\n  stop_event: something\n")
+
+        with pytest.raises(SystemExit):
+            RobotRuntime.from_config(cfg_path)
+
+        assert "does not accept option 'stop_event'" in capsys.readouterr().err

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -637,7 +637,7 @@ class TestPolicySourceModelInput:
 
 @dataclass
 class _LifecycleRecorder:
-    """Callback capturing lifecycle events and bus close, for shutdown assertions."""
+    """Captures lifecycle events and bus close, for shutdown assertions."""
 
     events: list[str] = field(default_factory=list)
     metadata: list[dict[str, Any]] = field(default_factory=list)
@@ -656,14 +656,23 @@ class _LifecycleRecorder:
 
 
 @dataclass
-class _StopBeforeSend:
-    """Requests a stop from ``on_action_ready`` — i.e. *before* the tick's send.
+class _InterruptOnceOnShutdown:
+    """Raises ``KeyboardInterrupt`` from ``on_lifecycle``, once, on shutdown."""
 
-    Stopping here is what makes the "in-flight action is still sent" guarantee
-    falsifiable: an implementation that bailed out between the stop check and
-    ``_resilient_send`` would drop this tick's action and fail the assertion.
-    Wired post-construction because the runtime needs its callbacks at
-    construction time.
+    fired: bool = False
+
+    def on_lifecycle(self, event: LifecycleEvent) -> None:
+        if event.event == "shutdown" and not self.fired:
+            self.fired = True
+            raise KeyboardInterrupt
+
+
+@dataclass
+class _StopBeforeSend:
+    """Requests a stop from ``on_action_ready``, i.e. before the tick's send.
+
+    Stopping here makes the "in-flight action is still sent" guarantee
+    falsifiable: bailing out between the check and the send would drop it.
     """
 
     step: int
@@ -678,12 +687,11 @@ class _StopBeforeSend:
 
 @dataclass
 class _RaisingActionSource:
-    """Action source whose ``update()`` always raises, to drive the exit paths."""
+    """Action source whose ``update()`` raises, to drive the exit paths."""
 
     exc: BaseException
     connect_exc: BaseException | None = None
     disconnect_exc: BaseException | None = None
-    disconnected: bool = False
 
     def connect(self, *, bus: Any, session_id: str) -> None:
         if self.connect_exc is not None:
@@ -693,33 +701,12 @@ class _RaisingActionSource:
         raise self.exc
 
     def disconnect(self) -> None:
-        self.disconnected = True
         if self.disconnect_exc is not None:
             raise self.disconnect_exc
 
 
-class _InterruptOnceOnShutdown:
-    """Raises ``KeyboardInterrupt`` from ``on_lifecycle``, once, on shutdown.
-
-    Fires a single time so a follow-up ``run()`` in the same test tears down
-    cleanly and can prove the stop flag did not survive.
-    """
-
-    def __init__(self) -> None:
-        self.fired = False
-
-    def on_lifecycle(self, event: LifecycleEvent) -> None:
-        if event.event == "shutdown" and not self.fired:
-            self.fired = True
-            raise KeyboardInterrupt
-
-
 class _CountdownStopSignal:
-    """Stop signal that trips after *polls* checks.
-
-    Implements only ``is_set()`` — nothing else — so it proves the runtime
-    duck-types the signal and never reaches for ``isinstance``.
-    """
+    """Stop signal that trips after *polls* checks; implements only ``is_set()``."""
 
     def __init__(self, polls: int) -> None:
         self.polls = polls
@@ -732,11 +719,7 @@ class _CountdownStopSignal:
 
 @contextmanager
 def _frozen_time() -> Iterator[MagicMock]:
-    """Patch ``core.time`` so ticks are instantaneous and deterministic.
-
-    Yields:
-        The mock standing in for ``physicalai.runtime.core.time``.
-    """
+    """Patch ``core.time`` so ticks are instantaneous and deterministic."""
     with patch("physicalai.runtime.core.time") as mock_time:
         mock_time.perf_counter.return_value = 0.0
         mock_time.time.return_value = 0.0
@@ -745,11 +728,7 @@ def _frozen_time() -> Iterator[MagicMock]:
 
 
 def _stop_runtime(**kwargs: Any) -> tuple[RobotRuntime, MagicMock]:
-    """Build a connected runtime with a trivial action source.
-
-    Returns:
-        Tuple ``(runtime, robot_mock)``.
-    """
+    """Build a connected runtime, defaulting to a trivial action source."""
     robot = kwargs.pop("robot", None) or _make_mock_robot()
     source = kwargs.pop("action_source", None) or FakeActionSource(next_action=np.zeros(3, dtype=np.float32))
     fps = kwargs.pop("fps", 10.0)
@@ -762,7 +741,6 @@ class TestCooperativeStop:
     """``stop()`` / ``stop_event`` — the cooperative exit path."""
 
     def test_stop_mid_run_still_sends_the_in_flight_action(self) -> None:
-        """A stop raised before the send still lets that tick's action through."""
         stopper = _StopBeforeSend(step=2)
         runtime, robot = _stop_runtime(callbacks=[stopper])
         stopper.runtime = runtime
@@ -771,43 +749,38 @@ class TestCooperativeStop:
             steps = runtime.run(duration_s=100.0)
 
         assert steps == 3
-        # Step 2 requested the stop before its send; that send must still happen.
-        assert robot.send_action.call_count == 3
+        assert robot.send_action.call_count == 3  # step 2's send still happened
         assert runtime.last_run_reason == "stop_requested"
 
-    def test_stop_before_run_exits_at_zero_steps(self) -> None:
-        """One code path, asserted end to end: the loop's stop check at step 0.
+    def test_stop_before_run_is_remembered_then_cleared(self) -> None:
+        """One path end to end: the loop's stop check at step 0.
 
-        A ``stop()`` arriving before ``run()`` — between ``connect()`` and
-        ``run()``, or on a fully idle runtime — is remembered rather than
-        dropped, and repeating it changes nothing. The next ``run()`` sees it
-        and returns immediately without sending anything.
+        A ``stop()`` arriving before ``run()`` is remembered, repeating it
+        changes nothing, and it wins over an equally-satisfied ``duration_s``.
+        The next ``run()`` is unaffected.
         """
         runtime, robot = _stop_runtime()
 
         runtime.stop()
-        runtime.stop()  # idempotent
-        assert runtime.last_run_reason is None  # stop() alone reports nothing
+        runtime.stop()
+        assert runtime.last_run_reason is None
 
         with _frozen_time():
-            steps = runtime.run(duration_s=100.0)
+            stopped = runtime.run(duration_s=0.0)  # both exits satisfied
+            assert stopped == 0
+            assert type(stopped) is int  # noqa: E721 — not np.int64
+            robot.send_action.assert_not_called()
+            assert runtime.last_run_reason == "stop_requested"
 
-        assert steps == 0
-        assert type(steps) is int  # noqa: E721 — must not be np.int64
-        robot.send_action.assert_not_called()
-        assert runtime.last_run_reason == "stop_requested"
+            resumed = runtime.run(duration_s=0.3)
 
-    @pytest.mark.parametrize(
-        "make_event",
-        [threading.Event, mp.Event],
-        ids=["threading", "multiprocessing"],
-    )
+        assert resumed == 3
+        assert robot.send_action.call_count == 3
+        assert runtime.last_run_reason == "duration_elapsed"
+
+    @pytest.mark.parametrize("make_event", [threading.Event, mp.Event], ids=["threading", "multiprocessing"])
     def test_external_stop_event(self, make_event: Callable[[], Any]) -> None:
-        """Both Event flavours work; multiprocessing is the parent-process case.
-
-        Parametrized on the factory, not an instance, so no multiprocessing
-        semaphore is created at collection time.
-        """
+        """Factory, not instance, so no mp semaphore is created at collection."""
         runtime, robot = _stop_runtime()
         stop_event = make_event()
         stop_event.set()
@@ -836,7 +809,7 @@ class TestCooperativeStop:
             isinstance(threading.Event(), StopSignal)  # type: ignore[misc]  # noqa: S101
 
     def test_stop_from_another_thread_ends_a_live_loop(self) -> None:
-        """The headline claim, against a real running loop and real time."""
+        """The headline claim, against a real loop and real time."""
         first_tick = threading.Event()
 
         class _Signal:
@@ -857,45 +830,14 @@ class TestCooperativeStop:
             thread.join(timeout=5.0)
 
         assert runtime.last_run_reason == "stop_requested"
-        # Ended on the stop, nowhere near the 1500 steps duration_s allows.
-        assert 1 <= steps < 500
-
-    def test_stop_checked_before_duration(self) -> None:
-        """Both exits satisfied at once reports stop_requested, not duration_elapsed."""
-        runtime, _robot = _stop_runtime()
-        runtime.stop()
-
-        with _frozen_time():
-            steps = runtime.run(duration_s=0.0)
-
-        assert steps == 0
-        assert runtime.last_run_reason == "stop_requested"
-
-    def test_runtime_reusable_after_stop(self) -> None:
-        """_shutdown() clears the flag, so the next run() is unaffected."""
-        runtime, robot = _stop_runtime()
-
-        runtime.stop()
-        with _frozen_time():
-            assert runtime.run(duration_s=100.0) == 0
-            assert runtime.last_run_reason == "stop_requested"
-
-            second = runtime.run(duration_s=0.3)
-
-        assert second == 3
-        assert robot.send_action.call_count == 3
-        assert runtime.last_run_reason == "duration_elapsed"
+        assert 1 <= steps < 500  # ended on the stop, far short of duration_s
 
 
 class TestStopFlagLifecycle:
     """The stop flag must never survive a run, however that run ended."""
 
     def test_action_source_connect_failure_does_not_poison_runtime(self) -> None:
-        """A failed connect() still runs _shutdown(), so the flag cannot leak."""
-        source = _RaisingActionSource(
-            exc=RuntimeError("unused"),
-            connect_exc=RuntimeError("model load failed"),
-        )
+        source = _RaisingActionSource(exc=RuntimeError("unused"), connect_exc=RuntimeError("model load failed"))
         recorder = _LifecycleRecorder()
         runtime, robot = _stop_runtime(action_source=source, callbacks=[recorder])
 
@@ -907,56 +849,43 @@ class TestStopFlagLifecycle:
         assert recorder.shutdown_metadata["reason"] == "error"
         assert recorder.closed
 
-        # The flag is gone, so a healthy source runs normally afterwards.
         runtime._action_source = FakeActionSource(next_action=np.zeros(3, dtype=np.float32))  # noqa: SLF001
         with _frozen_time():
             assert runtime.run(duration_s=0.3) == 3
         assert robot.send_action.call_count == 3
 
-    def test_base_exception_in_disconnect_still_completes_shutdown(self) -> None:
-        """A Ctrl+C mid-teardown must not skip the shutdown event or the flush."""
-        source = _RaisingActionSource(exc=RuntimeError("unused"), disconnect_exc=KeyboardInterrupt())
+    @pytest.mark.parametrize("raise_from", ["disconnect", "on_lifecycle"], ids=["disconnect", "on_lifecycle"])
+    def test_base_exception_during_teardown_still_completes_shutdown(self, raise_from: str) -> None:
+        """A Ctrl+C mid-teardown must not skip the event, the flush, or the clear.
+
+        The bus isolates ``Exception`` but lets ``BaseException`` through, so
+        each teardown step needs its own ``finally``.
+        """
         recorder = _LifecycleRecorder()
-        runtime, _robot = _stop_runtime(action_source=source, callbacks=[recorder])
+        callbacks: list[Any] = [recorder]
+        source: Any = FakeActionSource(next_action=np.zeros(3, dtype=np.float32))
+        if raise_from == "disconnect":
+            source = _RaisingActionSource(exc=RuntimeError("unused"), disconnect_exc=KeyboardInterrupt())
+        else:
+            callbacks.append(_InterruptOnceOnShutdown())
+
+        runtime, robot = _stop_runtime(action_source=source, callbacks=callbacks)
         runtime.stop()
 
         with _frozen_time(), pytest.raises(KeyboardInterrupt):
             runtime.run(duration_s=1.0)
 
-        assert "shutdown" in recorder.events
+        assert recorder.shutdown_metadata["reason"] == "stop_requested"
         assert recorder.closed
         assert runtime.last_run_reason == "stop_requested"
 
-    def test_base_exception_in_lifecycle_callback_still_clears_flag(self) -> None:
-        """The mirror of the disconnect case: a Ctrl+C from ``on_lifecycle``.
-
-        The bus isolates ``Exception`` but deliberately lets ``BaseException``
-        through (``_callback_bus.emit_lifecycle``/``close``), so the flush and
-        the flag clear each need their own ``finally``. Without them the flag
-        survives and the next ``run()`` silently zero-steps.
-        """
-        recorder = _LifecycleRecorder()
-        # Registered after the recorder, so the recorder still receives the
-        # event; fires once, so the follow-up run tears down cleanly.
-        interrupter = _InterruptOnceOnShutdown()
-        runtime, robot = _stop_runtime(callbacks=[recorder, interrupter])
-        runtime.stop()
-
-        with _frozen_time(), pytest.raises(KeyboardInterrupt):
-            runtime.run(duration_s=1.0)
-
-        assert interrupter.fired
-        assert runtime.last_run_reason == "stop_requested"
-        assert recorder.shutdown_metadata["reason"] == "stop_requested"
-        assert recorder.closed  # the flush ran despite the BaseException
-
         # The flag did not survive into the next session.
+        runtime._action_source = FakeActionSource(next_action=np.zeros(3, dtype=np.float32))  # noqa: SLF001
         with _frozen_time():
             assert runtime.run(duration_s=0.3) == 3
         assert robot.send_action.call_count == 3
 
     def test_not_connected_run_leaves_previous_reason_untouched(self) -> None:
-        """Documented behaviour: a run rejected before it starts changes nothing."""
         runtime, _robot = _stop_runtime()
         with _frozen_time():
             runtime.run(duration_s=0.1)
@@ -969,18 +898,14 @@ class TestStopFlagLifecycle:
         assert runtime.last_run_reason == "duration_elapsed"
 
     def test_stop_during_teardown_does_not_leak_into_next_run(self) -> None:
-        """Teardown is slow (joining workers, flushing sinks); a stop landing in
-        that window must not silently zero-step the following session.
-
-        This is why the flag clears at the *end* of ``_shutdown()``: clearing it
-        first would let this stop survive into the next ``run()``.
+        """Why the flag clears at the *end* of shutdown: clearing it first would
+        let a stop arriving mid-teardown zero-step the following session.
         """
 
         class _StopOnDisconnect:
             runtime: RobotRuntime | None = None
 
-            def connect(self, *, bus: Any, session_id: str) -> None:
-                pass
+            def connect(self, *, bus: Any, session_id: str) -> None: ...
 
             def update(self, robot_state: Any, camera_frames: Any, step: int) -> np.ndarray:
                 return np.zeros(3, dtype=np.float32)
@@ -995,62 +920,66 @@ class TestStopFlagLifecycle:
 
         with _frozen_time():
             assert runtime.run(duration_s=0.2) == 2
-            assert runtime.last_run_reason == "duration_elapsed"
             assert runtime.run(duration_s=0.3) == 3
 
         assert runtime.last_run_reason == "duration_elapsed"
 
 
+def _fake_source() -> FakeActionSource:
+    return FakeActionSource(next_action=np.zeros(3, dtype=np.float32))
+
+
 class TestRunReason:
     """All four exit reasons, on both the property and the shutdown event."""
 
-    @staticmethod
-    def _runtime(action_source: Any, recorder: _LifecycleRecorder) -> RobotRuntime:
-        runtime, _robot = _stop_runtime(action_source=action_source, callbacks=[recorder])
-        return runtime
-
-    def test_duration_elapsed(self) -> None:
+    @pytest.mark.parametrize(
+        ("make_source", "stop_first", "expected"),
+        [
+            (_fake_source, False, "duration_elapsed"),
+            (_fake_source, True, "stop_requested"),
+            (lambda: _RaisingActionSource(exc=KeyboardInterrupt()), False, "interrupted"),
+        ],
+        ids=["duration_elapsed", "stop_requested", "interrupted"],
+    )
+    def test_reason_on_normal_return(self, make_source: Callable[[], Any], stop_first: bool, expected: str) -> None:
         recorder = _LifecycleRecorder()
-        runtime = self._runtime(FakeActionSource(next_action=np.zeros(3, dtype=np.float32)), recorder)
+        runtime, _robot = _stop_runtime(action_source=make_source(), callbacks=[recorder])
+        if stop_first:
+            runtime.stop()
 
         with _frozen_time():
             runtime.run(duration_s=0.2)
 
-        assert runtime.last_run_reason == "duration_elapsed"
-        assert recorder.shutdown_metadata["reason"] == "duration_elapsed"
-
-    def test_stop_requested(self) -> None:
-        recorder = _LifecycleRecorder()
-        runtime = self._runtime(FakeActionSource(next_action=np.zeros(3, dtype=np.float32)), recorder)
-        runtime.stop()
-
-        with _frozen_time():
-            runtime.run(duration_s=100.0)
-
-        assert runtime.last_run_reason == "stop_requested"
-        assert recorder.shutdown_metadata["reason"] == "stop_requested"
-
-    def test_interrupted(self) -> None:
-        """KeyboardInterrupt is still swallowed, and now labelled."""
-        recorder = _LifecycleRecorder()
-        runtime = self._runtime(_RaisingActionSource(exc=KeyboardInterrupt()), recorder)
-
-        with _frozen_time():
-            steps = runtime.run(duration_s=100.0)
-
-        assert steps == 0
-        assert runtime.last_run_reason == "interrupted"
-        assert recorder.shutdown_metadata["reason"] == "interrupted"
+        assert runtime.last_run_reason == expected
+        assert recorder.shutdown_metadata["reason"] == expected
 
     @pytest.mark.parametrize(
-        ("exc_type", "message"),
-        [(ConnectionError, "link down"), (WorkerDiedError, "dead")],
-        ids=["connection_error", "worker_died"],
+        ("via", "exc_type", "message"),
+        [
+            ("source", ConnectionError, "link down"),
+            ("source", WorkerDiedError, "dead"),
+            ("callback", RuntimeError, "filter blew up"),
+        ],
+        ids=["source_connection_error", "source_worker_died", "callback_raises"],
     )
-    def test_error_on_propagating_exception(self, exc_type: type[Exception], message: str) -> None:
+    def test_error_reason_on_propagating_exception(
+        self,
+        via: str,
+        exc_type: type[Exception],
+        message: str,
+    ) -> None:
         """A crashed run is not mislabelled as a normal exit."""
         recorder = _LifecycleRecorder()
-        runtime = self._runtime(_RaisingActionSource(exc=exc_type(message)), recorder)
+        callbacks: list[Any] = [recorder]
+        source: Any = _fake_source()
+        if via == "source":
+            source = _RaisingActionSource(exc=exc_type(message))
+        else:
+            bad = MagicMock()
+            bad.on_action_ready.side_effect = exc_type(message)
+            callbacks.append(bad)
+
+        runtime, _robot = _stop_runtime(action_source=source, callbacks=callbacks)
 
         with _frozen_time(), pytest.raises(exc_type, match=message):
             runtime.run(duration_s=100.0)
@@ -1058,20 +987,7 @@ class TestRunReason:
         assert runtime.last_run_reason == "error"
         assert recorder.shutdown_metadata["reason"] == "error"
 
-    def test_error_on_callback_raising_in_action_ready(self) -> None:
-        bad = MagicMock()
-        bad.on_action_ready.side_effect = RuntimeError("filter blew up")
-        recorder = _LifecycleRecorder()
-        runtime, _robot = _stop_runtime(callbacks=[recorder, bad])
-
-        with _frozen_time(), pytest.raises(RuntimeError, match="filter blew up"):
-            runtime.run(duration_s=100.0)
-
-        assert runtime.last_run_reason == "error"
-        assert recorder.shutdown_metadata["reason"] == "error"
-
     def test_reason_is_none_while_run_in_flight(self) -> None:
-        """_reset_session() clears the previous run's reason at the top of run()."""
         seen: list[Any] = []
 
         class _ReasonProbe:
@@ -1085,19 +1001,10 @@ class TestRunReason:
             assert runtime.last_run_reason == "duration_elapsed"
             runtime.run(duration_s=0.1)
 
-        # Mid-run the property reports None, never the prior run's reason.
-        assert seen == [None, None]
+        assert seen == [None, None]  # never the prior run's reason
 
 
 class TestStopEventNotInConfigSchema:
-    """``stop_event`` is a live object; it must never reach the config surface."""
-
-    def test_from_config_still_loads(self, tmp_path: Path) -> None:
-        cfg_path = tmp_path / "runtime.yaml"
-        cfg_path.write_text(_minimal_yaml(include_run_block=True))
-
-        assert isinstance(RobotRuntime.from_config(cfg_path), RobotRuntime)
-
     def test_from_config_rejects_stop_event_as_unknown_option(
         self,
         tmp_path: Path,
@@ -1105,9 +1012,8 @@ class TestStopEventNotInConfigSchema:
     ) -> None:
         """Asserts the *reason* for rejection, which is what the skip controls.
 
-        Without ``skip={"stop_event"}`` the key is a known option and fails
-        type validation instead ("Parser key ..."), so asserting on plain
-        ``SystemExit`` would pass either way and cover nothing.
+        Without ``skip={"stop_event"}`` the key is a known option and fails type
+        validation instead, so asserting on bare ``SystemExit`` covers nothing.
         """
         cfg_path = tmp_path / "runtime.yaml"
         cfg_path.write_text(_minimal_yaml() + "run:\n  stop_event: something\n")
@@ -1119,12 +1025,7 @@ class TestStopEventNotInConfigSchema:
 
 
 class TestPolicySourceRerun:
-    """A runtime carrying a real ``PolicySource`` must survive being run twice.
-
-    ``stop()`` makes stop-then-run-again a normal workflow, and the reuse test
-    above covers it with a trivial action source. These cover the real one,
-    where the queue and the inference worker both have to come back.
-    """
+    """A runtime carrying a real ``PolicySource`` must survive being run twice."""
 
     @staticmethod
     def _model(chunk_rows: int = 5, action_dim: int = 3) -> MagicMock:
@@ -1132,27 +1033,15 @@ class TestPolicySourceRerun:
         model.predict_action_chunk.side_effect = lambda _obs: np.zeros((chunk_rows, action_dim), dtype=np.float32)
         return model
 
-    def test_rerun_with_sync_execution(self) -> None:
-        source = PolicySource(model=self._model(), execution=SyncExecution())
-        runtime, robot = _stop_runtime(action_source=source)
-
-        with _frozen_time():
-            first = runtime.run(duration_s=0.5)
-            second = runtime.run(duration_s=0.5)
-
-        assert first == second == 5
-        assert robot.send_action.call_count == 10
-
     def test_queue_counters_describe_one_run_not_all_runs(self) -> None:
         """``connect()`` calls ``reset()``, so the counters are per-session.
 
-        ``docs/reference/runtime-api.md`` points callers at
-        ``action_source.action_queue.total_pops`` for run stats, and
-        ``RobotRuntime._reset_session()`` zeroes its own counters each run — the
-        queue has to agree, or half the stats are cumulative and half are not.
+        The reference docs point callers at ``action_queue.total_pops`` for run
+        stats, and ``_reset_session()`` zeroes its own counters each run — the
+        queue has to agree.
         """
         source = PolicySource(model=self._model(), execution=SyncExecution())
-        runtime, _robot = _stop_runtime(action_source=source)
+        runtime, robot = _stop_runtime(action_source=source)
 
         with _frozen_time():
             first = runtime.run(duration_s=0.5)
@@ -1160,15 +1049,15 @@ class TestPolicySourceRerun:
 
             second = runtime.run(duration_s=0.5)
 
-        # Not first + second: the second run starts the count over.
-        assert source.action_queue.total_pops == second
+        assert first == second == 5
+        assert robot.send_action.call_count == 10
+        assert source.action_queue.total_pops == second  # not first + second
 
     def test_previous_queue_contents_are_never_replayed(self) -> None:
-        """Actions computed in run 1 must not reach the robot in run 2.
+        """A stopped run leaves unsent actions behind; they must be dropped.
 
-        A stopped run leaves unsent actions in the queue. They were computed
-        from observations that are now stale, so ``connect()`` drops them
-        instead of resuming mid-chunk.
+        They were computed from observations that are now stale, so ``connect()``
+        discards them instead of resuming mid-chunk.
         """
         tag = {"value": 1.0}
         model = MagicMock()
@@ -1178,7 +1067,7 @@ class TestPolicySourceRerun:
 
         with _frozen_time():
             runtime.run(duration_s=0.2)
-        assert source.action_queue.remaining > 0, "run 1 should leave unsent actions behind"
+        assert source.action_queue.remaining > 0
 
         tag["value"] = 2.0
         robot.send_action.reset_mock()
@@ -1186,19 +1075,18 @@ class TestPolicySourceRerun:
             runtime.run(duration_s=0.2)
 
         sent = [float(call[0][0][0]) for call in robot.send_action.call_args_list]
-        assert sent, "run 2 sent nothing"
+        assert sent
         assert all(value == 2.0 for value in sent), f"run 1 actions replayed: {sent}"
 
     def test_rerun_with_async_execution_keeps_inferring(self) -> None:
         """The second run must be driven by fresh inference, not a frozen action.
 
-        Regression guard for two separate faults that made a re-run *look*
-        fine: ``PolicySource`` skipping warmup on an emptied queue, and
+        Regression guard for two faults that made a re-run *look* fine:
+        ``PolicySource`` skipping warmup on an emptied queue, and
         ``AsyncExecution`` spawning a worker that saw a stale stop flag and
-        exited. Together they produced a full-length run with zero inference
-        and the robot repeating one action.
+        exited. Together: a full-length run with zero inference.
 
-        Uses real time, since the whole point is that a background thread runs.
+        Real time, since the point is that a background thread runs.
         """
         execution = AsyncExecution()
         source = PolicySource(model=self._model(chunk_rows=5), execution=execution)
@@ -1206,13 +1094,9 @@ class TestPolicySourceRerun:
 
         steps_first = runtime.run(duration_s=0.6)
         steps_second = runtime.run(duration_s=0.6)
-        # Both counters restart each run, so read them directly rather than
-        # differencing against the previous run.
-        inferences_during_second = execution.inference_count
-        holds_during_second = source.action_queue.total_holds
 
         assert steps_first == steps_second == 30
-        # A 5-row chunk over 30 steps needs several refills; the bug gave zero.
-        assert inferences_during_second >= 2, "no background inference in the second run"
-        # The bug held a stale action for 25 of 30 ticks.
-        assert holds_during_second < steps_second // 3, f"queue starved: {holds_during_second} holds"
+        # Both counters restart each run, so read them directly.
+        assert execution.inference_count >= 2, "no background inference in the second run"
+        holds = source.action_queue.total_holds
+        assert holds < steps_second // 3, f"queue starved: {holds} holds"

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -18,7 +18,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from physicalai.runtime import ChunkedActionQueue as ActionQueue, ChunkedActionQueue, LifecycleEvent, PolicySource, RobotRuntime, StopSignal, SyncExecution, WorkerDiedError
+from physicalai.runtime import AsyncExecution, ChunkedActionQueue as ActionQueue, ChunkedActionQueue, LifecycleEvent, PolicySource, RobotRuntime, StopSignal, SyncExecution, WorkerDiedError
 from physicalai.robot.interface import RobotObservation
 from physicalai.inference.model import InferenceModel
 from physicalai.inference.constants import IMAGES, STATE, TASK
@@ -1116,3 +1116,103 @@ class TestStopEventNotInConfigSchema:
             RobotRuntime.from_config(cfg_path)
 
         assert "does not accept option 'stop_event'" in capsys.readouterr().err
+
+
+class TestPolicySourceRerun:
+    """A runtime carrying a real ``PolicySource`` must survive being run twice.
+
+    ``stop()`` makes stop-then-run-again a normal workflow, and the reuse test
+    above covers it with a trivial action source. These cover the real one,
+    where the queue and the inference worker both have to come back.
+    """
+
+    @staticmethod
+    def _model(chunk_rows: int = 5, action_dim: int = 3) -> MagicMock:
+        model = MagicMock()
+        model.predict_action_chunk.side_effect = lambda _obs: np.zeros((chunk_rows, action_dim), dtype=np.float32)
+        return model
+
+    def test_rerun_with_sync_execution(self) -> None:
+        source = PolicySource(model=self._model(), execution=SyncExecution())
+        runtime, robot = _stop_runtime(action_source=source)
+
+        with _frozen_time():
+            first = runtime.run(duration_s=0.5)
+            second = runtime.run(duration_s=0.5)
+
+        assert first == second == 5
+        assert robot.send_action.call_count == 10
+
+    def test_queue_counters_describe_one_run_not_all_runs(self) -> None:
+        """``connect()`` calls ``reset()``, so the counters are per-session.
+
+        ``docs/reference/runtime-api.md`` points callers at
+        ``action_source.action_queue.total_pops`` for run stats, and
+        ``RobotRuntime._reset_session()`` zeroes its own counters each run — the
+        queue has to agree, or half the stats are cumulative and half are not.
+        """
+        source = PolicySource(model=self._model(), execution=SyncExecution())
+        runtime, _robot = _stop_runtime(action_source=source)
+
+        with _frozen_time():
+            first = runtime.run(duration_s=0.5)
+            assert source.action_queue.total_pops == first
+
+            second = runtime.run(duration_s=0.5)
+
+        # Not first + second: the second run starts the count over.
+        assert source.action_queue.total_pops == second
+
+    def test_previous_queue_contents_are_never_replayed(self) -> None:
+        """Actions computed in run 1 must not reach the robot in run 2.
+
+        A stopped run leaves unsent actions in the queue. They were computed
+        from observations that are now stale, so ``connect()`` drops them
+        instead of resuming mid-chunk.
+        """
+        tag = {"value": 1.0}
+        model = MagicMock()
+        model.predict_action_chunk.side_effect = lambda _obs: np.full((8, 3), tag["value"], dtype=np.float32)
+        source = PolicySource(model=model, execution=SyncExecution())
+        runtime, robot = _stop_runtime(action_source=source)
+
+        with _frozen_time():
+            runtime.run(duration_s=0.2)
+        assert source.action_queue.remaining > 0, "run 1 should leave unsent actions behind"
+
+        tag["value"] = 2.0
+        robot.send_action.reset_mock()
+        with _frozen_time():
+            runtime.run(duration_s=0.2)
+
+        sent = [float(call[0][0][0]) for call in robot.send_action.call_args_list]
+        assert sent, "run 2 sent nothing"
+        assert all(value == 2.0 for value in sent), f"run 1 actions replayed: {sent}"
+
+    def test_rerun_with_async_execution_keeps_inferring(self) -> None:
+        """The second run must be driven by fresh inference, not a frozen action.
+
+        Regression guard for two separate faults that made a re-run *look*
+        fine: ``PolicySource`` skipping warmup on an emptied queue, and
+        ``AsyncExecution`` spawning a worker that saw a stale stop flag and
+        exited. Together they produced a full-length run with zero inference
+        and the robot repeating one action.
+
+        Uses real time, since the whole point is that a background thread runs.
+        """
+        execution = AsyncExecution()
+        source = PolicySource(model=self._model(chunk_rows=5), execution=execution)
+        runtime, _robot = _stop_runtime(action_source=source, fps=50.0)
+
+        steps_first = runtime.run(duration_s=0.6)
+        steps_second = runtime.run(duration_s=0.6)
+        # Both counters restart each run, so read them directly rather than
+        # differencing against the previous run.
+        inferences_during_second = execution.inference_count
+        holds_during_second = source.action_queue.total_holds
+
+        assert steps_first == steps_second == 30
+        # A 5-row chunk over 30 steps needs several refills; the bug gave zero.
+        assert inferences_during_second >= 2, "no background inference in the second run"
+        # The bug held a stale action for 25 of 30 ticks.
+        assert holds_during_second < steps_second // 3, f"queue starved: {holds_during_second} holds"


### PR DESCRIPTION
## Summary

Adds option to stop a runtime execution and resume it.

## Why

-

## Validation

-

## Breaking changes

- None

## Related issues

- Closes #
