### PR TITLE
fix(trossen): align WidowX state with recorded policies

### DIFF
--- a/src/physicalai/robot/trossen/bimanual_widowxai.py
+++ b/src/physicalai/robot/trossen/bimanual_widowxai.py
@@ -53,9 +53,7 @@ class BimanualWidowXAIObservation:
 
     @property
     def state(self) -> np.ndarray:
-        """State vector: positions (14) + velocities (14) = (28,)."""
-        if self.sensor_data and "velocities" in self.sensor_data:
-            return np.concatenate([self.joint_positions, self.sensor_data["velocities"]])
+        """State vector: joint positions (14)."""
         return self.joint_positions
 
 

--- a/src/physicalai/robot/trossen/widowxai.py
+++ b/src/physicalai/robot/trossen/widowxai.py
@@ -72,9 +72,7 @@ class WidowXAIObservation:
 
     @property
     def state(self) -> np.ndarray:
-        """State vector: positions (7) + velocities (7) = (14,)."""
-        if self.sensor_data and "velocities" in self.sensor_data:
-            return np.concatenate([self.joint_positions, self.sensor_data["velocities"]])
+        """State vector: joint positions (7)."""
         return self.joint_positions
 
 

--- a/tests/unit/robot/test_bimanual_widowxai.py
+++ b/tests/unit/robot/test_bimanual_widowxai.py
@@ -166,12 +166,16 @@ class TestBimanualWidowXAIConnectivity:
 class TestBimanualWidowXAIObservation:
     def test_follower_observation_shape(self, mock_trossen_arm: MagicMock) -> None:
         robot = _make_bimanual(mock_trossen_arm, role="follower")
+        robot._left._driver.get_all_velocities.return_value = [0.1] * 7  # type: ignore[attr-defined]
+        robot._right._driver.get_all_velocities.return_value = [0.2] * 7  # type: ignore[attr-defined]
         obs = robot.get_observation()
 
         assert obs.joint_positions.shape == (14,)
         assert obs.sensor_data is not None
         assert obs.sensor_data["velocities"].shape == (14,)
         assert obs.sensor_data["efforts"].shape == (14,)
+        assert obs.state.shape == (14,)
+        np.testing.assert_array_equal(obs.state, obs.joint_positions)
 
     def test_leader_observation_no_efforts(self, mock_trossen_arm: MagicMock) -> None:
         robot = _make_bimanual(mock_trossen_arm, role="leader")

--- a/tests/unit/robot/test_widowxai.py
+++ b/tests/unit/robot/test_widowxai.py
@@ -216,9 +216,10 @@ class TestWidowXAIObservation:
     """Tests for get_observation()."""
 
     def test_get_observation_follower(self, mock_trossen_arm: MagicMock) -> None:
-        """Follower observation has positions, timestamp, velocities and efforts."""
+        """Follower state contains positions while velocities remain auxiliary data."""
         driver = mock_trossen_arm.TrossenArmDriver.return_value
         driver.get_all_positions.return_value = [1.0, 0.5, -0.5, 1.5, -1.0, 0.3, 0.02]
+        driver.get_all_velocities.return_value = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
         robot = _create_robot(mock_trossen_arm, role="follower")
         obs = robot.get_observation()  # type: ignore[union-attr]
 
@@ -229,6 +230,9 @@ class TestWidowXAIObservation:
         assert obs.sensor_data is not None
         assert "velocities" in obs.sensor_data
         assert "efforts" in obs.sensor_data
+        assert obs.sensor_data["velocities"].shape == (7,)
+        assert obs.state.shape == (7,)
+        np.testing.assert_array_equal(obs.state, obs.joint_positions)
         assert obs.joint_positions[0] == pytest.approx(57.2958, abs=0.01)
         assert obs.joint_positions[5] == pytest.approx(17.1887, abs=0.01)
         assert obs.joint_positions[6] == pytest.approx(0.02, abs=1e-6)

--- a/tests/unit/runtime/test_runtime.py
+++ b/tests/unit/runtime/test_runtime.py
@@ -655,6 +655,21 @@ class TestPolicySourceModelInput:
         assert IMAGES not in model_input
         assert not any(key.startswith(f"{IMAGES}.") for key in model_input)
 
+    def test_state_uses_position_only_observation_contract(self) -> None:
+        """Auxiliary velocities must not expand the policy's batched state input."""
+        robot_obs = FakeRobotObservation(
+            joint_positions=np.arange(7, dtype=np.float32),
+            timestamp=0.0,
+            sensor_data={"velocities": np.arange(10, 17, dtype=np.float32)},
+            images=None,
+        )
+        policy_source = self._policy_source()
+
+        model_input = policy_source.to_model_input(robot_obs, {})
+
+        assert model_input[STATE].shape == (1, 7)
+        np.testing.assert_array_equal(model_input[STATE][0], robot_obs.joint_positions)
+
     def test_task_included_when_set(self) -> None:
         """The task string is forwarded when configured on the action source."""
         robot_obs = FakeRobotObservation(


### PR DESCRIPTION
Physical AI Studio records only joint positions (it uses `include_velocities=False`), so any model trained with a dataset recorded with Studio expects a state vector with length 7 (14 for bimanual).
However when performing inference via the physicalai runtime the robot's velocities get appended to the joint position space, resulting in a state vector of length 14 (28 for bimanual).
This then results in a runtime error.

This PR fixes the runtime error when doing inference by removing the velocities from widowx's observation state.

In the future we should allow users to opt-in into appending velocities both while recording and inference.
Ideally the library should be able to detect if a model was trained with velocities and append them conditionally.