### PR TITLE
refactor: rename execution episode_id to incarnation

### DIFF
--- a/src/physicalai/runtime/execution/async_execution.py
+++ b/src/physicalai/runtime/execution/async_execution.py
@@ -63,11 +63,11 @@ class AsyncExecution(Execution):
         self._thread: threading.Thread | None = None
         self._death_cause: BaseException | None = None
         self._inference_count: int = 0
-        # Episode counter bumped by start()/reset(). Each observation handed to
-        # the worker carries the current value; if reset() lands while inference
-        # is in flight, the worker's episode_id no longer matches and the result
-        # is discarded instead of reaching the queue.
-        self._episode_id: int = 0
+        # Incarnation counter bumped by start()/reset(). Each observation handed
+        # to the worker carries the current value; if reset() lands while
+        # inference is in flight, the worker's incarnation no longer matches
+        # and the result is discarded instead of reaching the queue.
+        self._incarnation: int = 0
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""
 
@@ -94,7 +94,7 @@ class AsyncExecution(Execution):
         self._obs_ready = threading.Event()
         self._inference_count = 0
         with self._lock:
-            self._episode_id += 1
+            self._incarnation += 1
             # A stale observation would be inferred on as if it were current.
             self._obs_slot = None
             self._running_inference = False
@@ -147,11 +147,11 @@ class AsyncExecution(Execution):
         if self._model is None or self._queue is None:
             raise RuntimeError(NOT_STARTED)
         with self._lock:
-            episode_id = self._episode_id
+            incarnation = self._incarnation
         with self._model_lock:
             actions = self._model.predict_action_chunk(sample_observation)
         with self._lock:
-            if episode_id != self._episode_id:
+            if incarnation != self._incarnation:
                 msg = "AsyncExecution warmup cancelled by reset"
                 raise RuntimeError(msg)
             self._chunk_size = actions.shape[0]
@@ -178,7 +178,7 @@ class AsyncExecution(Execution):
         if self._queue.below_threshold(self._threshold_count) and not self._busy:
             snapshot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
             with self._lock:
-                self._obs_slot = (snapshot, self._episode_id)
+                self._obs_slot = (snapshot, self._incarnation)
                 self._request_time = time.perf_counter()
                 self._pops_at_request = self._queue.total_pops
             self._obs_ready.set()
@@ -196,7 +196,7 @@ class AsyncExecution(Execution):
         if self._model is None:
             raise RuntimeError(NOT_STARTED)
         with self._lock:
-            self._episode_id += 1
+            self._incarnation += 1
             self._obs_slot = None
             self._request_time = time.perf_counter()
         if reset_model:
@@ -283,7 +283,7 @@ class AsyncExecution(Execution):
                     self._obs_slot = None
                     if request is None:
                         continue
-                    obs, episode_id = request
+                    obs, incarnation = request
                     self._running_inference = True
 
                 if self._model is None or self._queue is None:
@@ -291,7 +291,7 @@ class AsyncExecution(Execution):
                 t0 = time.perf_counter()
                 with self._model_lock:
                     with self._lock:
-                        if episode_id != self._episode_id:
+                        if incarnation != self._incarnation:
                             self._running_inference = False
                             continue
                     actions = self._model.predict_action_chunk(obs)
@@ -306,7 +306,7 @@ class AsyncExecution(Execution):
                 # Offset = actions actually sent since the observation was
                 # captured. This is exact (no fps estimation error).
                 with self._lock:
-                    if episode_id != self._episode_id:
+                    if incarnation != self._incarnation:
                         self._running_inference = False
                         continue
                     pops_since = self._queue.total_pops - self._pops_at_request

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -148,7 +148,7 @@ class RTCExecution(Execution):
         self._incarnation: int = 0
         # Separate from _inference_count, which restarts each run. This gate
         # prevents RTC's own cold-start discard from re-arming. A caller may
-        # still reset the model's latency callback at an episode boundary.
+        # still reset the model's latency callback at an incarnation boundary.
         self._lifetime_inferences: int = 0
         self._bus: _CallbackBus | None = None
         self._session_id: str = ""

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -141,11 +141,11 @@ class RTCExecution(Execution):
         self._thread: threading.Thread | None = None
         self._death_cause: BaseException | None = None
         self._inference_count: int = 0
-        # Episode counter bumped by start()/reset(). Each observation handed to
-        # the worker carries the current value; if reset() lands while inference
-        # is in flight, the worker's episode_id no longer matches and the result
-        # is discarded instead of reaching the queue.
-        self._episode_id: int = 0
+        # Incarnation counter bumped by start()/reset(). Each observation handed
+        # to the worker carries the current value; if reset() lands while
+        # inference is in flight, the worker's incarnation no longer matches
+        # and the result is discarded instead of reaching the queue.
+        self._incarnation: int = 0
         # Separate from _inference_count, which restarts each run. This gate
         # prevents RTC's own cold-start discard from re-arming. A caller may
         # still reset the model's latency callback at an episode boundary.
@@ -192,7 +192,7 @@ class RTCExecution(Execution):
         # Wake direct warmup callers before waiting on or refusing an active
         # worker. Otherwise they can remain blocked until the 120 s timeout.
         with self._obs_lock:
-            self._episode_id += 1
+            self._incarnation += 1
             self._obs_slot = None
             self._cancel_warmup_locked("RTCExecution warmup cancelled by restart")
 
@@ -281,9 +281,9 @@ class RTCExecution(Execution):
             if self._warmup_signal is not None:
                 msg = "RTCExecution warmup is already in progress"
                 raise RuntimeError(msg)
-            episode_id = self._episode_id
+            incarnation = self._incarnation
             self._warmup_signal = signal
-            self._obs_slot = (deepcopy(sample_observation), episode_id, signal)
+            self._obs_slot = (deepcopy(sample_observation), incarnation, signal)
 
         # Wait for the first chunk with a generous timeout
         if not signal.event.wait(timeout=120.0):
@@ -326,7 +326,7 @@ class RTCExecution(Execution):
 
         with self._obs_lock:
             snapshot = {k: v.copy() if isinstance(v, np.ndarray) else v for k, v in observation.items()}
-            self._obs_slot = (snapshot, self._episode_id, None)
+            self._obs_slot = (snapshot, self._incarnation, None)
 
     def reset(self, *, reset_model: bool = True) -> None:
         """Invalidate pending RTC work and optionally wait for active inference.
@@ -339,7 +339,7 @@ class RTCExecution(Execution):
         if self._model is None:
             raise RuntimeError(_NOT_STARTED)
         with self._obs_lock:
-            self._episode_id += 1
+            self._incarnation += 1
             self._obs_slot = None
             self._cancel_warmup_locked("RTCExecution warmup cancelled by reset")
         if reset_model:
@@ -356,7 +356,7 @@ class RTCExecution(Execution):
         alongside it.
         """
         with self._obs_lock:
-            self._episode_id += 1
+            self._incarnation += 1
             self._obs_slot = None
             self._cancel_warmup_locked("RTCExecution warmup cancelled because execution stopped")
         if self._thread is not None:
@@ -425,7 +425,7 @@ class RTCExecution(Execution):
             if request is None:
                 time.sleep(_IDLE_SLEEP_S)
                 continue
-            inputs, episode_id, signal = request
+            inputs, incarnation, signal = request
             inputs = deepcopy(inputs)
 
             # Build RTC-specific inputs
@@ -439,7 +439,7 @@ class RTCExecution(Execution):
                 t0 = time.perf_counter()
                 with self._model_lock:
                     with self._obs_lock:
-                        if episode_id != self._episode_id:
+                        if incarnation != self._incarnation:
                             self._cancel_signal_locked(signal, "RTCExecution warmup cancelled by reset")
                             continue
                     outputs = self._model(inputs)
@@ -471,7 +471,7 @@ class RTCExecution(Execution):
 
             processed_actions = self._accept_result(
                 outputs,
-                episode_id=episode_id,
+                incarnation=incarnation,
                 signal=signal,
                 elapsed=elapsed,
                 action_index_before=action_index_before,
@@ -504,15 +504,15 @@ class RTCExecution(Execution):
         self,
         outputs: dict[str, np.ndarray],
         *,
-        episode_id: int,
+        incarnation: int,
         signal: _WarmupSignal | None,
         elapsed: float,
         action_index_before: int,
     ) -> np.ndarray | None:
-        """Merge a result only if it belongs to the current episode.
+        """Merge a result only if it belongs to the current incarnation.
 
         Returns:
-            Processed actions, or ``None`` when the episode has changed.
+            Processed actions, or ``None`` when the incarnation has changed.
         """
         assert self._rtc_queue is not None  # noqa: S101
         raw_actions = outputs["action"]
@@ -521,7 +521,7 @@ class RTCExecution(Execution):
         processed_actions = self._postprocess(raw_actions)
 
         with self._obs_lock:
-            if episode_id != self._episode_id:
+            if incarnation != self._incarnation:
                 self._cancel_signal_locked(signal, "RTCExecution warmup cancelled by reset")
                 return None
 

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -349,12 +349,12 @@ class TestAsyncExecution:
                 time.sleep(0.001)
             assert ex._running_inference  # noqa: SLF001
 
-            episode_id = ex._episode_id  # noqa: SLF001
+            incarnation = ex._incarnation  # noqa: SLF001
             reset_thread = threading.Thread(target=ex.reset)
             reset_thread.start()
-            while ex._episode_id == episode_id and time.monotonic() < deadline:  # noqa: SLF001
+            while ex._incarnation == incarnation and time.monotonic() < deadline:  # noqa: SLF001
                 time.sleep(0.001)
-            assert ex._episode_id > episode_id  # noqa: SLF001
+            assert ex._incarnation > incarnation  # noqa: SLF001
         finally:
             ex._model_lock.release()  # noqa: SLF001
             if reset_thread is not None:
@@ -503,7 +503,7 @@ class TestRTCExecutionObsSlot:
         worker = ex._thread  # noqa: SLF001
         with ex._obs_lock:  # noqa: SLF001
             observation = {"state": np.zeros(3, dtype=np.float32)}
-            ex._obs_slot = (observation, ex._episode_id, None)  # noqa: SLF001
+            ex._obs_slot = (observation, ex._incarnation, None)  # noqa: SLF001
         assert entered.wait(timeout=5.0)
 
         reset_done = threading.Event()
@@ -540,18 +540,18 @@ class TestRTCExecutionObsSlot:
         try:
             with ex._obs_lock:  # noqa: SLF001
                 observation = {"state": np.zeros(3, dtype=np.float32)}
-                ex._obs_slot = (observation, ex._episode_id, None)  # noqa: SLF001
+                ex._obs_slot = (observation, ex._incarnation, None)  # noqa: SLF001
             deadline = time.monotonic() + 5.0
             while ex._obs_slot is not None and time.monotonic() < deadline:  # noqa: SLF001
                 time.sleep(0.001)
             assert ex._obs_slot is None  # noqa: SLF001
 
-            episode_id = ex._episode_id  # noqa: SLF001
+            incarnation = ex._incarnation  # noqa: SLF001
             reset_thread = threading.Thread(target=ex.reset)
             reset_thread.start()
-            while ex._episode_id == episode_id and time.monotonic() < deadline:  # noqa: SLF001
+            while ex._incarnation == incarnation and time.monotonic() < deadline:  # noqa: SLF001
                 time.sleep(0.001)
-            assert ex._episode_id > episode_id  # noqa: SLF001
+            assert ex._incarnation > incarnation  # noqa: SLF001
         finally:
             ex._model_lock.release()  # noqa: SLF001
             if reset_thread is not None:
@@ -781,7 +781,7 @@ class TestRestartAfterStop:
         ex._inference_count = 5  # noqa: SLF001
         with ex._lock:  # noqa: SLF001
             stale = {"state": np.full(4, 99.0, dtype=np.float32)}
-            ex._obs_slot = (stale, ex._episode_id)  # noqa: SLF001
+            ex._obs_slot = (stale, ex._incarnation)  # noqa: SLF001
             ex._running_inference = True  # noqa: SLF001
 
         ex.start(model, queue)
@@ -805,7 +805,7 @@ class TestRestartAfterStop:
         ex._death_cause = RuntimeError("died previously")  # noqa: SLF001
         with ex._obs_lock:  # noqa: SLF001
             stale = {"state": np.full(3, 99.0, dtype=np.float32)}
-            ex._obs_slot = (stale, ex._episode_id, None)  # noqa: SLF001
+            ex._obs_slot = (stale, ex._incarnation, None)  # noqa: SLF001
 
         ex.start(model, queue)
         try:
@@ -942,7 +942,7 @@ class TestStopTimeoutStraggler:
             model.side_effect = blocking
             ex.start(model, queue)
             with ex._obs_lock:  # noqa: SLF001
-                ex._obs_slot = (dict(obs), ex._episode_id, None)  # noqa: SLF001
+                ex._obs_slot = (dict(obs), ex._incarnation, None)  # noqa: SLF001
 
         assert entered.wait(timeout=5.0), "worker never entered inference"
         straggler = ex._thread  # noqa: SLF001


### PR DESCRIPTION
## Summary
- Rename the async/RTC execution generation counter from `_episode_id` to `_incarnation`.
- Follow-up to [#237](https://github.com/openvinotoolkit/physicalai/pull/237#discussion_r3783289417): `episode_id` read as a recording-episode identifier, but this value only tags in-flight inference so `reset()` can discard stale results.

`incarnation` is the usual name for a sequential instance after reset/recovery, used so delayed work from a previous generation cannot affect the current one.
