### PR TITLE
fix: add reorder parameters to SmolVLA preprocessing

### DIFF
--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -112,14 +112,14 @@ class ResizeSmolVLA(Preprocessor):
             resized_img = self._resize_with_pad(img_fp32, target_width, target_height, pad_value=0)
             resized_img = resized_img * 2.0 - 1.0
             bsize = resized_img.shape[0]
-            mask = np.ones(bsize, dtype=np.bool)
+            mask = np.ones(bsize, dtype=np.bool_)
             resized_images.append(resized_img)
             img_masks.append(mask)
 
         reference_img = next((img for img in resized_images if img is not None), None)
         if reference_img is None:
             inputs[IMAGES] = np.empty(0, dtype=np.float32)
-            inputs[IMAGE_MASKS] = np.empty(0, dtype=np.bool)
+            inputs[IMAGE_MASKS] = np.empty(0, dtype=np.bool_)
             return inputs
 
         reference_mask = next(mask for mask in img_masks if mask is not None)

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -36,7 +36,7 @@ class ResizeSmolVLA(Preprocessor):
         """Initialize the SmolVLA numpy-based preprocessor.
 
         Args:
-            image_resolution (tuple[int, int]): The target resolution for input images
+            image_resolution: The target resolution for input images
                 as (height, width). Defaults to (512, 512).
             image_key_reorder_map: Optional mapping from source image keys to target
                 camera indices used for deterministic ordering. Keys may be given with

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -61,21 +61,23 @@ class ResizeSmolVLA(Preprocessor):
         - (B, C, H, W) or (B, H, W, C) with uint8 values in [0, 255]
 
         Args:
-            inputs: Dictionary containing IMAGES key with numpy array(s) of shape
-                    (height, width, channels) or list of such arrays.
+            inputs: Dictionary containing image arrays under the ``images`` key (single
+                array or camera-name dict) or under flat ``images.<camera>`` keys.
 
         Returns:
             Dictionary with processed:
-            - IMAGES: Stacked resized images of shape (batch_size, height, width, channels)
+            - IMAGES: Stacked resized images of shape (n_cameras, batch, channels, height, width)
                         with pixel values normalized to [-1, 1].
-            - IMAGE_MASKS: Boolean masks of shape (batch_size, height, width) indicating
-                             valid image regions (all ones for padded images).
+            - IMAGE_MASKS: Boolean masks of shape (n_cameras, batch) marking which camera
+                             slots hold a real image.
 
         Raises:
-            ValueError: If input images have unsupported data types.
+            ValueError: If input images have unsupported data types, have an ambiguous
+                channel layout, or the camera slots cannot be resolved.
         """
         inputs = dict(inputs)
 
+        target_height, target_width = self.image_resolution
         images_by_key = self._collect_images(inputs)
 
         img_masks: list[np.ndarray | None] = []
@@ -107,7 +109,7 @@ class ResizeSmolVLA(Preprocessor):
             if img_fp32.ndim == 4 and img_fp32.shape[-1] in {1, 2, 3, 4} and img_fp32.shape[1] not in {1, 2, 3, 4}:  # noqa: PLR2004
                 img_fp32 = np.transpose(img_fp32, (0, 3, 1, 2))  # (B, H, W, C) to (B, C, H, W)
 
-            resized_img = self._resize_with_pad(img_fp32, *self.image_resolution, pad_value=0)
+            resized_img = self._resize_with_pad(img_fp32, target_width, target_height, pad_value=0)
             resized_img = resized_img * 2.0 - 1.0
             bsize = resized_img.shape[0]
             mask = np.ones(bsize, dtype=np.bool)
@@ -206,7 +208,20 @@ class ResizeSmolVLA(Preprocessor):
 
     @staticmethod
     def _resize_with_pad(img: np.ndarray, width: int, height: int, pad_value: int = -1) -> np.ndarray:
-        # assume no-op when width height fits already
+        """Resize a batch to fit ``width`` x ``height``, padding the top and left edges.
+
+        Args:
+            img: Image batch of shape (B, C, H, W).
+            width: Target width.
+            height: Target height.
+            pad_value: Fill value for the padded region.
+
+        Returns:
+            Resized batch of shape (B, C, height, width).
+
+        Raises:
+            ValueError: If ``img`` is not 4D or has a zero spatial dimension.
+        """
         img_dim = 4
         if img.ndim != img_dim:
             msg = f"(b,c,h,w) expected, but {img.shape}"

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -23,17 +23,34 @@ class ResizeSmolVLA(Preprocessor):
     Attributes:
         image_resolution (tuple[int, int]): The target resolution for input images
             as (height, width). Defaults to (512, 512).
+        image_key_reorder_map (dict[str, int]): Mapping from image key to camera slot index.
+        num_cameras (int): Total number of camera slots expected by the model.
     """
 
-    def __init__(self, image_resolution: tuple[int, int] = (512, 512)) -> None:
+    def __init__(
+        self,
+        image_resolution: tuple[int, int] = (512, 512),
+        image_key_reorder_map: dict[str, int] | None = None,
+        num_cameras: int = 0,
+    ) -> None:
         """Initialize the SmolVLA numpy-based preprocessor.
 
         Args:
             image_resolution (tuple[int, int]): The target resolution for input images
                 as (height, width). Defaults to (512, 512).
+            image_key_reorder_map: Optional mapping from source image keys to target
+                camera indices used for deterministic ordering. Keys may be given with
+                or without the ``images.`` prefix.
+            num_cameras: Total number of camera slots expected by the model. Slots left
+                unfilled by the input image keys are filled with masked dummy images.
+                Values <= 0 keep only the input cameras, without any dummy images.
         """
         super().__init__()
         self.image_resolution = image_resolution
+        self.image_key_reorder_map = {
+            self._normalize_image_key(key): order for key, order in (image_key_reorder_map or {}).items()
+        }
+        self.num_cameras = num_cameras
 
     def __call__(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """Process and prepare images for model inference.
@@ -59,18 +76,18 @@ class ResizeSmolVLA(Preprocessor):
         """
         inputs = dict(inputs)
 
-        if IMAGES in inputs and isinstance(inputs[IMAGES], np.ndarray):
-            images = [inputs[IMAGES]]
-        elif IMAGES in inputs and isinstance(inputs[IMAGES], dict):
-            images = list(inputs[IMAGES].values())
-        else:
-            img_keys = [key for key in inputs if key.startswith(IMAGES)]
-            images = [inputs[img_keys[0]]] if len(img_keys) == 1 else [inputs[key] for key in img_keys]
+        images_by_key = self._collect_images(inputs)
 
-        img_masks = []
-        resized_images = []
+        img_masks: list[np.ndarray | None] = []
+        resized_images: list[np.ndarray | None] = []
 
-        for img in images:
+        for key in self._camera_slot_layout(list(images_by_key)):
+            if key is None:
+                resized_images.append(None)
+                img_masks.append(None)
+                continue
+
+            img = images_by_key[key]
             if img.dtype == np.uint8:
                 img_fp32 = img.astype(np.float32) / 255.0
             elif np.issubdtype(img.dtype, np.floating):
@@ -97,10 +114,95 @@ class ResizeSmolVLA(Preprocessor):
             resized_images.append(resized_img)
             img_masks.append(mask)
 
-        inputs[IMAGES] = np.stack(resized_images, axis=0)
-        inputs[IMAGE_MASKS] = np.stack(img_masks, axis=0)
+        reference_img = next((img for img in resized_images if img is not None), None)
+        if reference_img is None:
+            inputs[IMAGES] = np.empty(0, dtype=np.float32)
+            inputs[IMAGE_MASKS] = np.empty(0, dtype=np.bool)
+            return inputs
+
+        reference_mask = next(mask for mask in img_masks if mask is not None)
+        inputs[IMAGES] = np.stack(
+            [np.full_like(reference_img, -1.0) if img is None else img for img in resized_images],
+            axis=0,
+        )
+        inputs[IMAGE_MASKS] = np.stack(
+            [np.zeros_like(reference_mask) if mask is None else mask for mask in img_masks],
+            axis=0,
+        )
 
         return inputs
+
+    @staticmethod
+    def _normalize_image_key(key: str) -> str:
+        """Prefix a bare camera name with ``images.``.
+
+        Args:
+            key: Image key or camera name.
+
+        Returns:
+            Key in canonical ``images.<camera>`` form, or ``images`` when already exact.
+        """
+        if key == IMAGES or key.startswith(f"{IMAGES}."):
+            return key
+        return f"{IMAGES}.{key}"
+
+    @staticmethod
+    def _collect_images(inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Gather camera images from the input dict, keyed by canonical image key.
+
+        Args:
+            inputs: Preprocessor input dict.
+
+        Returns:
+            Mapping of image key to image array, in input order.
+        """
+        images_value = inputs.get(IMAGES)
+        if isinstance(images_value, np.ndarray):
+            return {IMAGES: images_value}
+        if isinstance(images_value, dict):
+            return {ResizeSmolVLA._normalize_image_key(name): img for name, img in images_value.items()}
+        return {key: value for key, value in inputs.items() if key.startswith(f"{IMAGES}.")}
+
+    def _camera_slot_layout(self, image_keys: list[str]) -> list[str | None]:
+        """Resolve the camera slot layout for a set of image keys.
+
+        Args:
+            image_keys: Image keys present in the input.
+
+        Returns:
+            List of camera slots, where each entry is either an image key or ``None``
+            for a slot that must be filled with an empty camera.
+
+        Raises:
+            ValueError: If ``image_key_reorder_map`` is set and its keys do not match
+                the input image keys exactly, or if the resolved slots do not fit into
+                ``num_cameras``.
+        """
+        if self.image_key_reorder_map:
+            if set(self.image_key_reorder_map) != set(image_keys):
+                msg = (
+                    "image_key_reorder_map keys must match the input image keys exactly. "
+                    f"Expected {sorted(self.image_key_reorder_map)}, got {sorted(image_keys)}."
+                )
+                raise ValueError(msg)
+            slot_by_key = {key: self.image_key_reorder_map[key] for key in image_keys}
+        else:
+            slot_by_key = {key: index for index, key in enumerate(image_keys)}
+
+        if self.num_cameras <= 0:
+            return sorted(image_keys, key=lambda key: slot_by_key[key])
+
+        if any(slot >= self.num_cameras for slot in slot_by_key.values()):
+            msg = (
+                f"num_cameras={self.num_cameras} is too small for the resolved camera slots "
+                f"{sorted(slot_by_key.values())} of image keys {sorted(image_keys)}."
+            )
+            raise ValueError(msg)
+
+        layout: list[str | None] = [None] * self.num_cameras
+        for key, slot in slot_by_key.items():
+            layout[slot] = key
+        return layout
 
     @staticmethod
     def _resize_with_pad(img: np.ndarray, width: int, height: int, pad_value: int = -1) -> np.ndarray:

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -43,7 +43,9 @@ class ResizeSmolVLA(Preprocessor):
                 as (height, width). Defaults to (512, 512).
             image_key_reorder_map: Optional mapping from source image keys to target
                 camera indices used for deterministic ordering. Keys may be given with
-                or without the ``images.`` prefix.
+                or without the ``images.`` prefix. When the input holds a single unnamed
+                image under ``images``, a single-entry map applies to it regardless of
+                its key name.
             num_cameras: Total number of camera slots expected by the model. Slots left
                 unfilled by the input image keys are filled with masked dummy images
                 shaped after the real cameras, or after ``image_resolution`` with a
@@ -203,16 +205,21 @@ class ResizeSmolVLA(Preprocessor):
         Raises:
             ValueError: If ``image_key_reorder_map`` is set and its keys do not match
                 the input image keys exactly, or if the resolved slots do not fit into
-                ``num_cameras``.
+                ``num_cameras``. A single-entry map is exempt from the name check when
+                the input is one unnamed image.
         """
         if self.image_key_reorder_map:
-            if set(self.image_key_reorder_map) != set(image_keys):
+            # An unnamed single image cannot be matched by name, so a single-entry map applies to it.
+            if image_keys == [IMAGES] and len(self.image_key_reorder_map) == 1:
+                slot_by_key = {IMAGES: next(iter(self.image_key_reorder_map.values()))}
+            elif set(self.image_key_reorder_map) != set(image_keys):
                 msg = (
                     "image_key_reorder_map keys must match the input image keys exactly. "
                     f"Expected {sorted(self.image_key_reorder_map)}, got {sorted(image_keys)}."
                 )
                 raise ValueError(msg)
-            slot_by_key = {key: self.image_key_reorder_map[key] for key in image_keys}
+            else:
+                slot_by_key = {key: self.image_key_reorder_map[key] for key in image_keys}
         else:
             slot_by_key = {key: index for index, key in enumerate(image_keys)}
 

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -44,6 +44,10 @@ class ResizeSmolVLA(Preprocessor):
             num_cameras: Total number of camera slots expected by the model. Slots left
                 unfilled by the input image keys are filled with masked dummy images.
                 Values <= 0 keep only the input cameras, without any dummy images.
+
+        Raises:
+            ValueError: If ``image_key_reorder_map`` contains negative or duplicate slot
+                indices.
         """
         super().__init__()
         self.image_resolution = image_resolution
@@ -51,6 +55,17 @@ class ResizeSmolVLA(Preprocessor):
             self._normalize_image_key(key): order for key, order in (image_key_reorder_map or {}).items()
         }
         self.num_cameras = num_cameras
+
+        negative = sorted(key for key, slot in self.image_key_reorder_map.items() if slot < 0)
+        if negative:
+            msg = f"image_key_reorder_map slot indices must be non-negative, got negative values for {negative}."
+            raise ValueError(msg)
+
+        slots = list(self.image_key_reorder_map.values())
+        if len(set(slots)) != len(slots):
+            duplicates = sorted({slot for slot in slots if slots.count(slot) > 1})
+            msg = f"image_key_reorder_map slot indices must be unique, got duplicates {duplicates}."
+            raise ValueError(msg)
 
     def __call__(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """Process and prepare images for model inference.

--- a/src/physicalai/inference/preprocessors/smolvla.py
+++ b/src/physicalai/inference/preprocessors/smolvla.py
@@ -12,6 +12,9 @@ from physicalai.inference.constants import IMAGE_MASKS, IMAGES
 
 from .base import Preprocessor
 
+# Dummy camera slots assume RGB, matching the SigLIP vision tower.
+_RGB_CHANNELS = 3
+
 
 class ResizeSmolVLA(Preprocessor):
     """Preprocessor for resizing images for SmolVLA model using numpy operations.
@@ -42,8 +45,10 @@ class ResizeSmolVLA(Preprocessor):
                 camera indices used for deterministic ordering. Keys may be given with
                 or without the ``images.`` prefix.
             num_cameras: Total number of camera slots expected by the model. Slots left
-                unfilled by the input image keys are filled with masked dummy images.
-                Values <= 0 keep only the input cameras, without any dummy images.
+                unfilled by the input image keys are filled with masked dummy images
+                shaped after the real cameras, or after ``image_resolution`` with a
+                single RGB frame when no real camera is present. Values <= 0 keep only
+                the input cameras, without any dummy images.
 
         Raises:
             ValueError: If ``image_key_reorder_map`` contains negative or duplicate slot
@@ -132,12 +137,17 @@ class ResizeSmolVLA(Preprocessor):
             img_masks.append(mask)
 
         reference_img = next((img for img in resized_images if img is not None), None)
-        if reference_img is None:
+        if reference_img is not None:
+            reference_mask = next(mask for mask in img_masks if mask is not None)
+        elif resized_images:
+            # All slots are dummies, so there is no real frame to copy shape from.
+            reference_img = np.empty((1, _RGB_CHANNELS, target_height, target_width), dtype=np.float32)
+            reference_mask = np.empty(1, dtype=np.bool_)
+        else:
             inputs[IMAGES] = np.empty(0, dtype=np.float32)
             inputs[IMAGE_MASKS] = np.empty(0, dtype=np.bool_)
             return inputs
 
-        reference_mask = next(mask for mask in img_masks if mask is not None)
         inputs[IMAGES] = np.stack(
             [np.full_like(reference_img, -1.0) if img is None else img for img in resized_images],
             axis=0,

--- a/tests/unit/inference/preprocessors/test_smolvla.py
+++ b/tests/unit/inference/preprocessors/test_smolvla.py
@@ -317,6 +317,22 @@ class TestResizeSmolVLACameraSlots:
         assert result[IMAGE_MASKS][0].all()
         assert not result[IMAGE_MASKS][1].any()
 
+    def test_single_array_input_uses_single_entry_reorder_map(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": 1}, num_cameras=3)
+        result = prep({IMAGES: np.ones((1, 3, 64, 64), dtype=np.float32)})
+        assert result[IMAGES].shape == (3, 1, 3, 64, 64)
+        np.testing.assert_allclose(result[IMAGES][1].max(), 1.0, atol=1e-5)
+        np.testing.assert_allclose(result[IMAGES][0], -1.0)
+        np.testing.assert_allclose(result[IMAGES][2], -1.0)
+        assert result[IMAGE_MASKS][1].all()
+        assert not result[IMAGE_MASKS][0].any()
+        assert not result[IMAGE_MASKS][2].any()
+
+    def test_single_array_input_with_multi_entry_reorder_map_raises(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": 1, "wrist": 0}, num_cameras=2)
+        with pytest.raises(ValueError, match="must match the input image keys exactly"):
+            prep({IMAGES: np.ones((1, 3, 64, 64), dtype=np.float32)})
+
     def test_single_array_input_unaffected_by_defaults(self) -> None:
         prep = ResizeSmolVLA(image_resolution=(64, 64))
         img = np.random.rand(2, 3, 32, 32).astype(np.float32)

--- a/tests/unit/inference/preprocessors/test_smolvla.py
+++ b/tests/unit/inference/preprocessors/test_smolvla.py
@@ -212,3 +212,92 @@ class TestResizeSmolVLAResizeWithPad:
         img = np.zeros((1, 3, 64, 0), dtype=np.float32)
         with pytest.raises(ValueError, match="zero spatial dimension"):
             prep({IMAGES: img})
+
+
+class TestResizeSmolVLACameraSlots:
+    @staticmethod
+    def _inputs() -> dict[str, np.ndarray]:
+        return {
+            f"{IMAGES}.top": np.zeros((1, 3, 64, 64), dtype=np.float32),
+            f"{IMAGES}.wrist": np.ones((1, 3, 64, 64), dtype=np.float32),
+        }
+
+    def test_reorder_map_orders_cameras(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": 1, "wrist": 0})
+        result = prep(self._inputs())
+        # wrist (all ones -> +1) occupies slot 0, top (all zeros -> -1) slot 1
+        np.testing.assert_allclose(result[IMAGES][0].max(), 1.0, atol=1e-5)
+        np.testing.assert_allclose(result[IMAGES][1].max(), -1.0, atol=1e-5)
+
+    def test_reorder_map_accepts_prefixed_keys(self) -> None:
+        prep = ResizeSmolVLA(
+            image_resolution=(64, 64),
+            image_key_reorder_map={f"{IMAGES}.top": 1, f"{IMAGES}.wrist": 0},
+        )
+        result = prep(self._inputs())
+        np.testing.assert_allclose(result[IMAGES][0].max(), 1.0, atol=1e-5)
+
+    def test_reorder_map_key_mismatch_raises(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": 0})
+        with pytest.raises(ValueError, match="must match the input image keys exactly"):
+            prep(self._inputs())
+
+    def test_num_cameras_pads_empty_slots(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), num_cameras=3)
+        result = prep(self._inputs())
+        assert result[IMAGES].shape == (3, 1, 3, 64, 64)
+        assert result[IMAGE_MASKS].shape == (3, 1)
+        np.testing.assert_allclose(result[IMAGES][2], -1.0)
+        assert not result[IMAGE_MASKS][2].any()
+        assert result[IMAGE_MASKS][0].all()
+
+    def test_num_cameras_with_reorder_map_leaves_gap(self) -> None:
+        prep = ResizeSmolVLA(
+            image_resolution=(64, 64),
+            image_key_reorder_map={"top": 0, "wrist": 2},
+            num_cameras=3,
+        )
+        result = prep(self._inputs())
+        np.testing.assert_allclose(result[IMAGES][1], -1.0)
+        assert not result[IMAGE_MASKS][1].any()
+        np.testing.assert_allclose(result[IMAGES][2].max(), 1.0, atol=1e-5)
+
+    def test_num_cameras_too_small_raises(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), num_cameras=1)
+        with pytest.raises(ValueError, match="too small for the resolved camera slots"):
+            prep(self._inputs())
+
+    def test_dict_images_respect_reorder_map(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": 1, "wrist": 0})
+        inputs = {
+            IMAGES: {
+                "top": np.zeros((1, 3, 64, 64), dtype=np.float32),
+                "wrist": np.ones((1, 3, 64, 64), dtype=np.float32),
+            },
+        }
+        result = prep(inputs)
+        np.testing.assert_allclose(result[IMAGES][0].max(), 1.0, atol=1e-5)
+
+    def test_no_images_returns_empty_arrays(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        result = prep({"task": "pick up"})
+        assert result[IMAGES].size == 0
+        assert result[IMAGE_MASKS].size == 0
+
+    def test_single_array_input_with_num_cameras(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64), num_cameras=2)
+        img = np.ones((1, 3, 64, 64), dtype=np.float32)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].shape == (2, 1, 3, 64, 64)
+        np.testing.assert_allclose(result[IMAGES][0].max(), 1.0, atol=1e-5)
+        np.testing.assert_allclose(result[IMAGES][1], -1.0)
+        assert result[IMAGE_MASKS][0].all()
+        assert not result[IMAGE_MASKS][1].any()
+
+    def test_single_array_input_unaffected_by_defaults(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(64, 64))
+        img = np.random.rand(2, 3, 32, 32).astype(np.float32)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].shape == (1, 2, 3, 64, 64)
+        assert result[IMAGE_MASKS].shape == (1, 2)
+        assert result[IMAGE_MASKS].all()

--- a/tests/unit/inference/preprocessors/test_smolvla.py
+++ b/tests/unit/inference/preprocessors/test_smolvla.py
@@ -86,6 +86,13 @@ class TestResizeSmolVLACall:
         assert result[IMAGES].shape[3] == 64
         assert result[IMAGES].shape[4] == 64
 
+    def test_non_square_resolution_not_transposed(self) -> None:
+        # Regression: image_resolution is (height, width); _resize_with_pad takes (width, height).
+        prep = ResizeSmolVLA(image_resolution=(120, 240))
+        img = np.random.rand(1, 3, 60, 60).astype(np.float32)
+        result = prep({IMAGES: img})
+        assert result[IMAGES].shape == (1, 1, 3, 120, 240)
+
     def test_dict_images_stacked(self) -> None:
         prep = ResizeSmolVLA(image_resolution=(64, 64))
         inputs = {

--- a/tests/unit/inference/preprocessors/test_smolvla.py
+++ b/tests/unit/inference/preprocessors/test_smolvla.py
@@ -299,6 +299,14 @@ class TestResizeSmolVLACameraSlots:
         assert result[IMAGES].size == 0
         assert result[IMAGE_MASKS].size == 0
 
+    def test_no_images_with_num_cameras_returns_dummy_slots(self) -> None:
+        prep = ResizeSmolVLA(image_resolution=(48, 64), num_cameras=2)
+        result = prep({"task": "pick up"})
+        assert result[IMAGES].shape == (2, 1, 3, 48, 64)
+        assert result[IMAGE_MASKS].shape == (2, 1)
+        np.testing.assert_allclose(result[IMAGES], -1.0)
+        assert not result[IMAGE_MASKS].any()
+
     def test_single_array_input_with_num_cameras(self) -> None:
         prep = ResizeSmolVLA(image_resolution=(64, 64), num_cameras=2)
         img = np.ones((1, 3, 64, 64), dtype=np.float32)

--- a/tests/unit/inference/preprocessors/test_smolvla.py
+++ b/tests/unit/inference/preprocessors/test_smolvla.py
@@ -249,6 +249,14 @@ class TestResizeSmolVLACameraSlots:
         with pytest.raises(ValueError, match="must match the input image keys exactly"):
             prep(self._inputs())
 
+    def test_negative_slot_index_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be non-negative"):
+            ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": -1, "wrist": 0})
+
+    def test_duplicate_slot_index_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be unique"):
+            ResizeSmolVLA(image_resolution=(64, 64), image_key_reorder_map={"top": 0, "wrist": 0})
+
     def test_num_cameras_pads_empty_slots(self) -> None:
         prep = ResizeSmolVLA(image_resolution=(64, 64), num_cameras=3)
         result = prep(self._inputs())


### PR DESCRIPTION
## Summary

- Aligns preprocessor with the changes from https://github.com/open-edge-platform/physical-ai-studio/pull/893
- resolves https://github.com/openvinotoolkit/physicalai/issues/218

## Why

- Inference of SmolVLA fails, because preprocessor sees unexpected extra parameters in the exported model manifest

## Validation

- Libero run + l2 comparison

