### PR TITLE
feat: targeted code quality dirs

### DIFF
--- a/.github/bandit_config.yml
+++ b/.github/bandit_config.yml
@@ -1,2 +1,2 @@
-exclude_dirs: ["tests", "*/tests/*"]
+exclude_dirs: ["tests", "*/tests/*", "tmp", "*/tmp/*"]
 skips: ["B101"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         name: pyrefly (type checking)
         entry: pyrefly check
         language: python
-        additional_dependencies: [pyrefly==0.57.1]
+        additional_dependencies: [pyrefly==1.2.0]
         pass_filenames: false
         types: [python]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,9 @@ repos:
     hooks:
       - id: ruff-check
         args: [--fix, --unsafe-fixes]
+        files: ^src/
       - id: ruff-format
+        files: ^src/
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: "0.9.7"

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,2 +1,3 @@
 **/uv.lock
 tests/
+tmp/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,15 @@ include = [
 
 [tool.pyrefly]
 python-version = "3.11"
+search-path = ["src"]
+project-includes = ["src", "tests"]
 ignore-missing-imports = ["*"]
+
+[tool.mypy]
+files = ["src", "tests"]
+mypy_path = "src"
+ignore_missing_imports = true
+explicit_package_bases = true
 
 [tool.uv]
 default-groups = ["dev"]
@@ -113,6 +121,7 @@ default-groups = ["dev"]
 target-version = "py311"
 line-length = 120
 preview = true
+include = ["src/**/*.py", "src/**/*.pyi"]
 exclude = [
     ".bzr",
     ".direnv",
@@ -225,6 +234,9 @@ exclude_lines = [
     "raise ValueError",
     "except ImportError:",
 ]
+
+[tool.coverage.run]
+source = ["src/physicalai"]
 
 [tool.coverage.paths]
 source = ["src"]


### PR DESCRIPTION
## Summary

Scopes Pyrefly and Mypy to Runtime-owned src and tests directories, while limiting Ruff and its Prek hooks to src.

Coverage now targets physicalai, and Bandit/Semgrep ignore temporary directories, preventing unrelated code and nested repositories from affecting checks.

## Why

#235 
