### PR TITLE
feat: add a two-stage inference runner

### DIFF
--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -98,6 +98,7 @@ component_registry = ComponentRegistry()
 
 # Runners
 component_registry.register("single_pass", "physicalai.inference.runners.SinglePass")
+component_registry.register("two_stage", "physicalai.inference.runners.TwoStage")
 
 # Preprocessors
 component_registry.register("normalize", "physicalai.inference.preprocessors.StatsNormalizer")

--- a/src/physicalai/inference/model.py
+++ b/src/physicalai/inference/model.py
@@ -144,7 +144,7 @@ class InferenceModel:
         self.adapter.load(model_path)
         logger.info("Model compiled in {:.1f}s", time.monotonic() - compile_started)
 
-        self.runner: InferenceRunner = runner if runner is not None else get_runner(self.manifest)
+        self.runner: InferenceRunner = runner if runner is not None else get_runner(self.manifest, self.export_dir)
 
         self.preprocessors: list[Preprocessor] = (
             preprocessors if preprocessors is not None else self._load_processors(self.manifest.model.preprocessors)

--- a/src/physicalai/inference/runners/__init__.py
+++ b/src/physicalai/inference/runners/__init__.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 from physicalai.inference.runners.base import InferenceRunner
 from physicalai.inference.runners.factory import get_runner
 from physicalai.inference.runners.single_pass import SinglePass
+from physicalai.inference.runners.two_stage import TwoStage
 
 __all__ = [
     "InferenceRunner",
     "SinglePass",
+    "TwoStage",
     "get_runner",
 ]

--- a/src/physicalai/inference/runners/factory.py
+++ b/src/physicalai/inference/runners/factory.py
@@ -11,10 +11,12 @@ from physicalai.inference.runners.base import InferenceRunner
 from physicalai.inference.runners.single_pass import SinglePass
 
 if TYPE_CHECKING:
-    from physicalai.inference.manifest import Manifest
+    from pathlib import Path
+
+    from physicalai.inference.manifest import ComponentSpec, Manifest
 
 
-def get_runner(source: Manifest | dict[str, Any]) -> InferenceRunner:
+def get_runner(source: Manifest | dict[str, Any], export_dir: Path | None = None) -> InferenceRunner:
     """Select and instantiate a runner from a manifest.
 
     Supports three input formats:
@@ -28,38 +30,54 @@ def get_runner(source: Manifest | dict[str, Any]) -> InferenceRunner:
 
     Args:
         source: A :class:`Manifest` instance or a raw manifest dict.
+        export_dir: Directory the manifest was read from. When given, a relative
+            ``artifact`` on the runner spec is resolved against it, the same way
+            preprocessor artifacts are. Runners that load a model of their own —
+            :class:`~physicalai.inference.runners.two_stage.TwoStage`, say — need
+            this; the others ignore it.
 
     Returns:
         Configured runner instance.
-
-    Raises:
-        TypeError: If a configured component is not an :class:`InferenceRunner`.
     """
     from physicalai.inference.manifest import Manifest  # noqa: PLC0415
 
     if isinstance(source, Manifest):
         if source.model.runner is not None:
-            from physicalai.inference.component_factory import instantiate_component  # noqa: PLC0415
-
-            runner = instantiate_component(source.model.runner)
-            if not isinstance(runner, InferenceRunner):
-                msg = f"Configured runner is not an InferenceRunner: {type(runner).__name__}"
-                raise TypeError(msg)
-            return runner
+            return _instantiate_runner(source.model.runner, export_dir)
         return SinglePass()
 
     runner_spec = _extract_runner_spec(source)
     if runner_spec is not None:
-        from physicalai.inference.component_factory import instantiate_component  # noqa: PLC0415
         from physicalai.inference.manifest import ComponentSpec  # noqa: PLC0415
 
-        runner = instantiate_component(ComponentSpec.model_validate(runner_spec))
-        if not isinstance(runner, InferenceRunner):
-            msg = f"Configured runner is not an InferenceRunner: {type(runner).__name__}"
-            raise TypeError(msg)
-        return runner
+        return _instantiate_runner(ComponentSpec.model_validate(runner_spec), export_dir)
 
     return SinglePass()
+
+
+def _instantiate_runner(spec: ComponentSpec, export_dir: Path | None) -> InferenceRunner:
+    """Build a runner from a component spec.
+
+    Args:
+        spec: Runner component spec.
+        export_dir: Directory used to resolve a relative ``artifact``, if any.
+
+    Returns:
+        The instantiated runner.
+
+    Raises:
+        TypeError: If the component is not an :class:`InferenceRunner`.
+    """
+    from physicalai.inference.component_factory import instantiate_component, resolve_artifact  # noqa: PLC0415
+
+    if export_dir is not None:
+        spec = resolve_artifact(spec, export_dir)
+
+    runner = instantiate_component(spec)
+    if not isinstance(runner, InferenceRunner):
+        msg = f"Configured runner is not an InferenceRunner: {type(runner).__name__}"
+        raise TypeError(msg)
+    return runner
 
 
 def _extract_runner_spec(manifest_dict: dict[str, Any]) -> dict[str, Any] | None:

--- a/src/physicalai/inference/runners/two_stage.py
+++ b/src/physicalai/inference/runners/two_stage.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Two-stage inference runner.
+
+Chains a second model onto the primary one: the primary adapter runs, and its
+outputs are fed by name into a second artifact loaded on a backend of its own.
+
+This exists for policies whose graph cannot be exported in one piece. A
+vision-language-action model, for example, may have a backbone that no exporter
+can capture and an action head that exports cleanly - and it is the head that is
+evaluated repeatedly per action chunk, so running it on an accelerated backend is
+where the time goes. Splitting the two lets each part run on the backend that can
+actually take it, without pretending the whole policy is one graph.
+
+The runner is deliberately generic: it knows nothing about which policy it is
+serving. The contract is only that the primary adapter's output names match the
+second model's input names.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+from typing_extensions import override
+
+from physicalai.inference.adapters import get_adapter
+from physicalai.inference.runners.base import InferenceRunner
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from physicalai.inference.adapters.base import RuntimeAdapter
+
+
+class TwoStage(InferenceRunner):
+    """Run the primary adapter, then feed its outputs to a second model.
+
+    The second model is loaded lazily on the first call, so constructing the
+    runner - which happens while the manifest is being read - never touches the
+    filesystem or compiles a graph.
+
+    Example:
+        A manifest declaring a Torch backbone with an OpenVINO action head::
+
+            "runner": {
+                "type": "two_stage",
+                "backend": "openvino",
+                "artifact": "xr1_action_expert.xml"
+            }
+
+        ``artifact`` is resolved against the export directory by
+        :func:`~physicalai.inference.component_factory.resolve_artifact`, the same
+        way preprocessor artifacts are.
+    """
+
+    def __init__(
+        self,
+        backend: str,
+        artifact: str,
+        device: str = "auto",
+        **adapter_kwargs: Any,  # noqa: ANN401 - forwarded to the second adapter's constructor
+    ) -> None:
+        """Configure the second stage.
+
+        Args:
+            backend: Backend name for the second model, e.g. ``"openvino"``.
+            artifact: Path to the second model, absolute after the manifest has
+                been resolved against the export directory.
+            device: Device for the second model, or ``"auto"`` to use the
+                backend's own default.
+            **adapter_kwargs: Forwarded to the second adapter's constructor.
+        """
+        self.backend = backend
+        self.artifact = artifact
+        self.device = device
+        self._adapter_kwargs = adapter_kwargs
+        self._second: RuntimeAdapter | None = None
+
+    def _second_adapter(self) -> RuntimeAdapter:
+        """Return the second stage's adapter, loading it on first use.
+
+        Returns:
+            The loaded adapter.
+        """
+        if self._second is None:
+            kwargs = dict(self._adapter_kwargs)
+            if self.device != "auto":
+                kwargs["device"] = self.device
+            adapter = get_adapter(self.backend, **kwargs)
+            logger.info("Loading second stage: {} from {}", self.backend, self.artifact)
+            adapter.load(Path(self.artifact))
+            self._second = adapter
+        return self._second
+
+    @override
+    def run(
+        self,
+        adapter: RuntimeAdapter,
+        inputs: dict[str, np.ndarray],
+    ) -> dict[str, np.ndarray]:
+        """Run both stages and return the second stage's output.
+
+        Args:
+            adapter: The primary adapter, already loaded by ``InferenceModel``.
+            inputs: Pre-processed model inputs.
+
+        Returns:
+            The second stage's output dict.
+
+        Raises:
+            KeyError: If the primary stage does not produce every input the
+                second stage declares. Reported up front, because the alternative
+                is a shape error from inside the second backend.
+        """
+        intermediate = dict(adapter.predict(inputs))
+        second = self._second_adapter()
+
+        expected = second.input_names
+        if not expected:
+            return dict(second.predict(intermediate))
+
+        missing = [name for name in expected if name not in intermediate]
+        if missing:
+            msg = (
+                f"The first stage did not produce {missing}, which the second stage needs. "
+                f"It produced {sorted(intermediate)}."
+            )
+            raise KeyError(msg)
+
+        return dict(second.predict({name: intermediate[name] for name in expected}))
+
+    @override
+    def reset(self) -> None:
+        """Reset for a new episode.
+
+        Both stages are stateless, so there is nothing to clear; the loaded
+        second-stage adapter is kept, since reloading it would recompile the graph.
+        """
+
+    def __repr__(self) -> str:
+        """Return string representation of the runner.
+
+        Returns:
+            A representation naming the second stage.
+        """
+        return f"{self.__class__.__name__}(backend={self.backend!r}, artifact={self.artifact!r})"

--- a/tests/unit/inference/test_runners.py
+++ b/tests/unit/inference/test_runners.py
@@ -1,0 +1,217 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for inference runners and the runner factory."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+from physicalai.inference.manifest import ComponentSpec
+from physicalai.inference.runners import SinglePass, TwoStage, get_runner
+
+
+def fake_adapter(outputs: dict[str, np.ndarray], input_names: list[str] | None = None) -> Mock:
+    """Build an adapter stand-in whose predict returns fixed outputs.
+
+    Args:
+        outputs: What ``predict`` returns.
+        input_names: Declared input names, empty when omitted.
+
+    Returns:
+        The mock adapter.
+    """
+    adapter = Mock()
+    adapter.predict.return_value = outputs
+    adapter.input_names = input_names or []
+    return adapter
+
+
+class TestSinglePass:
+    """The default runner is a passthrough."""
+
+    def test_returns_adapter_output(self) -> None:
+        """Test SinglePass forwards the adapter's output unchanged."""
+        adapter = fake_adapter({"action": np.zeros(3)})
+
+        outputs = SinglePass().run(adapter, {"state": np.zeros(2)})
+
+        assert set(outputs) == {"action"}
+        adapter.predict.assert_called_once()
+
+
+class TestTwoStage:
+    """Chaining a second model onto the primary adapter."""
+
+    @staticmethod
+    def _runner(second: Mock, tmp_path: Path) -> TwoStage:
+        """Build a runner whose second stage is a mock adapter.
+
+        Args:
+            second: The stand-in for the second adapter.
+            tmp_path: Directory used as the artifact location.
+
+        Returns:
+            The configured runner.
+        """
+        runner = TwoStage(backend="openvino", artifact=str(tmp_path / "second.xml"))
+        runner._second = second  # noqa: SLF001 - bypasses lazy loading in tests
+        return runner
+
+    def test_feeds_the_first_stage_output_into_the_second(self, tmp_path: Path) -> None:
+        """Test the intermediate tensors are passed on by name."""
+        first = fake_adapter({"noise": np.zeros(2), "state_embed": np.ones(2)})
+        second = fake_adapter({"action": np.full(3, 7.0)}, input_names=["noise", "state_embed"])
+
+        outputs = self._runner(second, tmp_path).run(first, {"state": np.zeros(2)})
+
+        assert outputs["action"].tolist() == [7.0, 7.0, 7.0]
+        passed = second.predict.call_args.args[0]
+        assert set(passed) == {"noise", "state_embed"}
+
+    def test_drops_intermediates_the_second_stage_does_not_want(self, tmp_path: Path) -> None:
+        """Test extra outputs from the first stage are filtered out.
+
+        The first stage is a whole model, so it may emit diagnostics the second
+        graph has no input for; passing those on would fail inside the backend.
+        """
+        first = fake_adapter({"noise": np.zeros(2), "debug": np.zeros(1)})
+        second = fake_adapter({"action": np.zeros(3)}, input_names=["noise"])
+
+        self._runner(second, tmp_path).run(first, {})
+
+        assert set(second.predict.call_args.args[0]) == {"noise"}
+
+    def test_passes_everything_when_the_second_stage_declares_nothing(self, tmp_path: Path) -> None:
+        """Test an adapter without declared inputs receives the whole dict."""
+        first = fake_adapter({"noise": np.zeros(2), "extra": np.zeros(1)})
+        second = fake_adapter({"action": np.zeros(3)})
+
+        self._runner(second, tmp_path).run(first, {})
+
+        assert set(second.predict.call_args.args[0]) == {"noise", "extra"}
+
+    def test_missing_intermediate_is_reported(self, tmp_path: Path) -> None:
+        """Test a naming mismatch is reported rather than left to the backend."""
+        first = fake_adapter({"noise": np.zeros(2)})
+        second = fake_adapter({"action": np.zeros(3)}, input_names=["noise", "state_embed"])
+
+        with pytest.raises(KeyError, match="state_embed"):
+            self._runner(second, tmp_path).run(first, {})
+
+    def test_second_stage_is_loaded_lazily(self, tmp_path: Path) -> None:
+        """Test constructing the runner does not compile the second graph.
+
+        The runner is built while the manifest is read, before the export
+        directory has necessarily been validated.
+        """
+        artifact = tmp_path / "second.xml"
+        runner = TwoStage(backend="openvino", artifact=str(artifact))
+        first = fake_adapter({"noise": np.zeros(2)})
+        second = fake_adapter({"action": np.zeros(3)})
+
+        with patch("physicalai.inference.runners.two_stage.get_adapter", return_value=second) as factory:
+            factory.assert_not_called()
+            runner.run(first, {})
+            runner.run(first, {})
+
+        factory.assert_called_once()
+        second.load.assert_called_once_with(artifact)
+
+    def test_reset_keeps_the_compiled_second_stage(self, tmp_path: Path) -> None:
+        """Test a new episode does not force a graph recompile."""
+        second = fake_adapter({"action": np.zeros(3)})
+        runner = self._runner(second, tmp_path)
+
+        runner.reset()
+
+        assert runner._second is second  # noqa: SLF001 - asserting the cache survives
+
+    def test_repr_names_the_second_stage(self, tmp_path: Path) -> None:
+        """Test the representation is useful in a log line."""
+        assert "openvino" in repr(TwoStage(backend="openvino", artifact=str(tmp_path / "second.xml")))
+
+
+class TestGetRunner:
+    """Runner selection from a manifest."""
+
+    def test_defaults_to_single_pass(self) -> None:
+        """Test a manifest without a runner spec gets the passthrough runner."""
+        assert isinstance(get_runner({}), SinglePass)
+
+    def test_builds_a_declared_runner(self) -> None:
+        """Test a type-based spec resolves through the component registry."""
+        runner = get_runner({"model": {"runner": {"type": "single_pass"}}})
+
+        assert isinstance(runner, SinglePass)
+
+    def test_rejects_a_component_that_is_not_a_runner(self) -> None:
+        """Test a misconfigured manifest fails at load, not at first inference."""
+        spec = {"model": {"runner": {"type": "normalize", "stats": {}}}}
+
+        with pytest.raises(TypeError, match="not an InferenceRunner"):
+            get_runner(spec)
+
+    def test_resolves_the_runner_artifact_against_the_export_dir(self, tmp_path: Path) -> None:
+        """Test a relative artifact becomes absolute, as it does for preprocessors.
+
+        A manifest names artifacts relative to the export directory, so a runner
+        that loads a model of its own cannot use the name as given.
+        """
+        spec = {"model": {"runner": {"type": "two_stage", "backend": "openvino", "artifact": "expert.xml"}}}
+
+        runner = get_runner(spec, export_dir=tmp_path)
+
+        assert isinstance(runner, TwoStage)
+        assert runner.artifact == str(tmp_path.resolve() / "expert.xml")
+
+    def test_resolves_a_class_path_runner_artifact(self, tmp_path: Path) -> None:
+        """Test class_path specs resolve their artifact too.
+
+        Exporters prefer class_path mode for runners that carry manifest metadata:
+        in type mode every extra field is forwarded to the constructor, so a
+        chunk_size annotation would be passed to the runner as an argument.
+        """
+        spec = {
+            "model": {
+                "runner": {
+                    "class_path": "physicalai.inference.runners.TwoStage",
+                    "init_args": {"backend": "openvino", "artifact": "expert.xml"},
+                    "chunk_size": 8,
+                },
+            },
+        }
+
+        runner = get_runner(spec, export_dir=tmp_path)
+
+        assert isinstance(runner, TwoStage)
+        assert runner.artifact == str(tmp_path.resolve() / "expert.xml")
+
+    def test_rejects_an_artifact_outside_the_export_dir(self, tmp_path: Path) -> None:
+        """Test path traversal in a manifest is refused."""
+        spec = {
+            "model": {
+                "runner": {"type": "two_stage", "backend": "openvino", "artifact": "../../etc/passwd"},
+            },
+        }
+
+        with pytest.raises(ValueError, match="escapes the export directory"):
+            get_runner(spec, export_dir=tmp_path)
+
+    def test_manifest_object_path_resolves_too(self, tmp_path: Path) -> None:
+        """Test the Manifest branch behaves like the dict branch."""
+        from physicalai.inference.manifest import Manifest, ModelSpec
+
+        manifest = Manifest(
+            model=ModelSpec(
+                runner=ComponentSpec(type="two_stage", backend="openvino", artifact="expert.xml"),
+                artifacts={"torch": "policy.pt"},
+            ),
+        )
+
+        runner = get_runner(manifest, export_dir=tmp_path)
+
+        assert isinstance(runner, TwoStage)
+        assert runner.artifact == str(tmp_path.resolve() / "expert.xml")


### PR DESCRIPTION
## Summary

- Adds `physicalai.inference.runners.TwoStage`, a runner that executes two artifacts in sequence: the first stage's output feeds the second's input, and each stage can sit on a different backend.
- Registers it in the runner factory, so a manifest can name it through `class_path` like any other runner.
- 217 lines of tests in `tests/unit/inference/test_runners.py`.

## Why

A vision-language-action policy is not always exportable as one graph. Concretely, a Qwen3-VL backbone under `transformers` 5.5.4 is capturable by neither `torch.export` nor `torch.jit.trace`, while the action expert that runs several times per chunk exports cleanly and benefits most from an optimized backend.

Splitting execution recovers the value: the backbone runs on the Torch adapter, the action expert on the OpenVINO one, and `InferenceModel` loads the directory unchanged. Measured end to end on such an export, the hybrid path matches the pure-Torch path to **7.9e-08** absolute, with the action expert **2.9x faster** on CPU (2.6 ms vs 7.6 ms, AMD Threadripper 3960X).

The runner is deliberately generic. It takes any two adapters, has no policy name in its logic, and knows nothing about the model that motivated it. An earlier draft added a `bind_export_dir` hook to `InferenceRunner`; it was dropped once it became clear the existing `resolve_artifact` already solved the problem. One new concept, in the place runners already live.

Consumer side: [open-edge-platform/physical-ai-studio PR](https://github.com/open-edge-platform/physical-ai-studio) adding the XR-1 policy, whose hybrid export writes a manifest naming this runner.

## Validation

- `pytest tests/unit/inference/test_runners.py` — new coverage for two-stage execution, including artifact resolution and stage wiring.
- `pytest tests/unit` — full unit suite passes.
- `prek run --all-files` and `pyrefly check` clean.
- Exercised end to end from the Studio side: `InferenceModel(...)` loading a two-artifact export, backbone on Torch and action expert on OpenVINO, 7.9e-08 against the single-backend export.

## Breaking changes

- None. New runner plus its registration; existing runners and manifests are untouched.

## Related issues

- None.
