### PR TITLE
chore: add security/trust model and suppress some SAST findings

### DIFF
--- a/.github/scripts/skills/agent_skills.py
+++ b/.github/scripts/skills/agent_skills.py
@@ -10,7 +10,7 @@ import argparse
 import os
 import platform
 import re
-import subprocess
+import subprocess  # nosec: B404
 import sys
 from pathlib import Path
 
@@ -88,7 +88,9 @@ def _create_windows_link(link: Path, abs_target: Path) -> None:
     try:
         link.symlink_to(abs_target, target_is_directory=True)
     except OSError:
-        subprocess.run(
+        # Local CI script, link/abs_target come from this repo's own
+        # skills/ directory listing, not external input
+        subprocess.run(  # nosec: B607, B603
             ["cmd", "/c", "mklink", "/J", str(link), str(abs_target)],
             check=True,
             capture_output=True,

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -7,6 +7,7 @@ This section contains short tutorials for the first successful PhysicalAI workfl
 1. [Installation](installation.md)
 2. [Quickstart](quickstart.md)
 3. [Run a Policy](run-a-policy.md)
+4. [Security Model](security.md)
 
 ## Minimal Path
 

--- a/docs/getting-started/security.md
+++ b/docs/getting-started/security.md
@@ -13,7 +13,7 @@ sources, callbacks. Currently, nothing restricts which class a `class_path` may 
 Only load configs, exported policies, and manifests from sources you trust. See also the `class_path` note in
 [Config Schema Reference](../reference/config-schema.md#security).
 
-## Use only trusted reviewed policies
+## Use only trusted, reviewed policies
 
 An exported policy package (`manifest.json` plus artifacts) runs with the same privileges as the
 `physicalai` process.
@@ -24,7 +24,7 @@ loaded on every run.
 
 **Loading via `export_dir`:** `physicalai run` and direct `InferenceModel(export_dir=...)` construction both
 load whatever package is already in that local directory. Only place a reviewed, trusted export there.
-treat populating that directory (downloading, copying, extracting) as the point where you decide to trust
+Treat populating that directory (downloading, copying, extracting) as the point where you decide to trust
 its contents.
 
 ## Remote robot sharing has no built-in security controls

--- a/docs/getting-started/security.md
+++ b/docs/getting-started/security.md
@@ -1,0 +1,57 @@
+# Security Model
+
+The runtime treats several categories of input as trusted by design and does not sandbox them further. If you
+load a config, manifest, or exported policy you did not author or fully review, you are running that content
+with the same privileges as the `physicalai` process itself. The sections below describe each trust boundary.
+
+## Configs and manifests can execute arbitrary code
+
+YAML/JSON configs passed via `--config` flag and an exported policy's `manifest.json` both use `class_path` values to
+dynamically import and construct Python objects - robots, cameras, preprocessors, postprocessors, action
+sources, callbacks. Currently, nothing restricts which class a `class_path` may name.
+
+Only load configs, exported policies and manifest from sources you trust. See also the `class_path` note in
+[Config Schema Reference](../reference/config-schema.md#security).
+
+## Use only trusted reviewed policies
+
+An exported policy package (`manifest.json` plus artifacts) runs with the same privileges as the
+`physicalai` process.
+
+**Loading via `InferenceModel.from_pretrained()`:** pin `revision` to the commit SHA of a version you have
+reviewed and trust, rather than a mutable branch or tag, so the content you reviewed is exactly what gets
+loaded on every run.
+
+**Loading via `export_dir`:** `physicalai run` and direct `InferenceModel(export_dir=...)` construction both
+load whatever package is already in that local directory. Only place a reviewed, trusted export there - 
+treat populating that directory (downloading, copying, extracting) as the point where you decide to trust
+its contents.
+
+## Remote robot sharing has no built-in security controls
+
+The `SharedRobot` network transport (used to share one robot connection across processes) has no
+authentication, access control or encryption of its own.
+
+If you enable `allow_remote=True` (`--allow_remote` on `physicalai robot serve`/`discover`), use it only on
+an isolated, firewalled robot-cell network (VLAN/firewall) or with Zenoh ACL/TLS configured yourself — the
+same requirement documented in [CLI Reference](../reference/cli.md#physicalai-robot-serve). Without one of
+those, anyone who can reach that network can observe robot state and, if nothing else restricts it, send
+actions to the robot.
+
+## Runtime callbacks run with full trust
+
+Callbacks registered with `RobotRuntime` (see
+[Add Runtime Callbacks](../how-to/runtime/add-runtime-callbacks.md)) can inspect and modify the
+action sent to the robot on every control tick. Currently, the runtime does not validate a callback's output before
+sending it to hardware.
+
+Only register callbacks you wrote or have reviewed, especially any callback that can transform the outgoing
+action.
+
+## CLI subcommands load from the active Python environment
+
+`physicalai <subcommand>` discovers third-party subcommands via Python entry points registered by packages
+installed in the current environment. There is no allow-list of which packages may register a subcommand.
+
+Treat installing a package into the same environment as granting it the ability to run as a `physicalai`
+subcommand and apply the same security review you would to any other dependency.

--- a/docs/getting-started/security.md
+++ b/docs/getting-started/security.md
@@ -10,7 +10,7 @@ YAML/JSON configs passed via `--config` flag and an exported policy's `manifest.
 dynamically import and construct Python objects - robots, cameras, preprocessors, postprocessors, action
 sources, callbacks. Currently, nothing restricts which class a `class_path` may name.
 
-Only load configs, exported policies and manifest from sources you trust. See also the `class_path` note in
+Only load configs, exported policies, and manifests from sources you trust. See also the `class_path` note in
 [Config Schema Reference](../reference/config-schema.md#security).
 
 ## Use only trusted reviewed policies
@@ -23,7 +23,7 @@ reviewed and trust, rather than a mutable branch or tag, so the content you revi
 loaded on every run.
 
 **Loading via `export_dir`:** `physicalai run` and direct `InferenceModel(export_dir=...)` construction both
-load whatever package is already in that local directory. Only place a reviewed, trusted export there - 
+load whatever package is already in that local directory. Only place a reviewed, trusted export there.
 treat populating that directory (downloading, copying, extracting) as the point where you decide to trust
 its contents.
 

--- a/docs/reference/config-schema.md
+++ b/docs/reference/config-schema.md
@@ -68,4 +68,5 @@ manifest unification is a separate design decision.
 
 `class_path` is executable local configuration. `instantiate()` is for
 trusted application and user-authored configs only, never metadata or control
-messages received from peers.
+messages received from peers. See [Security Model](../getting-started/security.md)
+for the full set of deployment-time trust assumptions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - Installation: getting-started/installation.md
       - Quickstart: getting-started/quickstart.md
       - Run a Policy: getting-started/run-a-policy.md
+      - Security Model: getting-started/security.md
   - How-To:
       - Overview: how-to/README.md
       - Runtime:

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -144,7 +144,10 @@ def build_camera(config: dict) -> Camera:
 
         # Validate / reject flat keys even on the factory-override path.
         spec = CameraPublisherConfig.from_json_dict(config)
-        module_path, _, attr = factory_override.rpartition(":")
+        module_path, sep, attr = factory_override.rpartition(":")
+        if not sep or not module_path or not attr:
+            msg = f"invalid _factory_override {factory_override!r}; expected 'module:factory'"
+            raise ValueError(msg)
         # _factory_override is a private, test-only constructor kwarg (see build_camera's
         # docstring) delivered over a stdin pipe this same process's CameraPublisher.start()
         # writes, no production call site or external input sets it.

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -145,6 +145,10 @@ def build_camera(config: dict) -> Camera:
         # Validate / reject flat keys even on the factory-override path.
         spec = CameraPublisherConfig.from_json_dict(config)
         module_path, _, attr = factory_override.rpartition(":")
+        # _factory_override is a private, test-only constructor kwarg (see build_camera's
+        # docstring) delivered over a stdin pipe this same process's CameraPublisher.start()
+        # writes, no production call site or external input sets it.
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
         mod = importlib.import_module(module_path)
         factory = getattr(mod, attr)
         init_args = spec.camera.get("init_args", {})

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -155,9 +155,13 @@ def build_camera(config: dict) -> Camera:
         # _factory_override is a private, test-only constructor kwarg (see build_camera's
         # docstring) delivered over a stdin pipe this same process's CameraPublisher.start()
         # writes, no production call site or external input sets it.
-        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
-        mod = importlib.import_module(module_path)
-        factory = getattr(mod, attr)
+        try:
+            # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
+            mod = importlib.import_module(module_path)
+            factory = getattr(mod, attr)
+        except (ImportError, AttributeError) as exc:
+            msg = f"invalid _factory_override {factory_override!r}: {exc}"
+            raise ValueError(msg) from exc
         init_args = spec.camera.get("init_args", {})
         if not isinstance(init_args, dict):
             init_args = {}

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -159,6 +159,10 @@ def build_camera(config: dict) -> Camera:
             # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
             mod = importlib.import_module(module_path)
             factory = getattr(mod, attr)
+            if not callable(factory):
+                raise ValueError(
+                    f"invalid _factory_override {factory_override!r}: {module_path}:{attr} is not callable"
+                )
         except (ImportError, AttributeError) as exc:
             msg = f"invalid _factory_override {factory_override!r}: {exc}"
             raise ValueError(msg) from exc

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -137,10 +137,6 @@ def build_camera(config: dict) -> Camera:
 
     Returns:
         Camera instance (not yet connected).
-
-    Raises:
-        ValueError: If ``_factory_override`` is set but not a valid ``'module:factory'`` path,
-            or if the ``camera`` entry fails publisher-envelope validation.
     """
     factory_override = config.get("_factory_override")
     if factory_override:
@@ -148,24 +144,13 @@ def build_camera(config: dict) -> Camera:
 
         # Validate / reject flat keys even on the factory-override path.
         spec = CameraPublisherConfig.from_json_dict(config)
-        module_path, sep, attr = factory_override.rpartition(":")
-        if not sep or not module_path or not attr:
-            msg = f"invalid _factory_override {factory_override!r}; expected 'module:factory'"
-            raise ValueError(msg)
-        # _factory_override is a private, test-only constructor kwarg (see build_camera's
-        # docstring) delivered over a stdin pipe this same process's CameraPublisher.start()
+        module_path, _, attr = factory_override.rpartition(":")
+        # _factory_override is a private, test-only constructor kwarg
+        # delivered over a stdin pipe this same process's CameraPublisher.start()
         # writes, no production call site or external input sets it.
-        try:
-            # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
-            mod = importlib.import_module(module_path)
-            factory = getattr(mod, attr)
-            if not callable(factory):
-                raise ValueError(
-                    f"invalid _factory_override {factory_override!r}: {module_path}:{attr} is not callable"
-                )
-        except (ImportError, AttributeError) as exc:
-            msg = f"invalid _factory_override {factory_override!r}: {exc}"
-            raise ValueError(msg) from exc
+        # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
+        mod = importlib.import_module(module_path)
+        factory = getattr(mod, attr)
         init_args = spec.camera.get("init_args", {})
         if not isinstance(init_args, dict):
             init_args = {}

--- a/src/physicalai/capture/transport/_publisher_worker.py
+++ b/src/physicalai/capture/transport/_publisher_worker.py
@@ -137,6 +137,10 @@ def build_camera(config: dict) -> Camera:
 
     Returns:
         Camera instance (not yet connected).
+
+    Raises:
+        ValueError: If ``_factory_override`` is set but not a valid ``'module:factory'`` path,
+            or if the ``camera`` entry fails publisher-envelope validation.
     """
     factory_override = config.get("_factory_override")
     if factory_override:


### PR DESCRIPTION
This PR adds documentation of the library deployment-time trust assumptions (security model) and suppress several false positives detected by static code analyzers.