### PR TITLE
feat: add policy source reset

### DIFF
--- a/docs/explanation/runtime.md
+++ b/docs/explanation/runtime.md
@@ -48,7 +48,9 @@ A stop takes effect between ticks, never inside one. The tick already underway f
 
 Use `runtime.stop()` when the code asking for the stop lives in the same program. Use `run(stop_event=...)` when it does not: pass any object with an `is_set()` method, and one process can stop a session running in another. The runtime checks both, so whichever comes first ends the run.
 
-Stopping is not the same as shutting down. It ends the control loop, but the robot and cameras stay connected until the context manager releases them, so one runtime can stop and run again. `last_run_reason` and the `shutdown` event's `reason` field say why a run ended.
+Stopping is not the same as shutting down. It ends the control loop, but the robot, cameras, and callbacks stay active, so one runtime can stop and run again. Each run emits its own `start` and `shutdown` lifecycle events. `last_run_reason` and the `shutdown` event's `reason` field say why a run ended.
+
+`disconnect()` is final. It closes callbacks and disconnects hardware exactly once; create a new runtime to connect again. A failed `connect()` already rolls back partial hardware setup, so retry it by calling `connect()` again without calling `disconnect()`. This keeps callback resources such as files and background threads usable across runs while giving them one clear disposal point.
 
 ## Execution Modes
 

--- a/docs/how-to/runtime/add-runtime-callbacks.md
+++ b/docs/how-to/runtime/add-runtime-callbacks.md
@@ -25,4 +25,6 @@ runtime = RobotRuntime(
 )
 ```
 
+The same callback instances receive every `run()` performed before the runtime is disconnected. Use the `start` and `shutdown` lifecycle events to separate per-run state. `RobotRuntime.disconnect()` or context exit closes callback resources exactly once and permanently disposes that runtime.
+
 As a general rule, keep workflow-specific logic in callbacks unless the same behavior becomes a reusable runtime primitive.

--- a/docs/how-to/runtime/run-policy-on-robot.md
+++ b/docs/how-to/runtime/run-policy-on-robot.md
@@ -43,7 +43,7 @@ with runtime:
 print(runtime.last_run_reason)      # stop_requested
 ```
 
-The event only has to provide `is_set()`, so a `multiprocessing.Event` works the same way when the session runs in a subprocess. Either way the run ends through the normal shutdown path: the `shutdown` lifecycle event fires, callbacks are flushed, and the action source is disconnected.
+The event only has to provide `is_set()`, so a `multiprocessing.Event` works the same way when the session runs in a subprocess. Either way the run ends through the normal shutdown path: the `shutdown` lifecycle event fires, callbacks are flushed, and the action source is disconnected. Callback resources remain open for another `run()` and close when the runtime context exits or `disconnect()` is called.
 
 ## From Config
 

--- a/docs/reference/runtime-api.md
+++ b/docs/reference/runtime-api.md
@@ -26,6 +26,8 @@ runtime.last_run_reason -> RunReason | None
 
 `RobotRuntime` also supports context-manager usage so connections are cleaned up automatically. A "step" is one iteration of the control loop at `fps`: read an observation, get one action from `action_source`, and send it to the robot. `run()` returns the number of steps completed this run — there is no aggregate stats object. Other stats are read directly off the objects the caller already holds, e.g. `runtime.action_source.action_queue.total_pops` or `execution.inference_count`. Each `run()` starts those counters from zero, so they describe the latest run rather than a running total.
 
+Callbacks belong to the runtime. They remain open across consecutive `run()` calls and receive a separate `start` and `shutdown` lifecycle event for each one. `disconnect()` means the caller is finished with the runtime: it closes callbacks and hardware exactly once, and the runtime cannot reconnect. If `connect()` fails, it rolls back partially connected hardware; call `connect()` again directly to retry.
+
 ```python
 with RobotRuntime(...) as runtime:
     steps = runtime.run(duration_s=60)
@@ -65,7 +67,7 @@ class ActionSource(Protocol):
     def disconnect(self) -> None: ...
 ```
 
-`bus` is an internal callback bus injected fresh by `RobotRuntime` on every `run()`; action sources typically only forward it into an `Execution` strategy (see `PolicySource` below) rather than using it directly.
+`bus` is an internal, runtime-scoped callback bus injected by `RobotRuntime` on every `run()`; action sources typically only forward it into an `Execution` strategy (see `PolicySource` below) rather than using it directly.
 
 The action-source implementations shipped today are listed below.
 
@@ -83,6 +85,9 @@ PolicySource(
     task: str | None = None,
 )
 
+source.reset(*, reset_model: bool = True) -> None
+source.warmup(observation: dict[str, Any]) -> None
+
 TeleopSource(
     leader: Robot,
     *,
@@ -90,13 +95,18 @@ TeleopSource(
 )
 ```
 
+`reset()` starts a fresh policy episode without stopping the execution worker. It discards queued, pending, and in-flight actions, clears the last action, and resets model state by default. If inference is already running, reset waits for that model call to finish before resetting model state, while rejecting its stale result. Model or execution reset errors propagate to the caller. Pass `reset_model=False` only when model state should continue across the episode boundary. Custom execution strategies must implement `Execution.reset()` before they can support this operation.
+
+`warmup()` accepts model-ready input, such as `source.to_model_input(robot_state, camera_frames)`, and seeds the queue before the next control tick. It is optional: `update()` performs the same warmup lazily after `connect()` or `reset()`.
+
 ## `Execution`
 
 ```python
 class Execution:
     def start(self, model: InferenceModel, action_queue: ActionQueue) -> None: ...
-    def maybe_request(self, observation: dict[str, np.ndarray]) -> None: ...
-    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None: ...
+    def maybe_request(self, observation: dict[str, Any]) -> None: ...
+    def warmup(self, sample_observation: dict[str, Any]) -> None: ...
+    def reset(self, *, reset_model: bool = True) -> None: ...
     def stop(self) -> None: ...
     @property
     def chunk_size(self) -> int: ...

--- a/src/physicalai/runtime/_callback_bus.py
+++ b/src/physicalai/runtime/_callback_bus.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from collections import deque
 from typing import TYPE_CHECKING, Any
 
@@ -40,6 +41,8 @@ class _CallbackBus:
     def __init__(self, callbacks: Sequence[Any]) -> None:
         self._callbacks = list(callbacks)
         self._inference_queue: deque[InferenceEvent] = deque(maxlen=_INFERENCE_QUEUE_MAXLEN)
+        self._close_lock = threading.Lock()
+        self._closed = False
 
     def emit_tick(self, event: TickEvent) -> None:
         self._drain_inference()
@@ -125,13 +128,38 @@ class _CallbackBus:
                 logger.exception("Callback %r failed in on_metrics", cb)
 
     def close(self) -> None:
+        """Flush and close every callback exactly once."""
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        try:
+            self.flush()
+        finally:
+            first_base_exception: BaseException | None = None
+            for cb in self._callbacks:
+                close_fn = getattr(cb, "close", None)
+                if close_fn is not None:
+                    try:
+                        close_fn()
+                    except Exception:
+                        logger.exception("Callback %r failed in close", cb)
+                    except BaseException as exc:  # noqa: BLE001
+                        if first_base_exception is None:
+                            first_base_exception = exc
+            if first_base_exception is not None:
+                raise first_base_exception
+
+    def flush(self) -> None:
+        """Deliver queued inference events and flush callback-owned buffers."""
+        self._drain_inference()
         for cb in self._callbacks:
-            close_fn = getattr(cb, "close", None)
-            if close_fn is not None:
+            flush_fn = getattr(cb, "flush", None)
+            if flush_fn is not None:
                 try:
-                    close_fn()
+                    flush_fn()
                 except Exception:
-                    logger.exception("Callback %r failed in close", cb)
+                    logger.exception("Callback %r failed in flush", cb)
 
     def _drain_inference(self) -> None:
         while self._inference_queue:

--- a/src/physicalai/runtime/action_sources/policy.py
+++ b/src/physicalai/runtime/action_sources/policy.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,7 @@ from physicalai.config import export_config
 from physicalai.inference.constants import IMAGES, STATE, TASK
 from physicalai.runtime.action_sources.base import ActionSource
 from physicalai.runtime.events import MetricsEvent
+from physicalai.runtime.execution.base import Execution
 from physicalai.runtime.execution.queue import ChunkedActionQueue
 from physicalai.runtime.execution.sync import SyncExecution
 from physicalai.runtime.smoothers import LerpSmoother
@@ -25,7 +27,6 @@ if TYPE_CHECKING:
     from physicalai.inference.model import InferenceModel
     from physicalai.robot.interface import RobotObservation
     from physicalai.runtime._callback_bus import _CallbackBus
-    from physicalai.runtime.execution.base import Execution
     from physicalai.runtime.execution.queue import ActionQueue
 
 _DEFAULT_LERP_FRAMES = 5
@@ -55,10 +56,12 @@ class PolicySource(ActionSource):
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
         self._connected = False
+        self._state_lock = threading.RLock()
 
     def set_task(self, task: str | None) -> None:
         """Update the task string used for the *next* inference request."""
-        self._task = task
+        with self._state_lock:
+            self._task = task
 
     @property
     def action_queue(self) -> ActionQueue:
@@ -71,18 +74,75 @@ class PolicySource(ActionSource):
 
     def connect(self, *, bus: _CallbackBus, session_id: str) -> None:
         """Inject bus/session into execution and start it."""
-        if not self._connected:
-            self._connected = True
+        with self._state_lock:
+            if self._connected:
+                return
             self._bus = bus
             self._session_id = session_id
             self._execution.set_bus(bus, session_id)
             self._execution.start(self._model, self._action_queue)
-            # reset(): also zeroes total_pops/total_holds, so the
-            # queue's counters describe this run rather than every run so far.
-            self._action_queue.reset()
-            self._last = None
-            # Re-seed on every run. connect() has just emptied the queue
-            self._warmed_up = False
+            try:
+                if self._supports_reset:
+                    self._execution.reset(reset_model=True)
+                self._action_queue.reset()
+                self._last = None
+                self._warmed_up = False
+            except BaseException:
+                self._execution.stop()
+                raise
+            self._connected = True
+
+    def reset(self, *, reset_model: bool = True) -> None:
+        """Discard queued actions and per-episode state; the next update re-seeds.
+
+        The execution worker remains running. Pending and in-flight results from
+        the previous episode are invalidated before the queue is cleared. This
+        may wait for inference already inside the model to finish.
+
+        Args:
+            reset_model: Also reset state held by the inference model.
+
+        Raises:
+            RuntimeError: If the source is not connected or its execution
+                strategy does not support safe episode reset.
+        """
+        with self._state_lock:
+            if not self._connected:
+                msg = "PolicySource.reset() requires connect() first"
+                raise RuntimeError(msg)
+            if not self._supports_reset:
+                msg = f"{type(self._execution).__name__} does not support safe episode reset"
+                raise RuntimeError(msg)
+            try:
+                self._execution.reset(reset_model=reset_model)
+            finally:
+                self._action_queue.reset()
+                self._last = None
+                self._warmed_up = False
+
+    def warmup(self, observation: dict[str, Any]) -> None:
+        """Seed the action queue so the next :meth:`update` does not block.
+
+        Args:
+            observation: Model-ready input, such as the result of
+                :meth:`to_model_input`.
+
+        Raises:
+            RuntimeError: If the source is not connected or warmup is cancelled.
+        """
+        with self._state_lock:
+            if not self._connected:
+                msg = "PolicySource.warmup() requires connect() first"
+                raise RuntimeError(msg)
+            if self._warmed_up:
+                return
+            self._execution.warmup(observation)
+            self._warmed_up = True
+
+    @property
+    def _supports_reset(self) -> bool:
+        reset = getattr(type(self._execution), "reset", None)
+        return reset is not None and reset is not Execution.reset
 
     def update(self, robot_state: RobotObservation, camera_frames: Mapping[str, Frame], step: int) -> np.ndarray:
         """Maybe request inference and return the next action.
@@ -98,41 +158,44 @@ class PolicySource(ActionSource):
         Raises:
             RuntimeError: If the queue is empty and no action has ever been produced.
         """
-        model_input = self._to_model_input(robot_state, camera_frames)
+        with self._state_lock:
+            model_input = self._to_model_input(robot_state, camera_frames)
 
-        if not self._warmed_up:
-            self._execution.warmup(model_input)
-            self._warmed_up = True
+            if not self._warmed_up:
+                self.warmup(model_input)
 
-        self._execution.maybe_request(model_input)
+            self._execution.maybe_request(model_input)
 
-        action = self._action_queue.pop()
-        if action is None:
-            if self._last is None:
-                msg = "No action available and none produced yet (warmup may have failed)"
-                raise RuntimeError(msg)
-            action = self._last
-        else:
-            self._last = action
+            action = self._action_queue.pop()
+            if action is None:
+                if self._last is None:
+                    msg = "No action available and none produced yet (warmup may have failed)"
+                    raise RuntimeError(msg)
+                action = self._last
+            else:
+                self._last = action
 
-        if self._bus is not None:
-            self._bus.emit_metrics(
-                MetricsEvent(
-                    session_id=self._session_id,
-                    step=step,
-                    timestamp=time.time(),
-                    values={"queue_remaining": float(self._action_queue.remaining)},
+            if self._bus is not None:
+                self._bus.emit_metrics(
+                    MetricsEvent(
+                        session_id=self._session_id,
+                        step=step,
+                        timestamp=time.time(),
+                        values={"queue_remaining": float(self._action_queue.remaining)},
+                    )
                 )
-            )
 
-        return action
+            return action
 
     def disconnect(self) -> None:
         """Stop execution — no drain, queued actions are discarded."""
-        try:
-            self._execution.stop()
-        finally:
-            self._connected = False
+        with self._state_lock:
+            if not self._connected:
+                return
+            try:
+                self._execution.stop()
+            finally:
+                self._connected = False
 
     def _to_model_input(self, robot_obs: RobotObservation, camera_frames: Mapping[str, Frame]) -> dict[str, Any]:
         """Assemble model input dict from observation and camera frames.
@@ -165,4 +228,5 @@ class PolicySource(ActionSource):
         Returns:
             Dictionary ready for model inference.
         """
-        return self._to_model_input(robot_obs, camera_frames)
+        with self._state_lock:
+            return self._to_model_input(robot_obs, camera_frames)

--- a/src/physicalai/runtime/callbacks/async_callback.py
+++ b/src/physicalai/runtime/callbacks/async_callback.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import threading
+import time
 from collections import deque
 from typing import TYPE_CHECKING, Any
 
@@ -19,18 +20,24 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_CLOSE_TIMEOUT_S = 5.0
+_QUEUE_POLL_INTERVAL_S = 0.001
+
 
 @export_config(class_path="physicalai.runtime.AsyncCallback")
 class AsyncCallback:
     """Wraps a callback so all hooks run on a dedicated background thread.
 
-    The control loop only pays deque.append per event. On overflow, oldest
-    events are dropped.
+    The control loop takes two short locks and appends to a deque per event. On
+    overflow, oldest events are dropped.
     """
 
     _ACTION_HOOKS = ("on_action_ready", "on_action_sent")
 
     def __init__(self, inner: Any, max_queue: int = 1024) -> None:  # noqa: D107, ANN401
+        if max_queue <= 0:
+            msg = f"max_queue must be positive, got {max_queue}"
+            raise ValueError(msg)
         dropped = [h for h in self._ACTION_HOOKS if hasattr(inner, h)]
         if dropped:
             msg = (
@@ -39,9 +46,13 @@ class AsyncCallback:
             )
             raise TypeError(msg)
         self._inner = inner
+        self._max_queue = max_queue
         self._queue: deque[tuple[str, Any]] = deque(maxlen=max_queue)
+        self._queue_lock = threading.Lock()
+        self._close_lock = threading.Lock()
         self._stop = threading.Event()
         self._has_work = threading.Event()
+        self._closed = False
         self._thread = threading.Thread(target=self._worker, name="AsyncCallbackWorker", daemon=True)
         self._thread.start()
 
@@ -77,24 +88,71 @@ class AsyncCallback:
         self._enqueue("on_metrics", event)
 
     def close(self) -> None:
-        """Stop the worker thread and close the inner callback."""
-        self._stop.set()
+        """Drain queued events, stop the worker, and close the inner callback."""
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        deadline = time.monotonic() + _CLOSE_TIMEOUT_S
+        try:
+            self._flush_until(deadline)
+        finally:
+            self._stop.set()
+            self._has_work.set()
+            self._thread.join(timeout=max(0.0, deadline - time.monotonic()))
+            close_fn = getattr(self._inner, "close", None)
+            if close_fn is not None:
+                close_fn()
+
+    def flush(self) -> None:
+        """Wait until all events queued before this call are delivered."""
+        self._flush_until(time.monotonic() + _CLOSE_TIMEOUT_S)
+
+    def _flush_until(self, deadline: float) -> None:
+        if not self._thread.is_alive():
+            return
+        done = threading.Event()
+        while self._thread.is_alive():
+            with self._queue_lock:
+                if len(self._queue) < self._max_queue:
+                    self._queue.append(("_flush", done))
+                    break
+            if time.monotonic() >= deadline:
+                logger.warning("Async callback did not flush within %.1fs", _CLOSE_TIMEOUT_S)
+                return
+            time.sleep(_QUEUE_POLL_INTERVAL_S)
+        else:
+            return
         self._has_work.set()
-        self._thread.join(timeout=5.0)
-        close_fn = getattr(self._inner, "close", None)
-        if close_fn is not None:
-            close_fn()
+        if not done.wait(timeout=max(0.0, deadline - time.monotonic())):
+            logger.warning("Async callback did not flush within %.1fs", _CLOSE_TIMEOUT_S)
 
     def _enqueue(self, method: str, event: Any) -> None:  # noqa: ANN401
-        self._queue.append((method, event))
+        with self._close_lock:
+            if self._closed:
+                return
+            with self._queue_lock:
+                self._queue.append((method, event))
         self._has_work.set()
 
     def _worker(self) -> None:
         while not self._stop.is_set():
             self._has_work.wait()
             self._has_work.clear()
-            while self._queue:
-                method, event = self._queue.popleft()
+            while True:
+                with self._queue_lock:
+                    if not self._queue:
+                        break
+                    method, event = self._queue.popleft()
+                if method == "_flush":
+                    flush_fn = getattr(self._inner, "flush", None)
+                    if flush_fn is not None:
+                        try:
+                            flush_fn()
+                        except Exception:
+                            logger.exception("AsyncCallback inner %r.flush failed", self._inner)
+                    event.set()
+                    continue
                 fn = getattr(self._inner, method, None)
                 if fn is not None:
                     try:

--- a/src/physicalai/runtime/core.py
+++ b/src/physicalai/runtime/core.py
@@ -9,6 +9,7 @@ import logging
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, Self
 
@@ -19,7 +20,7 @@ from physicalai.runtime.events import LifecycleEvent, TickEvent
 from physicalai.runtime.execution.base import WorkerDiedError
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterator, Mapping, Sequence
     from typing import Any
 
     import numpy as np
@@ -145,6 +146,9 @@ class RobotRuntime:
         self._bus = _CallbackBus(callbacks)
         self._goal_time = (1.0 / fps) * _GOAL_TIME_TICKS
         self._connected = False
+        self._closed = False
+        self._lifecycle_lock = threading.Lock()
+        self._run_lock = threading.Lock()
         self._last_robot_obs: RobotObservation | None = None
         self._last_camera_frames: dict[str, Frame] = {}
         self._consecutive_error_ticks: int = 0
@@ -202,50 +206,70 @@ class RobotRuntime:
         disconnects everything already connected and re-raises.
 
         Idempotent — calling on an already-connected runtime is a no-op.
+
+        Raises:
+            RuntimeError: If a run is active or this runtime was disconnected.
         """
-        if self._connected:
-            logger.debug("connect() called but already connected — no-op")
-            return
+        with self._lifecycle_lock:
+            if self._run_lock.locked():
+                msg = "Cannot connect RobotRuntime while run() is active"
+                raise RuntimeError(msg)
+            if self._closed:
+                msg = "RobotRuntime has been disconnected and cannot be connected again; create a new runtime"
+                raise RuntimeError(msg)
+            if self._connected:
+                logger.debug("connect() called but already connected — no-op")
+                return
 
-        self._robot.connect()
-        connected_cameras: list[str] = []
-        try:
-            for name, cam in self._cameras.items():
-                cam.connect()
-                connected_cameras.append(name)
-        except Exception:
-            for cam_name in connected_cameras:
-                try:
-                    self._cameras[cam_name].disconnect()
-                except Exception:
-                    logger.warning("Failed to disconnect camera '%s' during rollback", cam_name, exc_info=True)
+            self._robot.connect()
+            connected_cameras: list[str] = []
             try:
-                self._robot.disconnect()
+                for name, cam in self._cameras.items():
+                    cam.connect()
+                    connected_cameras.append(name)
             except Exception:
-                logger.warning("Failed to disconnect robot during rollback", exc_info=True)
-            raise
-
-        self._connected = True
+                for cam_name in connected_cameras:
+                    try:
+                        self._cameras[cam_name].disconnect()
+                    except Exception:
+                        logger.warning("Failed to disconnect camera '%s' during rollback", cam_name, exc_info=True)
+                try:
+                    self._robot.disconnect()
+                except Exception:
+                    logger.warning("Failed to disconnect robot during rollback", exc_info=True)
+                raise
+            self._connected = True
 
     def disconnect(self) -> None:
-        """Disconnect cameras then robot. Never raises.
+        """Permanently close callbacks and disconnect cameras then robot.
 
-        Idempotent — calling on an already-disconnected runtime is a no-op.
+        Idempotent. A disconnected runtime cannot be connected again; construct
+        a new runtime with fresh callbacks instead.
+
+        Raises:
+            RuntimeError: If a run is still active.
         """
-        if not self._connected:
-            return
-
-        for name, cam in self._cameras.items():
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            if self._run_lock.locked():
+                msg = "Cannot disconnect RobotRuntime while run() is active; stop it and wait for run() to return"
+                raise RuntimeError(msg)
             try:
-                cam.disconnect()
-            except Exception:
-                logger.warning("Failed to disconnect camera '%s'", name, exc_info=True)
-        try:
-            self._robot.disconnect()
-        except Exception:
-            logger.warning("Failed to disconnect robot", exc_info=True)
-
-        self._connected = False
+                if self._connected:
+                    for name, cam in self._cameras.items():
+                        try:
+                            cam.disconnect()
+                        except Exception:
+                            logger.warning("Failed to disconnect camera '%s'", name, exc_info=True)
+                    try:
+                        self._robot.disconnect()
+                    except Exception:
+                        logger.warning("Failed to disconnect robot", exc_info=True)
+            finally:
+                self._connected = False
+                self._closed = True
+                self._bus.close()
 
     def __enter__(self) -> Self:  # noqa: D105
         self.connect()
@@ -326,13 +350,7 @@ class RobotRuntime:
         Raises:
             RuntimeError: If called before ``connect()``.
             WorkerDiedError: If the action source's execution worker dies.
-        """
-        if not self._connected:
-            msg = "RobotRuntime.run() called before connect(). Use 'with runtime:' or call runtime.connect() first."
-            raise RuntimeError(msg)
-
-        self._reset_session()
-
+        """  # noqa: DOC502
         goal_time = 1.0 / self._fps
         step = 0
         # Every normal exit overwrites this, so only a propagating exception
@@ -340,77 +358,104 @@ class RobotRuntime:
         # instead of inheriting whichever normal reason happened to be set.
         reason: RunReason = "error"
 
-        # Source connect and the start event sit inside the try so a failure
-        # there still runs _shutdown(): otherwise the stop flag would survive
-        # into the next run() and silently zero-step every later session.
-        try:
-            self._action_source.connect(bus=self._bus, session_id=self._session_id)
-            self._bus.emit_lifecycle(
-                LifecycleEvent(
-                    session_id=self._session_id,
-                    timestamp=time.time(),
-                    event="start",
-                    metadata={
-                        "fps": self._fps,
-                        "duration_s": duration_s,
-                        "cameras": list(self._cameras.keys()),
-                        "joint_names": self._robot.joint_names,
-                    },
+        with self._active_run():
+            # Source connect and the start event sit inside the try so a failure
+            # there still runs _shutdown(): otherwise the stop flag would survive
+            # into the next run() and silently zero-step every later session.
+            try:
+                self._reset_session()
+                self._action_source.connect(bus=self._bus, session_id=self._session_id)
+                self._bus.emit_lifecycle(
+                    LifecycleEvent(
+                        session_id=self._session_id,
+                        timestamp=time.time(),
+                        event="start",
+                        metadata={
+                            "fps": self._fps,
+                            "duration_s": duration_s,
+                            "cameras": list(self._cameras.keys()),
+                            "joint_names": self._robot.joint_names,
+                        },
+                    )
                 )
-            )
 
-            while True:
-                if self._stop.is_set() or (stop_event is not None and stop_event.is_set()):
-                    reason = "stop_requested"
-                    # Fires after the last tick. Callbacks may take control of the robot from this point.
-                    self._bus.emit_lifecycle(
-                        LifecycleEvent(
+                while True:
+                    if self._stop.is_set() or (stop_event is not None and stop_event.is_set()):
+                        reason = "stop_requested"
+                        # Fires after the last tick. Callbacks may take control of the robot from this point.
+                        self._bus.emit_lifecycle(
+                            LifecycleEvent(
+                                session_id=self._session_id,
+                                timestamp=time.time(),
+                                event="stop_requested",
+                                metadata={"step": step},
+                            )
+                        )
+                        break
+                    if duration_s is not None and step * goal_time >= duration_s:
+                        reason = "duration_elapsed"
+                        break
+
+                    loop_start = time.perf_counter()
+                    robot_state, camera_frames = self._read_observation()
+
+                    action = self._action_source.update(robot_state, camera_frames, step)
+                    action = self._bus.invoke_on_action_ready(action=action, step=step)
+
+                    self._resilient_send(action)
+                    self._bus.invoke_on_action_sent(action=action, step=step)
+
+                    elapsed, sleep_time = self._tick_sleep(loop_start, goal_time)
+                    self._bus.emit_tick(
+                        TickEvent(
                             session_id=self._session_id,
+                            step=step,
                             timestamp=time.time(),
-                            event="stop_requested",
-                            metadata={"step": step},
+                            robot_state=robot_state,
+                            camera_frames=camera_frames,
+                            action_sent=action,
+                            loop_duration_s=elapsed,
+                            sleep_time_s=max(sleep_time, 0.0),
+                            stale_obs=self._last_tick_stale,
                         )
                     )
-                    break
-                if duration_s is not None and step * goal_time >= duration_s:
-                    reason = "duration_elapsed"
-                    break
+                    step += 1
 
-                loop_start = time.perf_counter()
-                robot_state, camera_frames = self._read_observation()
-
-                action = self._action_source.update(robot_state, camera_frames, step)
-                action = self._bus.invoke_on_action_ready(action=action, step=step)
-
-                self._resilient_send(action)
-                self._bus.invoke_on_action_sent(action=action, step=step)
-
-                elapsed, sleep_time = self._tick_sleep(loop_start, goal_time)
-                self._bus.emit_tick(
-                    TickEvent(
-                        session_id=self._session_id,
-                        step=step,
-                        timestamp=time.time(),
-                        robot_state=robot_state,
-                        camera_frames=camera_frames,
-                        action_sent=action,
-                        loop_duration_s=elapsed,
-                        sleep_time_s=max(sleep_time, 0.0),
-                        stale_obs=self._last_tick_stale,
-                    )
-                )
-                step += 1
-
-        except KeyboardInterrupt:
-            reason = "interrupted"
-            logger.info("Interrupted by user")
-        except WorkerDiedError:
-            logger.exception("Worker died during runtime")
-            raise
-        finally:
-            self._shutdown(step, reason=reason)
+            except KeyboardInterrupt:
+                reason = "interrupted"
+                logger.info("Interrupted by user")
+            except WorkerDiedError:
+                logger.exception("Worker died during runtime")
+                raise
+            finally:
+                self._shutdown(step, reason=reason)
 
         return step
+
+    @contextmanager
+    def _active_run(self) -> Iterator[None]:
+        """Acquire the run slot and release it after the caller's block.
+
+        Raises:
+            RuntimeError: If another run is active or the runtime is not connected.
+        """
+        acquired = False
+        try:
+            with self._lifecycle_lock:
+                acquired = self._run_lock.acquire(blocking=False)
+                if not acquired:
+                    msg = "RobotRuntime.run() is already active"
+                    raise RuntimeError(msg)
+                if not self._connected:
+                    msg = (
+                        "RobotRuntime.run() called before connect(). "
+                        "Use 'with runtime:' or call runtime.connect() first."
+                    )
+                    raise RuntimeError(msg)
+            yield
+        finally:
+            if acquired:
+                self._run_lock.release()
 
     def _reset_session(self) -> None:
         """Reset all session-scoped state for a fresh run.
@@ -601,10 +646,8 @@ class RobotRuntime:
                 )
             )
         finally:
-            # The bus isolates Exception but deliberately lets BaseException
-            # through, so the flush needs its own guarantee — otherwise a Ctrl+C
-            # in on_lifecycle loses the session's buffered telemetry.
-            self._bus.close()
+            # A Ctrl+C in on_lifecycle must not lose buffered telemetry.
+            self._bus.flush()
 
     def _shutdown(self, step: int, *, reason: RunReason) -> None:
         self._last_run_reason = reason

--- a/src/physicalai/runtime/execution/async_execution.py
+++ b/src/physicalai/runtime/execution/async_execution.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
@@ -53,7 +53,8 @@ class AsyncExecution(Execution):
         self._threshold_count: int = 0
 
         self._lock = threading.Lock()
-        self._obs_slot: dict[str, np.ndarray] | None = None
+        self._model_lock = threading.Lock()
+        self._obs_slot: tuple[dict[str, Any], int] | None = None
         self._obs_ready = threading.Event()
         self._running_inference = False
         self._request_time: float = 0.0
@@ -62,6 +63,11 @@ class AsyncExecution(Execution):
         self._thread: threading.Thread | None = None
         self._death_cause: BaseException | None = None
         self._inference_count: int = 0
+        # Episode counter bumped by start()/reset(). Each observation handed to
+        # the worker carries the current value; if reset() lands while inference
+        # is in flight, the worker's episode_id no longer matches and the result
+        # is discarded instead of reaching the queue.
+        self._episode_id: int = 0
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
 
@@ -88,6 +94,7 @@ class AsyncExecution(Execution):
         self._obs_ready = threading.Event()
         self._inference_count = 0
         with self._lock:
+            self._episode_id += 1
             # A stale observation would be inferred on as if it were current.
             self._obs_slot = None
             self._running_inference = False
@@ -131,7 +138,7 @@ class AsyncExecution(Execution):
             )
             raise RuntimeError(msg)
 
-    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
+    def warmup(self, sample_observation: dict[str, Any]) -> None:
         """Run one inference in main thread, seed queue, discover chunk_size.
 
         Raises:
@@ -139,12 +146,19 @@ class AsyncExecution(Execution):
         """
         if self._model is None or self._queue is None:
             raise RuntimeError(NOT_STARTED)
-        actions = self._model.predict_action_chunk(sample_observation)
-        self._chunk_size = actions.shape[0]
-        self._threshold_count = int(self._chunk_size * self._threshold_frac)
-        self._queue.push_chunk(actions, offset=0)
+        with self._lock:
+            episode_id = self._episode_id
+        with self._model_lock:
+            actions = self._model.predict_action_chunk(sample_observation)
+        with self._lock:
+            if episode_id != self._episode_id:
+                msg = "AsyncExecution warmup cancelled by reset"
+                raise RuntimeError(msg)
+            self._chunk_size = actions.shape[0]
+            self._threshold_count = int(self._chunk_size * self._threshold_frac)
+            self._queue.push_chunk(actions, offset=0)
 
-    def maybe_request(self, observation: dict[str, np.ndarray]) -> None:
+    def maybe_request(self, observation: dict[str, Any]) -> None:
         """Submit observation for background inference if queue is low and worker idle.
 
         Raises:
@@ -164,10 +178,30 @@ class AsyncExecution(Execution):
         if self._queue.below_threshold(self._threshold_count) and not self._busy:
             snapshot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
             with self._lock:
-                self._obs_slot = snapshot
+                self._obs_slot = (snapshot, self._episode_id)
                 self._request_time = time.perf_counter()
                 self._pops_at_request = self._queue.total_pops
             self._obs_ready.set()
+
+    def reset(self, *, reset_model: bool = True) -> None:
+        """Invalidate queued requests and optionally wait for active inference.
+
+        The worker remains alive. A result whose inference began before this
+        method is discarded even if it completes after the reset. With
+        ``reset_model=True``, waits for inference already inside the model.
+
+        Raises:
+            RuntimeError: If :meth:`start` has not been called.
+        """
+        if self._model is None:
+            raise RuntimeError(NOT_STARTED)
+        with self._lock:
+            self._episode_id += 1
+            self._obs_slot = None
+            self._request_time = time.perf_counter()
+        if reset_model:
+            with self._model_lock:
+                self._model.reset()
 
     def stop(self) -> None:
         """Signal the worker and join it, with a timeout.
@@ -245,17 +279,23 @@ class AsyncExecution(Execution):
                     return
 
                 with self._lock:
-                    obs = self._obs_slot
+                    request = self._obs_slot
                     self._obs_slot = None
-                    if obs is None:
+                    if request is None:
                         continue
+                    obs, episode_id = request
                     self._running_inference = True
 
                 if self._model is None or self._queue is None:
                     raise RuntimeError(NOT_STARTED)  # noqa: TRY301
                 t0 = time.perf_counter()
-                actions = self._model.predict_action_chunk(obs)
-                latency = time.perf_counter() - t0
+                with self._model_lock:
+                    with self._lock:
+                        if episode_id != self._episode_id:
+                            self._running_inference = False
+                            continue
+                    actions = self._model.predict_action_chunk(obs)
+                    latency = time.perf_counter() - t0
 
                 if stop_event.is_set():
                     # This run ended while the inference was in flight. The
@@ -266,9 +306,12 @@ class AsyncExecution(Execution):
                 # Offset = actions actually sent since the observation was
                 # captured. This is exact (no fps estimation error).
                 with self._lock:
+                    if episode_id != self._episode_id:
+                        self._running_inference = False
+                        continue
                     pops_since = self._queue.total_pops - self._pops_at_request
-                offset = min(max(pops_since, 0), len(actions) - 1)
-                self._queue.push_chunk(actions, offset=offset)
+                    offset = min(max(pops_since, 0), len(actions) - 1)
+                    self._queue.push_chunk(actions, offset=offset)
                 self._inference_count += 1
 
                 if self._bus:

--- a/src/physicalai/runtime/execution/base.py
+++ b/src/physicalai/runtime/execution/base.py
@@ -6,11 +6,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from physicalai.inference.model import InferenceModel
     from physicalai.runtime._callback_bus import _CallbackBus
     from physicalai.runtime.execution.queue import ActionQueue
@@ -39,14 +37,30 @@ class Execution(ABC):
         ...
 
     @abstractmethod
-    def maybe_request(self, observation: dict[str, np.ndarray]) -> None:
+    def maybe_request(self, observation: dict[str, Any]) -> None:
         """Check if new inference is needed given the (already-read) observation. If so, run or schedule it."""
         ...
 
     @abstractmethod
-    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
+    def warmup(self, sample_observation: dict[str, Any]) -> None:
         """Run one inference to discover chunk_size and seed the queue."""
         ...
+
+    def reset(self, *, reset_model: bool = True) -> None:
+        """Invalidate pending work before an action-source episode reset.
+
+        Execution strategies must override this method because only they can
+        ensure work from before the reset cannot reach the action queue or
+        mutate model state afterward.
+
+        Args:
+            reset_model: Whether to reset state held by the inference model.
+
+        Raises:
+            NotImplementedError: Always; subclasses must implement episode reset.
+        """
+        msg = f"{type(self).__name__} does not support episode reset"
+        raise NotImplementedError(msg)
 
     @abstractmethod
     def stop(self) -> None:

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -420,15 +420,13 @@ class RTCExecution(Execution):
             # Snapshot observation and consume the slot so a stale sample
             # (e.g. the warmup observation) is never reused for a later refill.
             with self._obs_lock:
-                if self._obs_slot is None:
-                    time.sleep(_IDLE_SLEEP_S)
-                    continue
                 request = self._obs_slot
                 self._obs_slot = None
-                if request is None:
-                    continue
-                inputs, episode_id, signal = request
-                inputs = deepcopy(inputs)
+            if request is None:
+                time.sleep(_IDLE_SLEEP_S)
+                continue
+            inputs, episode_id, signal = request
+            inputs = deepcopy(inputs)
 
             # Build RTC-specific inputs
             inputs = self._inject_rtc_inputs(inputs)

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -14,6 +14,7 @@ import logging
 import threading
 import time
 from copy import deepcopy
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -36,6 +37,14 @@ _ERROR_RETRY_DELAY_S: float = 0.5
 _MAX_CONSECUTIVE_ERRORS: int = 10
 _JOIN_TIMEOUT_S: float = 5.0
 _STRAGGLER_GRACE_S: float = 2.0
+
+
+@dataclass
+class _WarmupSignal:
+    """Completion state for one blocking warmup request."""
+
+    event: threading.Event = field(default_factory=threading.Event)
+    error: BaseException | None = None
 
 
 @export_config(class_path="physicalai.runtime.RTCExecution")
@@ -125,15 +134,21 @@ class RTCExecution(Execution):
 
         # Thread state
         self._obs_lock = threading.Lock()
-        self._obs_slot: dict[str, np.ndarray] | None = None
+        self._model_lock = threading.Lock()
+        self._obs_slot: tuple[dict[str, Any], int, _WarmupSignal | None] | None = None
+        self._warmup_signal: _WarmupSignal | None = None
         self._stop_event = threading.Event()
-        self._first_chunk_ready = threading.Event()
         self._thread: threading.Thread | None = None
         self._death_cause: BaseException | None = None
         self._inference_count: int = 0
-        # Separate from _inference_count, which restarts each run: model
-        # compilation overhead is paid once per process, so the cold-start
-        # latency discard must not re-arm on a second run.
+        # Episode counter bumped by start()/reset(). Each observation handed to
+        # the worker carries the current value; if reset() lands while inference
+        # is in flight, the worker's episode_id no longer matches and the result
+        # is discarded instead of reaching the queue.
+        self._episode_id: int = 0
+        # Separate from _inference_count, which restarts each run. This gate
+        # prevents RTC's own cold-start discard from re-arming. A caller may
+        # still reset the model's latency callback at an episode boundary.
         self._lifetime_inferences: int = 0
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
@@ -174,8 +189,15 @@ class RTCExecution(Execution):
                 a short grace period. Running anyway would put two threads
                 through one ``InferenceModel``, which is not synchronised.
         """  # noqa: DOC502 — raised by the delegated _await_previous_worker(), but callers see it here.
-        # First, before any state is touched: a refusal here must not leave the
-        # execution half-configured or the model stripped of its postprocessors.
+        # Wake direct warmup callers before waiting on or refusing an active
+        # worker. Otherwise they can remain blocked until the 120 s timeout.
+        with self._obs_lock:
+            self._episode_id += 1
+            self._obs_slot = None
+            self._cancel_warmup_locked("RTCExecution warmup cancelled by restart")
+
+        # Before model/queue bindings are changed, refuse to run two workers
+        # through the same unsynchronised model.
         self._await_previous_worker()
 
         self._model = model
@@ -220,7 +242,6 @@ class RTCExecution(Execution):
         # outlived stop() keeps its own set stop event, so it cannot be revived
         # by this start(), and its in-flight chunk is discarded.
         self._stop_event = threading.Event()
-        self._first_chunk_ready = threading.Event()
         self._inference_count = 0
         # A death from the previous run must not fail this one, and a stale
         # observation must not be inferred on as if it were current.
@@ -229,7 +250,7 @@ class RTCExecution(Execution):
             self._obs_slot = None
         self._thread = threading.Thread(
             target=self._rtc_loop,
-            args=(self._stop_event, self._first_chunk_ready),
+            args=(self._stop_event,),
             name="rtc-inference",
             daemon=True,
         )
@@ -242,7 +263,7 @@ class RTCExecution(Execution):
             self.queue_threshold,
         )
 
-    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
+    def warmup(self, sample_observation: dict[str, Any]) -> None:
         """Run one inference to seed the queue and discover chunk size.
 
         Blocks until the first chunk is produced by the background
@@ -255,22 +276,37 @@ class RTCExecution(Execution):
         if self._model is None or self._rtc_queue is None:
             raise RuntimeError(_NOT_STARTED)
 
-        # Publish the sample observation for the background thread
+        signal = _WarmupSignal()
         with self._obs_lock:
-            self._obs_slot = deepcopy(sample_observation)
+            if self._warmup_signal is not None:
+                msg = "RTCExecution warmup is already in progress"
+                raise RuntimeError(msg)
+            episode_id = self._episode_id
+            self._warmup_signal = signal
+            self._obs_slot = (deepcopy(sample_observation), episode_id, signal)
 
         # Wait for the first chunk with a generous timeout
-        if not self._first_chunk_ready.wait(timeout=120.0):
+        if not signal.event.wait(timeout=120.0):
+            with self._obs_lock:
+                if self._warmup_signal is signal:
+                    self._warmup_signal = None
             if self._death_cause is not None:
                 msg = f"RTC thread died during warmup: {self._death_cause}"
                 raise WorkerDiedError(msg) from self._death_cause
             msg = "RTCExecution warmup timed out waiting for first chunk"
             raise RuntimeError(msg)
 
+        with self._obs_lock:
+            if self._warmup_signal is signal:
+                self._warmup_signal = None
+            error = signal.error
+        if error is not None:
+            raise error
+
         self._chunk_size_discovered = self._chunk_size
         logger.info("RTCExecution warmup complete — chunk_size=%d", self._chunk_size_discovered)
 
-    def maybe_request(self, observation: dict[str, np.ndarray]) -> None:
+    def maybe_request(self, observation: dict[str, Any]) -> None:
         """Publish the given observation for the background thread.
 
         The background thread decides when to re-infer based on
@@ -289,7 +325,26 @@ class RTCExecution(Execution):
             return
 
         with self._obs_lock:
-            self._obs_slot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
+            snapshot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
+            self._obs_slot = (snapshot, self._episode_id, None)
+
+    def reset(self, *, reset_model: bool = True) -> None:
+        """Invalidate pending RTC work and optionally wait for active inference.
+
+        With ``reset_model=True``, waits for inference already inside the model.
+
+        Raises:
+            RuntimeError: If :meth:`start` has not been called.
+        """
+        if self._model is None:
+            raise RuntimeError(_NOT_STARTED)
+        with self._obs_lock:
+            self._episode_id += 1
+            self._obs_slot = None
+            self._cancel_warmup_locked("RTCExecution warmup cancelled by reset")
+        if reset_model:
+            with self._model_lock:
+                self._model.reset()
 
     def stop(self) -> None:
         """Signal the worker and join it, with a timeout.
@@ -300,6 +355,10 @@ class RTCExecution(Execution):
         its reference here so the next :meth:`start` can refuse to run
         alongside it.
         """
+        with self._obs_lock:
+            self._episode_id += 1
+            self._obs_slot = None
+            self._cancel_warmup_locked("RTCExecution warmup cancelled because execution stopped")
         if self._thread is not None:
             self._stop_event.set()
             self._thread.join(timeout=_JOIN_TIMEOUT_S)
@@ -341,7 +400,7 @@ class RTCExecution(Execution):
             )
             raise RuntimeError(msg)
 
-    def _rtc_loop(self, stop_event: threading.Event, first_chunk_ready: threading.Event) -> None:
+    def _rtc_loop(self, stop_event: threading.Event) -> None:
         """Background loop for one run: infer chunks and merge into queue.
 
         Takes its own events rather than reading ``self``, so a worker that
@@ -364,8 +423,12 @@ class RTCExecution(Execution):
                 if self._obs_slot is None:
                     time.sleep(_IDLE_SLEEP_S)
                     continue
-                inputs = deepcopy(self._obs_slot)
+                request = self._obs_slot
                 self._obs_slot = None
+                if request is None:
+                    continue
+                inputs, episode_id, signal = request
+                inputs = deepcopy(inputs)
 
             # Build RTC-specific inputs
             inputs = self._inject_rtc_inputs(inputs)
@@ -376,10 +439,17 @@ class RTCExecution(Execution):
             # Run inference (callbacks fire inside model.__call__)
             try:
                 t0 = time.perf_counter()
-                outputs = self._model(inputs)
-                elapsed = time.perf_counter() - t0
+                with self._model_lock:
+                    with self._obs_lock:
+                        if episode_id != self._episode_id:
+                            self._cancel_signal_locked(signal, "RTCExecution warmup cancelled by reset")
+                            continue
+                    outputs = self._model(inputs)
+                    elapsed = time.perf_counter() - t0
                 consecutive_errors = 0
             except Exception:
+                with self._obs_lock:
+                    self._cancel_signal_locked(signal, "RTCExecution warmup inference failed")
                 consecutive_errors += 1
                 logger.exception(
                     "RTC inference error (%d/%d)",
@@ -397,42 +467,19 @@ class RTCExecution(Execution):
                 # This run ended while the inference was in flight. The chunk
                 # describes an observation from a finished session, so it must
                 # not reach a later run's queue.
+                with self._obs_lock:
+                    self._cancel_signal_locked(signal, "RTCExecution warmup cancelled because execution stopped")
                 return
 
-            self._inference_count += 1
-            self._lifetime_inferences += 1
-
-            # Reset latency tracker after warmup inferences to discard
-            # compilation overhead (e.g. OpenVINO first-run latency). Gated on
-            # the lifetime count: the model is compiled once, so a second run
-            # must not discard its perfectly good samples.
-            if self._lifetime_inferences <= self._warmup_inferences and self._latency_tracker is not None:
-                self._latency_tracker.on_reset()
-                logger.info(
-                    "Warmup inference %d/%d complete (%.2fs) — latency tracker reset",
-                    self._lifetime_inferences,
-                    self._warmup_inferences,
-                    elapsed,
-                )
-
-            # Extract raw actions: (1, chunk_size, action_dim) → (chunk_size, action_dim)
-            raw_actions = outputs["action"]
-            if raw_actions.ndim == 3:  # noqa: PLR2004
-                raw_actions = raw_actions[0]
-
-            # Postprocess (denormalize) for robot
-            processed_actions = self._postprocess(raw_actions)
-
-            # Merge into dual-track queue — trim is based on actual
-            # actions consumed (cursor movement) during inference, NOT
-            # wall-clock time.  For the first chunk nothing was consumed
-            # so trim=0 and the full chunk is kept.
-            self._rtc_queue.merge(
-                raw_actions,
-                processed_actions,
-                action_index_before_inference=action_index_before,
+            processed_actions = self._accept_result(
+                outputs,
+                episode_id=episode_id,
+                signal=signal,
+                elapsed=elapsed,
+                action_index_before=action_index_before,
             )
-            first_chunk_ready.set()
+            if processed_actions is None:
+                continue
 
             # Emit inference event so callbacks (e.g. RerunCallback) can
             # plot predicted future actions.
@@ -454,6 +501,65 @@ class RTCExecution(Execution):
                 elapsed,
                 self._rtc_queue.remaining,
             )
+
+    def _accept_result(
+        self,
+        outputs: dict[str, np.ndarray],
+        *,
+        episode_id: int,
+        signal: _WarmupSignal | None,
+        elapsed: float,
+        action_index_before: int,
+    ) -> np.ndarray | None:
+        """Merge a result only if it belongs to the current episode.
+
+        Returns:
+            Processed actions, or ``None`` when the episode has changed.
+        """
+        assert self._rtc_queue is not None  # noqa: S101
+        raw_actions = outputs["action"]
+        if raw_actions.ndim == 3:  # noqa: PLR2004
+            raw_actions = raw_actions[0]
+        processed_actions = self._postprocess(raw_actions)
+
+        with self._obs_lock:
+            if episode_id != self._episode_id:
+                self._cancel_signal_locked(signal, "RTCExecution warmup cancelled by reset")
+                return None
+
+            self._inference_count += 1
+            self._lifetime_inferences += 1
+            if self._lifetime_inferences <= self._warmup_inferences and self._latency_tracker is not None:
+                self._latency_tracker.on_reset()
+                logger.info(
+                    "Warmup inference %d/%d complete (%.2fs) — latency tracker reset",
+                    self._lifetime_inferences,
+                    self._warmup_inferences,
+                    elapsed,
+                )
+
+            self._rtc_queue.merge(
+                raw_actions,
+                processed_actions,
+                action_index_before_inference=action_index_before,
+            )
+            if signal is not None:
+                signal.event.set()
+            return processed_actions
+
+    def _cancel_warmup_locked(self, message: str) -> None:
+        signal = self._warmup_signal
+        if signal is None:
+            return
+        self._cancel_signal_locked(signal, message)
+        self._warmup_signal = None
+
+    @staticmethod
+    def _cancel_signal_locked(signal: _WarmupSignal | None, message: str) -> None:
+        if signal is None or signal.event.is_set():
+            return
+        signal.error = RuntimeError(message)
+        signal.event.set()
 
     def _inject_rtc_inputs(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """Add RTC-specific model inputs.

--- a/src/physicalai/runtime/execution/sync.py
+++ b/src/physicalai/runtime/execution/sync.py
@@ -5,15 +5,14 @@
 
 from __future__ import annotations
 
+import threading
 import time
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from physicalai.config import export_config
 from physicalai.runtime.execution.base import NOT_STARTED, Execution
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from physicalai.inference.model import InferenceModel
     from physicalai.runtime._callback_bus import _CallbackBus
     from physicalai.runtime.execution.queue import ActionQueue, ChunkedActionQueue
@@ -42,6 +41,7 @@ class SyncExecution(Execution):
         self._threshold_frac = request_threshold
         self._threshold_count: int = 0
         self._inference_count: int = 0
+        self._model_lock = threading.Lock()
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
 
@@ -51,7 +51,7 @@ class SyncExecution(Execution):
         self._queue = cast("ChunkedActionQueue", action_queue)
         self._inference_count = 0
 
-    def warmup(self, sample_observation: dict[str, np.ndarray]) -> None:
+    def warmup(self, sample_observation: dict[str, Any]) -> None:
         """Run one inference, seed queue, discover chunk_size.
 
         Raises:
@@ -59,12 +59,13 @@ class SyncExecution(Execution):
         """
         if self._model is None or self._queue is None:
             raise RuntimeError(NOT_STARTED)
-        actions = self._model.predict_action_chunk(sample_observation)
-        self._chunk_size = actions.shape[0]
-        self._threshold_count = max(1, int(self._chunk_size * self._threshold_frac))
-        self._queue.push_chunk(actions, offset=0)
+        with self._model_lock:
+            actions = self._model.predict_action_chunk(sample_observation)
+            self._chunk_size = actions.shape[0]
+            self._threshold_count = max(1, int(self._chunk_size * self._threshold_frac))
+            self._queue.push_chunk(actions, offset=0)
 
-    def maybe_request(self, observation: dict[str, np.ndarray]) -> None:
+    def maybe_request(self, observation: dict[str, Any]) -> None:
         """Refill queue synchronously when below threshold.
 
         Raises:
@@ -74,9 +75,10 @@ class SyncExecution(Execution):
             raise RuntimeError(NOT_STARTED)
         if self._queue.below_threshold(self._threshold_count):
             t0 = time.perf_counter()
-            actions = self._model.predict_action_chunk(observation)
-            latency = time.perf_counter() - t0
-            self._queue.push_chunk(actions, offset=0)
+            with self._model_lock:
+                actions = self._model.predict_action_chunk(observation)
+                latency = time.perf_counter() - t0
+                self._queue.push_chunk(actions, offset=0)
             self._inference_count += 1
             if self._bus:
                 from physicalai.runtime.events import InferenceEvent  # noqa: PLC0415
@@ -90,6 +92,18 @@ class SyncExecution(Execution):
                         chunk=actions,
                     )
                 )
+
+    def reset(self, *, reset_model: bool = True) -> None:
+        """Wait for current inference and optionally reset model state.
+
+        Raises:
+            RuntimeError: If :meth:`start` has not been called.
+        """
+        if self._model is None:
+            raise RuntimeError(NOT_STARTED)
+        if reset_model:
+            with self._model_lock:
+                self._model.reset()
 
     def stop(self) -> None:
         """No-op for synchronous execution."""

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -285,6 +285,128 @@ class TestAsyncExecution:
         release_inference.set()
         ex.stop()
 
+    def test_reset_discards_in_flight_result_without_restarting_worker(self) -> None:
+        chunk = np.ones((4, 2), dtype=np.float32)
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+
+        def predict(_obs: dict[str, Any]) -> np.ndarray:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                entered.set()
+                assert release.wait(timeout=5.0)
+            return chunk
+
+        model = _make_mock_model(chunk)
+        model.predict_action_chunk.side_effect = predict
+        queue = ChunkedActionQueue()
+        ex = AsyncExecution(request_threshold=0.5)
+        ex.start(model, queue)
+        ex.warmup({"state": np.zeros(2)})
+        for _ in range(4):
+            queue.pop()
+
+        worker = ex._thread  # noqa: SLF001
+        ex.maybe_request({"state": np.ones(2)})
+        assert entered.wait(timeout=5.0)
+
+        reset_done = threading.Event()
+
+        def reset() -> None:
+            ex.reset()
+            reset_done.set()
+
+        reset_thread = threading.Thread(target=reset)
+        reset_thread.start()
+        try:
+            assert not reset_done.wait(timeout=0.05)
+            release.set()
+            assert reset_done.wait(timeout=5.0)
+            assert queue.remaining == 0
+            assert ex._thread is worker  # noqa: SLF001
+            assert worker is not None and worker.is_alive()
+            model.reset.assert_called_once()
+        finally:
+            release.set()
+            reset_thread.join(timeout=5.0)
+            ex.stop()
+
+    def test_reset_skips_dequeued_request_that_has_not_entered_model(self) -> None:
+        model = _make_mock_model()
+        queue = ChunkedActionQueue()
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        ex._threshold_count = 1  # noqa: SLF001
+
+        ex._model_lock.acquire()  # noqa: SLF001
+        reset_thread: threading.Thread | None = None
+        try:
+            ex.maybe_request({"state": np.zeros(4, dtype=np.float32)})
+            deadline = time.monotonic() + 5.0
+            while not ex._running_inference and time.monotonic() < deadline:  # noqa: SLF001
+                time.sleep(0.001)
+            assert ex._running_inference  # noqa: SLF001
+
+            episode_id = ex._episode_id  # noqa: SLF001
+            reset_thread = threading.Thread(target=ex.reset)
+            reset_thread.start()
+            while ex._episode_id == episode_id and time.monotonic() < deadline:  # noqa: SLF001
+                time.sleep(0.001)
+            assert ex._episode_id > episode_id  # noqa: SLF001
+        finally:
+            ex._model_lock.release()  # noqa: SLF001
+            if reset_thread is not None:
+                reset_thread.join(timeout=5.0)
+            ex.stop()
+
+        model.predict_action_chunk.assert_not_called()
+        model.reset.assert_called_once()
+        assert queue.remaining == 0
+
+    def test_reset_cancels_explicit_warmup(self) -> None:
+        chunk = np.ones((4, 2), dtype=np.float32)
+        entered = threading.Event()
+        release = threading.Event()
+
+        def predict(_obs: dict[str, Any]) -> np.ndarray:
+            entered.set()
+            assert release.wait(timeout=5.0)
+            return chunk
+
+        model = _make_mock_model(chunk)
+        model.predict_action_chunk.side_effect = predict
+        queue = ChunkedActionQueue()
+        ex = AsyncExecution()
+        ex.start(model, queue)
+        warmup_error: list[BaseException] = []
+
+        def warmup() -> None:
+            try:
+                ex.warmup({"state": np.zeros(2, dtype=np.float32)})
+            except BaseException as exc:
+                warmup_error.append(exc)
+
+        warmup_thread = threading.Thread(target=warmup)
+        warmup_thread.start()
+        assert entered.wait(timeout=5.0)
+        reset_thread = threading.Thread(target=ex.reset, kwargs={"reset_model": False})
+        reset_thread.start()
+        try:
+            release.set()
+            warmup_thread.join(timeout=5.0)
+            reset_thread.join(timeout=5.0)
+
+            assert len(warmup_error) == 1
+            assert "cancelled by reset" in str(warmup_error[0])
+            assert queue.remaining == 0
+        finally:
+            release.set()
+            warmup_thread.join(timeout=5.0)
+            reset_thread.join(timeout=5.0)
+            ex.stop()
+
 
 class TestRTCExecutionObsSlot:
     def test_worker_clears_obs_slot_after_consuming_warmup_sample(self) -> None:
@@ -311,6 +433,284 @@ class TestRTCExecutionObsSlot:
                 assert ex._obs_slot is None  # noqa: SLF001
         finally:
             ex.stop()
+
+    def test_reset_rearms_warmup_without_restarting_worker(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        model = _rtc_model(chunk_size=20, action_dim=3)
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+        try:
+            ex.warmup({"state": np.zeros(3, dtype=np.float32)})
+            worker = ex._thread  # noqa: SLF001
+            assert queue.remaining == 20
+
+            queue.reset()
+            ex.reset(reset_model=False)
+            ex.warmup({"state": np.ones(3, dtype=np.float32)})
+
+            assert queue.remaining == 20
+            assert ex._thread is worker  # noqa: SLF001
+            assert worker is not None and worker.is_alive()
+            assert model.call_count == 2
+        finally:
+            ex.stop()
+
+    def test_reset_discards_in_flight_chunk(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        entered = threading.Event()
+        release = threading.Event()
+        model = _rtc_model(chunk_size=20, action_dim=3)
+
+        def predict(_inputs: dict[str, Any]) -> dict[str, np.ndarray]:
+            entered.set()
+            assert release.wait(timeout=5.0)
+            return {"action": np.ones((1, 20, 3), dtype=np.float32)}
+
+        model.side_effect = predict
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+        worker = ex._thread  # noqa: SLF001
+        with ex._obs_lock:  # noqa: SLF001
+            observation = {"state": np.zeros(3, dtype=np.float32)}
+            ex._obs_slot = (observation, ex._episode_id, None)  # noqa: SLF001
+        assert entered.wait(timeout=5.0)
+
+        reset_done = threading.Event()
+
+        def reset() -> None:
+            ex.reset()
+            reset_done.set()
+
+        reset_thread = threading.Thread(target=reset)
+        reset_thread.start()
+        try:
+            assert not reset_done.wait(timeout=0.05)
+            release.set()
+            assert reset_done.wait(timeout=5.0)
+            assert queue.remaining == 0
+            assert ex._thread is worker  # noqa: SLF001
+            assert worker is not None and worker.is_alive()
+            model.reset.assert_called_once()
+        finally:
+            release.set()
+            reset_thread.join(timeout=5.0)
+            ex.stop()
+
+    def test_reset_skips_dequeued_chunk_that_has_not_entered_model(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        model = _rtc_model(chunk_size=20, action_dim=3)
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+
+        ex._model_lock.acquire()  # noqa: SLF001
+        reset_thread: threading.Thread | None = None
+        try:
+            with ex._obs_lock:  # noqa: SLF001
+                observation = {"state": np.zeros(3, dtype=np.float32)}
+                ex._obs_slot = (observation, ex._episode_id, None)  # noqa: SLF001
+            deadline = time.monotonic() + 5.0
+            while ex._obs_slot is not None and time.monotonic() < deadline:  # noqa: SLF001
+                time.sleep(0.001)
+            assert ex._obs_slot is None  # noqa: SLF001
+
+            episode_id = ex._episode_id  # noqa: SLF001
+            reset_thread = threading.Thread(target=ex.reset)
+            reset_thread.start()
+            while ex._episode_id == episode_id and time.monotonic() < deadline:  # noqa: SLF001
+                time.sleep(0.001)
+            assert ex._episode_id > episode_id  # noqa: SLF001
+        finally:
+            ex._model_lock.release()  # noqa: SLF001
+            if reset_thread is not None:
+                reset_thread.join(timeout=5.0)
+            ex.stop()
+
+        model.assert_not_called()
+        model.reset.assert_called_once()
+        assert queue.remaining == 0
+
+    def test_reset_cancels_warmup_waiting_for_model_lock(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        model = _rtc_model(chunk_size=20, action_dim=3)
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+        ex._model_lock.acquire()  # noqa: SLF001
+        warmup_error: list[BaseException] = []
+
+        def warmup() -> None:
+            try:
+                ex.warmup({"state": np.zeros(3, dtype=np.float32)})
+            except BaseException as exc:
+                warmup_error.append(exc)
+
+        warmup_thread = threading.Thread(target=warmup)
+        warmup_thread.start()
+        try:
+            deadline = time.monotonic() + 5.0
+            while ex._warmup_signal is None and time.monotonic() < deadline:  # noqa: SLF001
+                time.sleep(0.001)
+            assert ex._warmup_signal is not None  # noqa: SLF001
+            while ex._obs_slot is not None and time.monotonic() < deadline:  # noqa: SLF001
+                time.sleep(0.001)
+            assert ex._obs_slot is None  # noqa: SLF001
+
+            ex.reset(reset_model=False)
+            warmup_thread.join(timeout=1.0)
+
+            assert not warmup_thread.is_alive()
+            assert len(warmup_error) == 1
+            assert isinstance(warmup_error[0], RuntimeError)
+            assert "cancelled by reset" in str(warmup_error[0])
+            model.assert_not_called()
+        finally:
+            ex._model_lock.release()  # noqa: SLF001
+            warmup_thread.join(timeout=5.0)
+            ex.stop()
+
+    def test_reset_cancels_warmup_during_inference(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        entered = threading.Event()
+        release = threading.Event()
+        model = _rtc_model(chunk_size=20, action_dim=3)
+
+        def predict(_inputs: dict[str, Any]) -> dict[str, np.ndarray]:
+            entered.set()
+            assert release.wait(timeout=5.0)
+            return {"action": np.ones((1, 20, 3), dtype=np.float32)}
+
+        model.side_effect = predict
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+        warmup_error: list[BaseException] = []
+
+        def warmup() -> None:
+            try:
+                ex.warmup({"state": np.zeros(3, dtype=np.float32)})
+            except BaseException as exc:
+                warmup_error.append(exc)
+
+        warmup_thread = threading.Thread(target=warmup)
+        warmup_thread.start()
+        assert entered.wait(timeout=5.0)
+
+        reset_thread = threading.Thread(target=ex.reset, kwargs={"reset_model": False})
+        reset_thread.start()
+        try:
+            warmup_thread.join(timeout=1.0)
+            assert not warmup_thread.is_alive()
+            assert len(warmup_error) == 1
+            assert "cancelled by reset" in str(warmup_error[0])
+        finally:
+            release.set()
+            reset_thread.join(timeout=5.0)
+            warmup_thread.join(timeout=5.0)
+            ex.stop()
+
+        assert queue.remaining == 0
+
+    def test_start_cancels_existing_warmup_before_refusing_active_worker(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+        from physicalai.runtime.execution import rtc
+
+        entered = threading.Event()
+        release = threading.Event()
+        model = _rtc_model(chunk_size=20, action_dim=3)
+
+        def predict(_inputs: dict[str, Any]) -> dict[str, np.ndarray]:
+            entered.set()
+            assert release.wait(timeout=5.0)
+            return {"action": np.ones((1, 20, 3), dtype=np.float32)}
+
+        model.side_effect = predict
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+        warmup_error: list[BaseException] = []
+
+        def warmup() -> None:
+            try:
+                ex.warmup({"state": np.zeros(3, dtype=np.float32)})
+            except BaseException as exc:
+                warmup_error.append(exc)
+
+        warmup_thread = threading.Thread(target=warmup)
+        warmup_thread.start()
+        assert entered.wait(timeout=5.0)
+
+        start_error: list[BaseException] = []
+
+        def restart() -> None:
+            try:
+                with patch.object(rtc, "_STRAGGLER_GRACE_S", 0.05):
+                    ex.start(model, queue)
+            except BaseException as exc:
+                start_error.append(exc)
+
+        start_thread = threading.Thread(target=restart)
+        start_thread.start()
+        try:
+            warmup_thread.join(timeout=1.0)
+            start_thread.join(timeout=1.0)
+            assert not warmup_thread.is_alive()
+            assert len(warmup_error) == 1
+            assert "cancelled by restart" in str(warmup_error[0])
+            assert len(start_error) == 1
+            assert isinstance(start_error[0], RuntimeError)
+        finally:
+            release.set()
+            warmup_thread.join(timeout=5.0)
+            start_thread.join(timeout=5.0)
+            ex.stop()
+
+    def test_stop_cancels_warmup_before_joining_worker(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+
+        entered = threading.Event()
+        release = threading.Event()
+        model = _rtc_model(chunk_size=20, action_dim=3)
+
+        def predict(_inputs: dict[str, Any]) -> dict[str, np.ndarray]:
+            entered.set()
+            assert release.wait(timeout=5.0)
+            return {"action": np.ones((1, 20, 3), dtype=np.float32)}
+
+        model.side_effect = predict
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex.start(model, queue)
+        warmup_error: list[BaseException] = []
+
+        def warmup() -> None:
+            try:
+                ex.warmup({"state": np.zeros(3, dtype=np.float32)})
+            except BaseException as exc:
+                warmup_error.append(exc)
+
+        warmup_thread = threading.Thread(target=warmup)
+        warmup_thread.start()
+        assert entered.wait(timeout=5.0)
+
+        stop_thread = threading.Thread(target=ex.stop)
+        stop_thread.start()
+        try:
+            warmup_thread.join(timeout=1.0)
+            assert not warmup_thread.is_alive()
+            assert len(warmup_error) == 1
+            assert "cancelled because execution stopped" in str(warmup_error[0])
+        finally:
+            release.set()
+            warmup_thread.join(timeout=5.0)
+            stop_thread.join(timeout=5.0)
 
 
 def _blocking_model(entered: threading.Event, release: threading.Event, rows: int = 6) -> MagicMock:
@@ -353,7 +753,8 @@ class TestRestartAfterStop:
         ex._death_cause = RuntimeError("died previously")  # noqa: SLF001
         ex._inference_count = 5  # noqa: SLF001
         with ex._lock:  # noqa: SLF001
-            ex._obs_slot = {"state": np.full(4, 99.0, dtype=np.float32)}  # noqa: SLF001
+            stale = {"state": np.full(4, 99.0, dtype=np.float32)}
+            ex._obs_slot = (stale, ex._episode_id)  # noqa: SLF001
             ex._running_inference = True  # noqa: SLF001
 
         ex.start(model, queue)
@@ -376,7 +777,8 @@ class TestRestartAfterStop:
 
         ex._death_cause = RuntimeError("died previously")  # noqa: SLF001
         with ex._obs_lock:  # noqa: SLF001
-            ex._obs_slot = {"state": np.full(3, 99.0, dtype=np.float32)}  # noqa: SLF001
+            stale = {"state": np.full(3, 99.0, dtype=np.float32)}
+            ex._obs_slot = (stale, ex._episode_id, None)  # noqa: SLF001
 
         ex.start(model, queue)
         try:
@@ -384,7 +786,7 @@ class TestRestartAfterStop:
             assert ex.inference_count == 0
             with ex._obs_lock:  # noqa: SLF001
                 assert ex._obs_slot is None  # noqa: SLF001
-            # warmup() blocks on _first_chunk_ready, which start() also replaced.
+            # warmup() blocks on a per-request signal created after restart.
             ex.warmup({"state": np.zeros(3, dtype=np.float32)})
         finally:
             ex.stop()
@@ -513,7 +915,7 @@ class TestStopTimeoutStraggler:
             model.side_effect = blocking
             ex.start(model, queue)
             with ex._obs_lock:  # noqa: SLF001
-                ex._obs_slot = dict(obs)  # noqa: SLF001
+                ex._obs_slot = (dict(obs), ex._episode_id, None)  # noqa: SLF001
 
         assert entered.wait(timeout=5.0), "worker never entered inference"
         straggler = ex._thread  # noqa: SLF001

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -409,6 +409,33 @@ class TestAsyncExecution:
 
 
 class TestRTCExecutionObsSlot:
+    def test_worker_releases_obs_lock_before_idle_wait(self) -> None:
+        from physicalai.runtime import RTCActionQueue, RTCExecution
+        from physicalai.runtime.execution import rtc
+
+        model = _rtc_model(chunk_size=20, action_dim=3)
+        queue = RTCActionQueue()
+        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        idle_wait_observed = threading.Event()
+        lock_was_available = False
+
+        def inspect_idle_wait(_seconds: float) -> None:
+            nonlocal lock_was_available
+            lock_was_available = ex._obs_lock.acquire(blocking=False)  # noqa: SLF001
+            if lock_was_available:
+                ex._obs_lock.release()  # noqa: SLF001
+            idle_wait_observed.set()
+            ex._stop_event.set()  # noqa: SLF001
+
+        with patch.object(rtc.time, "sleep", side_effect=inspect_idle_wait):
+            ex.start(model, queue)
+            try:
+                assert idle_wait_observed.wait(timeout=5.0)
+            finally:
+                ex.stop()
+
+        assert lock_was_available
+
     def test_worker_clears_obs_slot_after_consuming_warmup_sample(self) -> None:
         from physicalai.runtime import RTCActionQueue, RTCExecution
 

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import multiprocessing as mp
 import threading
 import time
@@ -18,7 +19,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-from physicalai.runtime import AsyncExecution, ChunkedActionQueue as ActionQueue, ChunkedActionQueue, LifecycleEvent, PolicySource, RobotRuntime, StopSignal, SyncExecution, WorkerDiedError
+from physicalai.runtime import AsyncCallback, AsyncExecution, ChunkedActionQueue as ActionQueue, ChunkedActionQueue, Execution, JsonlCallback, LifecycleEvent, PolicySource, RobotRuntime, StopSignal, SyncExecution, WorkerDiedError
+from physicalai.runtime._callback_bus import _CallbackBus
 from physicalai.robot.interface import RobotObservation
 from physicalai.inference.model import InferenceModel
 from physicalai.inference.constants import IMAGES, STATE, TASK
@@ -184,6 +186,16 @@ class TestRobotRuntimeWithPolicySource:
             mock_time.time.return_value = 0.0
             runtime.run(duration_s=1.0)
 
+    def test_execution_start_failure_does_not_call_stop(self) -> None:
+        execution = MagicMock()
+        execution.start.side_effect = RuntimeError("previous worker is busy")
+        runtime, _source = _make_runtime(execution=execution)
+
+        with pytest.raises(RuntimeError, match="previous worker is busy"):
+            runtime.run(duration_s=1.0)
+
+        execution.stop.assert_not_called()
+
     def test_shutdown_does_not_disconnect(self) -> None:
         robot = _make_mock_robot()
         model = _make_mock_model()
@@ -218,6 +230,29 @@ class TestRobotRuntimeWithPolicySource:
 
         with pytest.raises(RuntimeError, match="connect"):
             runtime.run(duration_s=1.0)
+
+    def test_failed_connect_can_be_retried_directly(self) -> None:
+        robot = _make_mock_robot()
+        robot.connect.side_effect = [ConnectionError("not ready"), None]
+        runtime = RobotRuntime(robot=robot, action_source=FakeActionSource(), fps=10.0)
+
+        with pytest.raises(ConnectionError, match="not ready"):
+            runtime.connect()
+
+        runtime.connect()
+        assert robot.connect.call_count == 2
+
+    def test_disconnect_after_failed_connect_is_terminal(self) -> None:
+        robot = _make_mock_robot()
+        robot.connect.side_effect = ConnectionError("not ready")
+        runtime = RobotRuntime(robot=robot, action_source=FakeActionSource(), fps=10.0)
+
+        with pytest.raises(ConnectionError, match="not ready"):
+            runtime.connect()
+        runtime.disconnect()
+
+        with pytest.raises(RuntimeError, match="cannot be connected again"):
+            runtime.connect()
 
 
 class TestGenericActionSource:
@@ -637,7 +672,7 @@ class TestPolicySourceModelInput:
 
 @dataclass
 class _LifecycleRecorder:
-    """Captures lifecycle events and bus close, for shutdown assertions."""
+    """Captures lifecycle events and final callback disposal."""
 
     events: list[str] = field(default_factory=list)
     metadata: list[dict[str, Any]] = field(default_factory=list)
@@ -847,7 +882,7 @@ class TestStopFlagLifecycle:
 
         assert runtime.last_run_reason == "error"
         assert recorder.shutdown_metadata["reason"] == "error"
-        assert recorder.closed
+        assert not recorder.closed
 
         runtime._action_source = FakeActionSource(next_action=np.zeros(3, dtype=np.float32))  # noqa: SLF001
         with _frozen_time():
@@ -876,7 +911,7 @@ class TestStopFlagLifecycle:
             runtime.run(duration_s=1.0)
 
         assert recorder.shutdown_metadata["reason"] == "stop_requested"
-        assert recorder.closed
+        assert not recorder.closed
         assert runtime.last_run_reason == "stop_requested"
 
         # The flag did not survive into the next session.
@@ -1100,3 +1135,210 @@ class TestPolicySourceRerun:
         assert execution.inference_count >= 2, "no background inference in the second run"
         holds = source.action_queue.total_holds
         assert holds < steps_second // 3, f"queue starved: {holds} holds"
+
+
+class TestPolicySourceEpisodeReset:
+    @staticmethod
+    def _observation(value: float) -> FakeRobotObservation:
+        return FakeRobotObservation(
+            joint_positions=np.full(3, value, dtype=np.float32),
+            timestamp=0.0,
+            sensor_data=None,
+            images=None,
+        )
+
+    def test_explicit_warmup_seeds_first_update_without_repeating_inference(self) -> None:
+        model = MagicMock()
+        model.predict_action_chunk.side_effect = lambda obs: np.repeat(obs[STATE], 4, axis=0)
+        source = PolicySource(model=model, execution=SyncExecution())
+        source.connect(bus=_CallbackBus([]), session_id="session")
+        try:
+            source.warmup(source.to_model_input(self._observation(2.0), {}))
+            action = source.update(self._observation(3.0), {}, step=0)
+
+            np.testing.assert_array_equal(action, np.full(3, 2.0, dtype=np.float32))
+            model.predict_action_chunk.assert_called_once()
+        finally:
+            source.disconnect()
+
+    def test_reset_reseeds_from_current_observation(self) -> None:
+        model = MagicMock()
+        model.predict_action_chunk.side_effect = lambda obs: np.repeat(obs[STATE], 4, axis=0)
+        source = PolicySource(model=model, execution=SyncExecution())
+        source.connect(bus=_CallbackBus([]), session_id="session")
+        try:
+            first = source.update(self._observation(1.0), {}, step=0)
+            np.testing.assert_array_equal(first, np.full(3, 1.0, dtype=np.float32))
+            assert source.action_queue.remaining > 0
+
+            resets_after_connect = model.reset.call_count
+            source.reset(reset_model=False)
+            assert source.action_queue.remaining == 0
+            second = source.update(self._observation(9.0), {}, step=1)
+
+            np.testing.assert_array_equal(second, np.full(3, 9.0, dtype=np.float32))
+            assert model.reset.call_count == resets_after_connect
+        finally:
+            source.disconnect()
+
+    def test_custom_execution_runs_but_rejects_episode_reset(self) -> None:
+        class LegacyExecution(Execution):
+            def start(self, model: Any, action_queue: Any) -> None:
+                self.model = model
+                self.queue = action_queue
+
+            def maybe_request(self, observation: dict[str, Any]) -> None:
+                pass
+
+            def warmup(self, sample_observation: dict[str, Any]) -> None:
+                self.queue.push_chunk(self.model.predict_action_chunk(sample_observation))
+
+            def stop(self) -> None:
+                pass
+
+            @property
+            def chunk_size(self) -> int:
+                return 1
+
+        model = MagicMock()
+        model.predict_action_chunk.return_value = np.ones((1, 3), dtype=np.float32)
+        source = PolicySource(model=model, execution=LegacyExecution())
+
+        source.connect(bus=_CallbackBus([]), session_id="session")
+        try:
+            action = source.update(self._observation(1.0), {}, step=0)
+            np.testing.assert_array_equal(action, np.ones(3, dtype=np.float32))
+            remaining = source.action_queue.remaining
+            with pytest.raises(RuntimeError, match="does not support safe episode reset"):
+                source.reset()
+            assert source.action_queue.remaining == remaining
+        finally:
+            source.disconnect()
+
+    def test_duck_typed_execution_with_reset_is_supported(self) -> None:
+        class DuckExecution:
+            def set_bus(self, bus: Any, session_id: str) -> None:
+                pass
+
+            def start(self, model: Any, action_queue: Any) -> None:
+                self.model = model
+                self.queue = action_queue
+
+            def reset(self, *, reset_model: bool = True) -> None:
+                if reset_model:
+                    self.model.reset()
+
+            def maybe_request(self, observation: dict[str, Any]) -> None:
+                pass
+
+            def warmup(self, sample_observation: dict[str, Any]) -> None:
+                self.queue.push_chunk(self.model.predict_action_chunk(sample_observation))
+
+            def stop(self) -> None:
+                pass
+
+        model = MagicMock()
+        model.predict_action_chunk.return_value = np.ones((1, 3), dtype=np.float32)
+        source = PolicySource(model=model, execution=DuckExecution())  # type: ignore[arg-type]
+
+        source.connect(bus=_CallbackBus([]), session_id="session")
+        try:
+            source.reset()
+            assert model.reset.call_count == 2
+        finally:
+            source.disconnect()
+
+    def test_reset_and_warmup_require_connection(self) -> None:
+        source = PolicySource(model=MagicMock(), execution=SyncExecution())
+
+        with pytest.raises(RuntimeError, match=r"reset\(\) requires connect"):
+            source.reset()
+        with pytest.raises(RuntimeError, match=r"warmup\(\) requires connect"):
+            source.warmup({STATE: np.zeros((1, 3), dtype=np.float32)})
+
+
+class TestRuntimeCallbackReuse:
+    def test_jsonl_callback_records_two_runs_and_closes_on_disconnect(self, tmp_path: Path) -> None:
+        path = tmp_path / "runs.jsonl"
+        callback = JsonlCallback(path)
+        robot = _make_mock_robot()
+        robot.joint_names = ["joint_1", "joint_2", "joint_3"]
+        runtime, _robot = _stop_runtime(robot=robot, callbacks=[callback])
+
+        with _frozen_time():
+            runtime.run(duration_s=0.1)
+            runtime.run(duration_s=0.1)
+
+        records = [json.loads(line) for line in path.read_text().splitlines()]
+        starts = [record for record in records if record.get("event") == "start"]
+        shutdowns = [record for record in records if record.get("event") == "shutdown"]
+        assert len(starts) == len(shutdowns) == 2
+        assert starts[0]["session_id"] != starts[1]["session_id"]
+
+        runtime.disconnect()
+        assert callback._file.closed  # noqa: SLF001
+        with pytest.raises(RuntimeError, match="cannot be connected again"):
+            runtime.connect()
+
+    def test_async_callback_delivers_two_runs_before_final_close(self) -> None:
+        inner = MagicMock(spec=["on_tick", "on_lifecycle", "close"])
+        callback = AsyncCallback(inner)
+        runtime, _robot = _stop_runtime(callbacks=[callback])
+
+        with _frozen_time():
+            runtime.run(duration_s=0.1)
+            runtime.run(duration_s=0.1)
+
+        lifecycle_events = [call.args[0].event for call in inner.on_lifecycle.call_args_list]
+        assert lifecycle_events == ["start", "shutdown", "start", "shutdown"]
+        assert inner.on_tick.call_count == 2
+        assert callback._thread.is_alive()  # noqa: SLF001
+        inner.close.assert_not_called()
+
+        runtime.disconnect()
+        assert not callback._thread.is_alive()  # noqa: SLF001
+        inner.close.assert_called_once()
+        runtime.disconnect()
+        inner.close.assert_called_once()
+
+    def test_concurrent_disconnect_is_idempotent(self) -> None:
+        callback = MagicMock(spec=["close"])
+        runtime, _robot = _stop_runtime(callbacks=[callback])
+        errors: list[BaseException] = []
+
+        def disconnect() -> None:
+            try:
+                runtime.disconnect()
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=disconnect) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5.0)
+
+        assert errors == []
+        callback.close.assert_called_once()
+
+    @pytest.mark.parametrize("operation", ["connect", "disconnect", "run"])
+    def test_lifecycle_operation_rejected_while_run_active(self, operation: str) -> None:
+        first_tick = threading.Event()
+        release = threading.Event()
+
+        class BlockingSource(FakeActionSource):
+            def update(self, robot_state: Any, camera_frames: Any, step: int) -> np.ndarray:
+                first_tick.set()
+                assert release.wait(timeout=5.0)
+                return np.zeros(3, dtype=np.float32)
+
+        runtime, _robot = _stop_runtime(action_source=BlockingSource())
+        run_thread = threading.Thread(target=runtime.run, kwargs={"duration_s": 0.1})
+        run_thread.start()
+        assert first_tick.wait(timeout=5.0)
+        try:
+            with pytest.raises(RuntimeError, match="active"):
+                getattr(runtime, operation)()
+        finally:
+            release.set()
+            run_thread.join(timeout=5.0)

--- a/tests/unit/runtime/test_telemetry.py
+++ b/tests/unit/runtime/test_telemetry.py
@@ -215,6 +215,47 @@ class TestCallbackBus:
         bus.close()
         cb.close.assert_called_once()
 
+    def test_close_is_idempotent(self) -> None:
+        cb = MagicMock()
+        bus = _CallbackBus([cb])
+
+        bus.close()
+        bus.close()
+
+        cb.close.assert_called_once()
+
+    def test_close_attempts_all_callbacks_before_propagating_base_exception(self) -> None:
+        interrupted = MagicMock()
+        interrupted.close.side_effect = KeyboardInterrupt
+        remaining = MagicMock()
+        bus = _CallbackBus([interrupted, remaining])
+
+        with pytest.raises(KeyboardInterrupt):
+            bus.close()
+
+        remaining.close.assert_called_once()
+
+    def test_concurrent_close_calls_callbacks_once(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        cb = MagicMock()
+
+        def close() -> None:
+            entered.set()
+            assert release.wait(timeout=5.0)
+
+        cb.close.side_effect = close
+        bus = _CallbackBus([cb])
+        threads = [threading.Thread(target=bus.close) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        assert entered.wait(timeout=5.0)
+        release.set()
+        for thread in threads:
+            thread.join(timeout=5.0)
+
+        cb.close.assert_called_once()
+
     def test_missing_methods_skipped(self) -> None:
         class MinimalCallback:
             pass
@@ -301,4 +342,16 @@ class TestAsyncCallback:
         cb = AsyncCallback(inner)
         cb.close()
         assert not cb._thread.is_alive()
+        inner.close.assert_called_once()
+
+    def test_concurrent_close_closes_inner_once(self) -> None:
+        inner = MagicMock(spec=["close"])
+        cb = AsyncCallback(inner)
+        threads = [threading.Thread(target=cb.close) for _ in range(2)]
+
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5.0)
+
         inner.close.assert_called_once()


### PR DESCRIPTION
## Summary

Makes the runtime reusable across runs and policy episodes for long-lived Studio sessions:

  • PolicySource.reset() — discard queued/stale actions without stopping the loop or restarting the inference worker
  • PolicySource.warmup() — optional eager first inference so arming policy doesn't stall a tick
  • Callback lifecycle fix — run() flushes callbacks; disconnect() closes them (fixes silent telemetry loss on second run())
  • Execution reset support — sync/async/RTC invalidate in-flight work via _episode_id and support safe episode boundaries
  • Docs + tests — API docs updated; ~900 lines of new unit tests

For more context: https://github.com/open-edge-platform/physical-ai-studio/pull/936/changes#diff-64daf1c928767ba3233bd70eaf2285c62b9c7323e6de4fb929cc40a29e67de7d

## Why

 Studio runs one long session and switches between hold, teleop, and policy. Stopping a task and restarting later must not replay old queued actions or require tearing down the whole runtime (which closes dataset writers and restarts inference workers). Callbacks also need to survive consecutive run() calls, previously JsonlCallback / AsyncCallback broke silently on the second run.
