### PR TITLE
fix(inference): support concrete InferenceFeature jsonargparse parsing

### DIFF
--- a/src/physicalai/inference/component_factory.py
+++ b/src/physicalai/inference/component_factory.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from jsonargparse import ArgumentParser
 
 from physicalai.config import Config
+from physicalai.config.base import parse_class_config
 
 from ._importing import import_dotted_path
 from .manifest import ComponentSpec
@@ -224,15 +225,23 @@ def instantiate_component(
     if not isinstance(class_path, str) or not isinstance(init_args, dict):
         msg = "Resolved component spec is not a valid class recipe"
         raise TypeError(msg)
-    parser = ArgumentParser(exit_on_error=False)
-    parser.add_subclass_arguments(base, "component", required=True)
+    target = _import_class(class_path)
     try:
+        # ``add_subclass_arguments`` expects an actual base class with
+        # selectable subclasses.  Feature descriptors are concrete dataclasses,
+        # so use the regular typed-class parser when the recipe names the
+        # expected class itself.
+        if target is base:
+            return parse_class_config(base, init_args)
+
+        parser = ArgumentParser(exit_on_error=False)
+        parser.add_subclass_arguments(base, "component", required=True)
         namespace = parser.parse_object(
             {"component": {"class_path": class_path, "init_args": init_args}},
             defaults=False,
         )
         return parser.instantiate(namespace).component
-    except ArgumentError as exc:
+    except (ArgumentError, ValueError) as exc:
         raise TypeError(str(exc)) from exc
 
 

--- a/tests/unit/inference/test_manifest.py
+++ b/tests/unit/inference/test_manifest.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
+from physicalai.inference.data.features import InferenceFeature, InferenceFeatureDtype, InferenceFeatureType
 from physicalai.inference.component_factory import (
     ComponentRegistry,
     component_registry,
@@ -216,6 +217,21 @@ class TestInstantiateComponent:
         spec = ComponentSpec.model_validate({"type": "single_pass"})
         runner = instantiate_component(spec)
         assert isinstance(runner, SinglePass)
+
+    def test_instantiate_concrete_dataclass(self) -> None:
+        spec = ComponentSpec.model_validate({
+            "class_path": "physicalai.inference.data.features.InferenceFeature",
+            "init_args": {"ftype": "STATE", "shape": [3], "name": "state", "dtype": "float32"},
+        })
+
+        feature = instantiate_component(InferenceFeature, spec)
+
+        assert feature == InferenceFeature(
+            ftype=InferenceFeatureType.STATE,
+            shape=(3,),
+            name="state",
+            dtype=InferenceFeatureDtype.FLOAT32,
+        )
 
     def test_instantiate_rejects_invalid_flat_params(self) -> None:
         spec = ComponentSpec.model_validate({"type": "single_pass", "": ""})


### PR DESCRIPTION
## Background

Runtime inference manifests describe `InferenceFeature` entries as component recipes. After the jsonargparse construction migration in Runtime PR #227, loading these entries passed the concrete `InferenceFeature` dataclass to `ArgumentParser.add_subclass_arguments()`. jsonargparse requires that API to receive a selectable base class, so feature loading failed before parsing the manifest.

## What changed

- Use the typed jsonargparse class parser for recipes whose target class is the expected concrete class.
- Keep subclass parsing for runners, preprocessors, postprocessors, and other polymorphic components.
- Reuse the non-deprecated `parse_class_config` path so enum wire values and tuple-shaped fields are coerced consistently.
- Add a regression test covering `InferenceFeature` construction from manifest-style values.