### PR TITLE
refactor: simplify RTC pipeline

### DIFF
--- a/src/physicalai/inference/model.py
+++ b/src/physicalai/inference/model.py
@@ -142,7 +142,6 @@ class InferenceModel:
         compile_started = time.monotonic()
         logger.info("Compiling {} model on {}...", self.backend, self.device)
         self.adapter.load(model_path)
-        #self.adapter._policy.rtc_enabled = True
         logger.info("Model compiled in {:.1f}s", time.monotonic() - compile_started)
 
         self.runner: InferenceRunner = runner if runner is not None else get_runner(self.manifest)

--- a/src/physicalai/inference/model.py
+++ b/src/physicalai/inference/model.py
@@ -142,6 +142,7 @@ class InferenceModel:
         compile_started = time.monotonic()
         logger.info("Compiling {} model on {}...", self.backend, self.device)
         self.adapter.load(model_path)
+        #self.adapter._policy.rtc_enabled = True
         logger.info("Model compiled in {:.1f}s", time.monotonic() - compile_started)
 
         self.runner: InferenceRunner = runner if runner is not None else get_runner(self.manifest)

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -582,4 +582,3 @@ class RTCExecution(Execution):
         inputs["execution_horizon"] = np.int64(execution_horizon)
 
         return inputs
-

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from physicalai.config import export_config
+from physicalai.inference.constants import ACTION
 from physicalai.runtime.execution.base import Execution, WorkerDiedError
 
 if TYPE_CHECKING:
@@ -479,7 +480,7 @@ class RTCExecution(Execution):
             Processed actions, or ``None`` when the incarnation has changed.
         """
         assert self._rtc_queue is not None  # noqa: S101
-        raw_actions = outputs["action"]
+        raw_actions = outputs[ACTION]
         if raw_actions.ndim == 3:  # noqa: PLR2004
             raw_actions = raw_actions[0]
         processed_actions = raw_actions

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -79,9 +79,6 @@ class RTCExecution(Execution):
             and more open-loop (re-plans less often); smaller = more
             reactive (re-plans more often, more model calls per second).
         fps: Robot control frequency in Hz.
-        max_action_dim: Model's internal action dimension (for noise/padding).
-            If None, is automatically inferred from the model's manifest or
-            defaulted to 32.
         max_guidance_weight: Strength of the RTC inpainting guidance
             (paper's β, default 5). Higher pulls each new chunk more
             tightly toward the previous chunk's tail (smoother seams)
@@ -102,7 +99,6 @@ class RTCExecution(Execution):
         chunk_size: int | None = None,
         execution_horizon: int = 15,
         fps: float = 30.0,
-        max_action_dim: int | None = None,
         max_guidance_weight: float = 5.0,
         queue_threshold: int | None = None,
         latency_tracker: RTCLatencyTracker | None = None,
@@ -111,7 +107,6 @@ class RTCExecution(Execution):
         self._chunk_size_param = chunk_size
         self._execution_horizon = execution_horizon
         self._fps = fps
-        self._max_action_dim_param = max_action_dim
         self._max_guidance_weight = max_guidance_weight
         self._queue_threshold_param = queue_threshold
         self._latency_tracker = latency_tracker
@@ -122,7 +117,6 @@ class RTCExecution(Execution):
 
         # Discovered/inferred state
         self._chunk_size: int = 50
-        self._max_action_dim: int = 32
         self._chunk_size_discovered: int = 0
 
         # Thread state
@@ -196,7 +190,7 @@ class RTCExecution(Execution):
         self._model = model
         self._rtc_queue = action_queue
 
-        # 1. Infer chunk_size
+        # Infer chunk_size
         if self._chunk_size_param is not None:
             self._chunk_size = self._chunk_size_param
         else:
@@ -207,23 +201,6 @@ class RTCExecution(Execution):
                 self._chunk_size = model.chunk_size
             else:
                 self._chunk_size = 50  # fallback default to Pi05 chunk size
-
-        # 2. Infer max_action_dim
-        if self._max_action_dim_param is not None:
-            self._max_action_dim = self._max_action_dim_param
-        else:
-            rtc_config = model.manifest.model_extra.get("rtc", {}) if hasattr(model, "manifest") else {}
-            if isinstance(rtc_config, dict) and "max_action_dim" in rtc_config:
-                self._max_action_dim = int(rtc_config["max_action_dim"])
-            elif (
-                hasattr(model, "manifest")
-                and model.manifest.hardware.robots
-                and model.manifest.hardware.robots[0].action is not None
-                and model.manifest.hardware.robots[0].action.shape
-            ):
-                self._max_action_dim = model.manifest.hardware.robots[0].action.shape[-1]
-            else:
-                self._max_action_dim = 32
 
         # Fresh events rather than clearing the shared ones: a worker that
         # outlived stop() keeps its own set stop event, so it cannot be revived

--- a/src/physicalai/runtime/execution/rtc.py
+++ b/src/physicalai/runtime/execution/rtc.py
@@ -25,7 +25,6 @@ from physicalai.runtime.execution.base import Execution, WorkerDiedError
 if TYPE_CHECKING:
     from physicalai.inference.callbacks.rtc_latency import RTCLatencyTracker
     from physicalai.inference.model import InferenceModel
-    from physicalai.inference.postprocessors.base import Postprocessor
     from physicalai.runtime._callback_bus import _CallbackBus
     from physicalai.runtime.execution.rtc_queue import RTCActionQueue
 
@@ -96,10 +95,6 @@ class RTCExecution(Execution):
         warmup_inferences: Number of initial inferences treated as warmup.
             The latency tracker is reset after these to discard
             compilation/kernel-build overhead (e.g. OpenVINO first-run).
-        postprocessors: Denormalization pipeline applied to raw actions.
-            These run in the background thread to produce the processed
-            track stored in the queue. If None, is automatically populated from
-            the model's postprocessors.
     """
 
     def __init__(  # noqa: D107
@@ -112,7 +107,6 @@ class RTCExecution(Execution):
         queue_threshold: int | None = None,
         latency_tracker: RTCLatencyTracker | None = None,
         warmup_inferences: int = 2,
-        postprocessors: list[Postprocessor] | None = None,
     ) -> None:
         self._chunk_size_param = chunk_size
         self._execution_horizon = execution_horizon
@@ -122,7 +116,6 @@ class RTCExecution(Execution):
         self._queue_threshold_param = queue_threshold
         self._latency_tracker = latency_tracker
         self._warmup_inferences = max(1, warmup_inferences)
-        self._postprocessors: list[Postprocessor] = postprocessors or []
 
         self._rtc_queue: RTCActionQueue | None = None
         self._model: InferenceModel | None = None
@@ -231,12 +224,6 @@ class RTCExecution(Execution):
                 self._max_action_dim = model.manifest.hardware.robots[0].action.shape[-1]
             else:
                 self._max_action_dim = 32
-
-        # 3. Automatically discover postprocessors from model if empty/not provided
-        if not self._postprocessors and hasattr(model, "postprocessors") and model.postprocessors:
-            logger.info("Moving postprocessors from InferenceModel to RTCExecution for async background execution")
-            self._postprocessors = model.postprocessors
-            model.postprocessors = []  # Clear from model so they aren't run twice
 
         # Fresh events rather than clearing the shared ones: a worker that
         # outlived stop() keeps its own set stop event, so it cannot be revived
@@ -518,7 +505,7 @@ class RTCExecution(Execution):
         raw_actions = outputs["action"]
         if raw_actions.ndim == 3:  # noqa: PLR2004
             raw_actions = raw_actions[0]
-        processed_actions = self._postprocess(raw_actions)
+        processed_actions = raw_actions
 
         with self._obs_lock:
             if incarnation != self._incarnation:
@@ -570,26 +557,15 @@ class RTCExecution(Execution):
         # prev_chunk_left_over from queue
         prev_chunk = self._rtc_queue.get_left_over()
         if prev_chunk is None:
-            prev_chunk_padded = np.zeros(
-                (1, self._chunk_size, self._max_action_dim),
-                dtype=np.float32,
-            )
+            prev_chunk_padded = prev_chunk
             # Suppress correction on the first step since there's no real previous trajectory
             max_guidance_weight = 0.0
             execution_horizon = 0
         else:
             remaining = prev_chunk.shape[0]
-            out_dim = prev_chunk.shape[-1]
 
-            # Pad action dim to model's max_action_dim if needed
-            if out_dim < self._max_action_dim:
-                prev_chunk = np.pad(
-                    prev_chunk,
-                    ((0, 0), (0, self._max_action_dim - out_dim)),
-                )
-
-            # Reshape to (1, remaining, max_action_dim) and pad time to chunk_size
-            prev_chunk_padded = prev_chunk.reshape(1, remaining, self._max_action_dim)
+            # Reshape to (1, remaining, action_dim) and pad time to chunk_size
+            prev_chunk_padded = prev_chunk.reshape(1, remaining, -1)
             pad_len = self._chunk_size - remaining
             if pad_len > 0:
                 prev_chunk_padded = np.pad(prev_chunk_padded, ((0, 0), (0, pad_len), (0, 0)))
@@ -607,19 +583,3 @@ class RTCExecution(Execution):
 
         return inputs
 
-    def _postprocess(self, actions: np.ndarray) -> np.ndarray:
-        """Apply postprocessors (denormalization) to raw actions.
-
-        Args:
-            actions: Shape ``(chunk_size, action_dim)``.
-
-        Returns:
-            Postprocessed actions, same shape.
-        """
-        if not self._postprocessors:
-            return actions.copy()
-
-        outputs: dict[str, Any] = {"action": actions}
-        for pp in self._postprocessors:
-            outputs = pp(outputs)
-        return outputs["action"]

--- a/tests/unit/runtime/test_execution.py
+++ b/tests/unit/runtime/test_execution.py
@@ -415,7 +415,7 @@ class TestRTCExecutionObsSlot:
 
         model = _rtc_model(chunk_size=20, action_dim=3)
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         idle_wait_observed = threading.Event()
         lock_was_available = False
 
@@ -448,7 +448,7 @@ class TestRTCExecutionObsSlot:
         model.return_value = {"action": np.random.randn(1, chunk_size, action_dim).astype(np.float32)}
 
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=chunk_size, max_action_dim=action_dim, fps=30.0)
+        ex = RTCExecution(chunk_size=chunk_size, fps=30.0)
         ex.start(model, queue)
         try:
             ex.warmup({"state": np.zeros(action_dim, dtype=np.float32)})
@@ -466,7 +466,7 @@ class TestRTCExecutionObsSlot:
 
         model = _rtc_model(chunk_size=20, action_dim=3)
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         try:
             ex.warmup({"state": np.zeros(3, dtype=np.float32)})
@@ -498,7 +498,7 @@ class TestRTCExecutionObsSlot:
 
         model.side_effect = predict
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         worker = ex._thread  # noqa: SLF001
         with ex._obs_lock:  # noqa: SLF001
@@ -532,7 +532,7 @@ class TestRTCExecutionObsSlot:
 
         model = _rtc_model(chunk_size=20, action_dim=3)
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
 
         ex._model_lock.acquire()  # noqa: SLF001
@@ -567,7 +567,7 @@ class TestRTCExecutionObsSlot:
 
         model = _rtc_model(chunk_size=20, action_dim=3)
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         ex._model_lock.acquire()  # noqa: SLF001
         warmup_error: list[BaseException] = []
@@ -616,7 +616,7 @@ class TestRTCExecutionObsSlot:
 
         model.side_effect = predict
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         warmup_error: list[BaseException] = []
 
@@ -660,7 +660,7 @@ class TestRTCExecutionObsSlot:
 
         model.side_effect = predict
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         warmup_error: list[BaseException] = []
 
@@ -713,7 +713,7 @@ class TestRTCExecutionObsSlot:
 
         model.side_effect = predict
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         warmup_error: list[BaseException] = []
 
@@ -798,7 +798,7 @@ class TestRestartAfterStop:
 
         model = _rtc_model()
         queue = RTCActionQueue()
-        ex = RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0)
+        ex = RTCExecution(chunk_size=20, fps=30.0)
         ex.start(model, queue)
         ex.stop()
 
@@ -848,7 +848,6 @@ class TestRestartAfterStop:
         queue = RTCActionQueue()
         ex = RTCExecution(
             chunk_size=20,
-            max_action_dim=3,
             fps=30.0,
             latency_tracker=tracker,
             warmup_inferences=1,
@@ -882,7 +881,7 @@ def _async_setup() -> tuple[Any, MagicMock, Any]:
 def _rtc_setup() -> tuple[Any, MagicMock, Any]:
     from physicalai.runtime import RTCActionQueue, RTCExecution
 
-    return RTCExecution(chunk_size=20, max_action_dim=3, fps=30.0), _rtc_model(), RTCActionQueue()
+    return RTCExecution(chunk_size=20, fps=30.0), _rtc_model(), RTCActionQueue()
 
 
 class TestStopTimeoutStraggler:

--- a/tests/unit/runtime/test_runtime_config.py
+++ b/tests/unit/runtime/test_runtime_config.py
@@ -192,13 +192,6 @@ class TestExecutionConfig:
         with pytest.raises(ConfigError, match=r"init_args\.latency_tracker"):
             Config.from_instance(execution)
 
-    def test_rtc_live_postprocessors_fail(self) -> None:
-        from physicalai.runtime import RTCExecution
-
-        execution = RTCExecution(postprocessors=[MagicMock()])
-        with pytest.raises(ConfigError, match=r"init_args\.postprocessors"):
-            Config.from_instance(execution)
-
 
 # ---------------------------------------------------------------------------
 # PolicySource


### PR DESCRIPTION
## Summary

- Add RTC parameters checks
- Remove action dim padding and manual leftover chunks processing
- Introduce RTC dict keys constants 

## Why

- In PAS training library RTC pipeline was updated: more precessing is done in the model


Merge after https://github.com/open-edge-platform/physical-ai-studio/pull/949
